### PR TITLE
Implement travel step for quests

### DIFF
--- a/Scenes/ContentManager/Custom_Editors/Scripts/QuestEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/QuestEditor.gd
@@ -313,7 +313,7 @@ func entity_drop(dropped_data: Dictionary, texteditcontrol: HBoxContainer) -> vo
 			"kill":
 				valid_data = Gamedata.mobs.has_id(dropped_data["id"])
 			"enter":
-				valid_data = not Gamedata.maps.by_id(dropped_data["id"]).is_empty()
+				valid_data = Gamedata.maps.has_id(dropped_data["id"])
 		
 		if valid_data:
 			texteditcontrol.set_text(dropped_data["id"])
@@ -332,7 +332,7 @@ func can_entity_drop(dropped_data: Dictionary, texteditcontrol: HBoxContainer) -
 		"kill":
 			valid_data = Gamedata.mobs.has_id(dropped_data["id"])
 		"enter":
-			valid_data = not Gamedata.maps.by_id(dropped_data["id"]).is_empty()
+			valid_data = Gamedata.maps.has_id(dropped_data["id"])
 	
 	return valid_data
 

--- a/Scenes/Overmap/Overmap.tscn
+++ b/Scenes/Overmap/Overmap.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" path="res://Scenes/Overmap/Scripts/Overmap.gd" id="1_fmft1"]
 [ext_resource type="PackedScene" uid="uid://budsoodfdkaea" path="res://Scenes/Overmap/OvermapTile.tscn" id="3_uq0vr"]
 
-[node name="Overmap" type="Control" node_paths=PackedStringArray("positionLabel", "tilesContainer", "overmapTileLabel")]
+[node name="Overmap" type="Control" node_paths=PackedStringArray("positionLabel", "tilesContainer", "overmapTileLabel", "controls_container", "margin_container")]
 layout_mode = 3
 anchor_left = 0.2
 anchor_top = 0.2
@@ -16,6 +16,8 @@ positionLabel = NodePath("MarginContainer/HBoxContainer/ControlsVBoxContainer/La
 tilesContainer = NodePath("MarginContainer/HBoxContainer/TilesContainer")
 overmapTile = ExtResource("3_uq0vr")
 overmapTileLabel = NodePath("MarginContainer/HBoxContainer/ControlsVBoxContainer/OvermapTileLabel")
+controls_container = NodePath("MarginContainer/HBoxContainer/ControlsVBoxContainer")
+margin_container = NodePath("MarginContainer")
 
 [node name="ColorRect" type="ColorRect" parent="."]
 layout_mode = 1

--- a/Scenes/Overmap/Overmap.tscn
+++ b/Scenes/Overmap/Overmap.tscn
@@ -12,10 +12,10 @@ anchor_bottom = 0.8
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_fmft1")
-positionLabel = NodePath("MarginContainer/HBoxContainer/VBoxContainer/Label")
+positionLabel = NodePath("MarginContainer/HBoxContainer/ControlsVBoxContainer/Label")
 tilesContainer = NodePath("MarginContainer/HBoxContainer/TilesContainer")
 overmapTile = ExtResource("3_uq0vr")
-overmapTileLabel = NodePath("MarginContainer/HBoxContainer/VBoxContainer/OvermapTileLabel")
+overmapTileLabel = NodePath("MarginContainer/HBoxContainer/ControlsVBoxContainer/OvermapTileLabel")
 
 [node name="ColorRect" type="ColorRect" parent="."]
 layout_mode = 1
@@ -48,28 +48,28 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.8
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/HBoxContainer"]
+[node name="ControlsVBoxContainer" type="VBoxContainer" parent="MarginContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_stretch_ratio = 0.2
 
-[node name="OvermapTileLabel" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer"]
+[node name="OvermapTileLabel" type="Label" parent="MarginContainer/HBoxContainer/ControlsVBoxContainer"]
 layout_mode = 2
 text = "Name: Urbanroad
 Environment: Forest
 Challenge: Easy"
 
-[node name="Label" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer"]
+[node name="Label" type="Label" parent="MarginContainer/HBoxContainer/ControlsVBoxContainer"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0, 0.898039, 0.356863, 1)
 text = "+"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="HomeButton" type="Button" parent="MarginContainer/HBoxContainer/VBoxContainer"]
+[node name="HomeButton" type="Button" parent="MarginContainer/HBoxContainer/ControlsVBoxContainer"]
 layout_mode = 2
 text = "Home"
 
-[node name="Label2" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer"]
+[node name="Label2" type="Label" parent="MarginContainer/HBoxContainer/ControlsVBoxContainer"]
 layout_mode = 2
 text = "         up
           🠕
@@ -87,4 +87,4 @@ theme_override_colors/font_outline_color = Color(0.894388, 0.571002, 0.642366, 1
 theme_override_font_sizes/font_size = 40
 text = "↑"
 
-[connection signal="button_up" from="MarginContainer/HBoxContainer/VBoxContainer/HomeButton" to="." method="_on_home_button_button_up"]
+[connection signal="button_up" from="MarginContainer/HBoxContainer/ControlsVBoxContainer/HomeButton" to="." method="_on_home_button_button_up"]

--- a/Scenes/Overmap/Overmap.tscn
+++ b/Scenes/Overmap/Overmap.tscn
@@ -27,6 +27,7 @@ grow_vertical = 2
 color = Color(0.129412, 0.14902, 0.180392, 1)
 
 [node name="ArrowLabel" type="Label" parent="."]
+visible = false
 layout_mode = 0
 offset_right = 40.0
 offset_bottom = 46.0

--- a/Scenes/Overmap/Overmap.tscn
+++ b/Scenes/Overmap/Overmap.tscn
@@ -84,8 +84,8 @@ offset_right = 40.0
 offset_bottom = 46.0
 theme_override_colors/font_color = Color(0.92549, 0, 0, 1)
 theme_override_colors/font_outline_color = Color(0.894388, 0.571002, 0.642366, 1)
-theme_override_font_sizes/font_size = 40
-text = "↑"
+theme_override_font_sizes/font_size = 90
+text = "→"
 
 [connection signal="resized" from="MarginContainer/HBoxContainer/TilesContainer" to="." method="_on_tiles_container_resized"]
 [connection signal="button_up" from="MarginContainer/HBoxContainer/ControlsVBoxContainer/HomeButton" to="." method="_on_home_button_button_up"]

--- a/Scenes/Overmap/Overmap.tscn
+++ b/Scenes/Overmap/Overmap.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" path="res://Scenes/Overmap/Scripts/Overmap.gd" id="1_fmft1"]
 [ext_resource type="PackedScene" uid="uid://budsoodfdkaea" path="res://Scenes/Overmap/OvermapTile.tscn" id="3_uq0vr"]
 
-[node name="Overmap" type="Control" node_paths=PackedStringArray("positionLabel", "tilesContainer", "overmapTileLabel", "controls_container", "margin_container")]
+[node name="Overmap" type="Control" node_paths=PackedStringArray("positionLabel", "tilesContainer", "overmapTileLabel")]
 layout_mode = 3
 anchor_left = 0.2
 anchor_top = 0.2
@@ -16,8 +16,6 @@ positionLabel = NodePath("MarginContainer/HBoxContainer/ControlsVBoxContainer/La
 tilesContainer = NodePath("MarginContainer/HBoxContainer/TilesContainer")
 overmapTile = ExtResource("3_uq0vr")
 overmapTileLabel = NodePath("MarginContainer/HBoxContainer/ControlsVBoxContainer/OvermapTileLabel")
-controls_container = NodePath("MarginContainer/HBoxContainer/ControlsVBoxContainer")
-margin_container = NodePath("MarginContainer")
 
 [node name="ColorRect" type="ColorRect" parent="."]
 layout_mode = 1
@@ -89,4 +87,5 @@ theme_override_colors/font_outline_color = Color(0.894388, 0.571002, 0.642366, 1
 theme_override_font_sizes/font_size = 40
 text = "↑"
 
+[connection signal="resized" from="MarginContainer/HBoxContainer/TilesContainer" to="." method="_on_tiles_container_resized"]
 [connection signal="button_up" from="MarginContainer/HBoxContainer/ControlsVBoxContainer/HomeButton" to="." method="_on_home_button_button_up"]

--- a/Scenes/Overmap/Overmap.tscn
+++ b/Scenes/Overmap/Overmap.tscn
@@ -79,6 +79,7 @@ left🠔   ➔Right
          "
 
 [node name="ArrowLabel" type="Label" parent="."]
+visible = false
 layout_mode = 0
 offset_right = 40.0
 offset_bottom = 46.0

--- a/Scenes/Overmap/Overmap.tscn
+++ b/Scenes/Overmap/Overmap.tscn
@@ -26,6 +26,14 @@ grow_horizontal = 2
 grow_vertical = 2
 color = Color(0.129412, 0.14902, 0.180392, 1)
 
+[node name="ArrowLabel" type="Label" parent="."]
+layout_mode = 0
+offset_right = 40.0
+offset_bottom = 46.0
+theme_override_colors/font_color = Color(0.92549, 0, 0, 1)
+theme_override_font_sizes/font_size = 33
+text = "↑"
+
 [node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 1
 anchors_preset = 15

--- a/Scenes/Overmap/Overmap.tscn
+++ b/Scenes/Overmap/Overmap.tscn
@@ -26,15 +26,6 @@ grow_horizontal = 2
 grow_vertical = 2
 color = Color(0.129412, 0.14902, 0.180392, 1)
 
-[node name="ArrowLabel" type="Label" parent="."]
-visible = false
-layout_mode = 0
-offset_right = 40.0
-offset_bottom = 46.0
-theme_override_colors/font_color = Color(0.92549, 0, 0, 1)
-theme_override_font_sizes/font_size = 33
-text = "↑"
-
 [node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 1
 anchors_preset = 15
@@ -86,5 +77,14 @@ left🠔   ➔Right
           🠗
       Down
          "
+
+[node name="ArrowLabel" type="Label" parent="."]
+layout_mode = 0
+offset_right = 40.0
+offset_bottom = 46.0
+theme_override_colors/font_color = Color(0.92549, 0, 0, 1)
+theme_override_colors/font_outline_color = Color(0.894388, 0.571002, 0.642366, 1)
+theme_override_font_sizes/font_size = 40
+text = "↑"
 
 [connection signal="button_up" from="MarginContainer/HBoxContainer/VBoxContainer/HomeButton" to="." method="_on_home_button_button_up"]

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -455,25 +455,8 @@ func find_location_on_overmap(mytarget: Target):
 	else:
 		print_debug("Using existing target coordinates: ", mytarget.coordinate)
 
-	# Attempt to find the tile at the target's coordinate
-	var target_tile = get_overmap_tile_at_position(mytarget.coordinate)
-
-	if target_tile:
-		# If a tile is found, calculate its position and check if it's within the visible area
-		var tile_pos = target_tile.get_global_position()
-		var visible_rect = Rect2(tilesContainer.get_global_position(), tilesContainer.size)
-		var is_tile_visible = visible_rect.has_point(tile_pos)
-
-		if is_tile_visible:
-			# Mark the tile and hide the arrow
-			set_tile_text(target_tile, "X")
-			$ArrowLabel.visible = false
-		else:
-			# Show the arrow pointing to the direction of the target
-			show_directional_arrow_to_cell(mytarget.coordinate)
-	else:
-		# If no tile found, treat it as invisible and show the arrow
-		show_directional_arrow_to_cell(mytarget.coordinate)
+	# Use the new function to check visibility after setting the target
+	check_target_tile_visibility()
 
 
 # Displays an arrow at the edge of the overmap window pointing towards the direction of the cell
@@ -529,6 +512,30 @@ func _on_tiles_container_resized() -> void:
 	var center_of_container = tilesContainer.size / 2
 	# Update the offset for all chunks
 	update_offset_for_all_chunks(center_of_container)
+	# Check if the target tile has become visible after the resize
+	check_target_tile_visibility()
+
+
+# If there is a target, check if we have to show an arrow or tile text
+func check_target_tile_visibility() -> void:
+	if target:
+		var target_tile = get_overmap_tile_at_position(target.coordinate)
+		if target_tile:
+			# Calculate the tile's position and the visible area
+			var tile_pos = target_tile.get_global_position()
+			var visible_rect = Rect2(tilesContainer.get_global_position(), tilesContainer.size)
+
+			# Check if the target tile is now visible
+			if visible_rect.has_point(tile_pos):
+				# If the tile is visible, hide the arrow and show the tile text
+				set_tile_text(target_tile, "X")
+				$ArrowLabel.visible = false
+			else:
+				# If the tile is still not visible, ensure the arrow is displayed
+				show_directional_arrow_to_cell(target.coordinate)
+		else:
+			# If no tile found, treat it as invisible and show the arrow
+			show_directional_arrow_to_cell(target.coordinate)
 
 
 # Updates the current offset globally, called when the window is resized

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -402,7 +402,6 @@ func on_overmap_visibility_toggled():
 
 
 # Function to assist the player in finding a location based on the map_id
-# Function to assist the player in finding a location based on the map_id
 func find_location_on_overmap(mytarget: Target):
 	# Check if mytarget's coordinate is set
 	if mytarget.coordinate == Vector2():
@@ -420,9 +419,10 @@ func find_location_on_overmap(mytarget: Target):
 	# Get the current visible area of the overmap (position and size of the TilesContainer)
 	var visible_rect = Rect2(tilesContainer.position, tilesContainer.size)
 
-	# Calculate the pixel position based on the target's coordinate
-	var target_position = mytarget.coordinate * tile_size
-	var is_cell_visible = visible_rect.has_point(target_position)
+	# Calculate the pixel position of the target's coordinate relative to Helper.position_coord (the map center)
+	# Convert the target's coordinates from the world grid to the view, adjusting for map panning
+	var target_position = (mytarget.coordinate - Helper.position_coord) * tile_size
+	var is_cell_visible = visible_rect.has_point(target_position + tilesContainer.position)
 
 	if is_cell_visible:
 		# Case 1: The target is visible, mark the tile and hide the arrow
@@ -431,6 +431,7 @@ func find_location_on_overmap(mytarget: Target):
 	else:
 		# Case 2: The target is not visible, show an arrow pointing to its direction
 		show_directional_arrow_to_cell(target_position)
+
 
 
 

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -263,49 +263,6 @@ func on_position_coord_changed(delta: Vector2):
 	else:
 		$ArrowLabel.visible = false  # Hide arrow if there's no target
 
-
-# This function creates and populates a GridContainer with tiles based on chunk size and position.
-# The function generates a new GridContainer, sets its columns to chunk_width, and ensures no space between tiles.
-# It then generates terrain for each tile based on a noise algorithm and assigns metadata to each tile.
-# Tiles are added as children to the GridContainer, which is positioned based on chunk_position.
-# The function returns the populated GridContainer.
-func create_and_fill_grid_container(grid_position: Vector2, chunk_position: Vector2) -> GridContainer:
-	var grid_container = GridContainer.new()
-	grid_container.columns = chunk_width  # Set the number of columns to chunk_width.
-	# Make sure there is no space between the tiles
-	grid_container.set("theme_override_constants/h_separation", 0)
-	grid_container.set("theme_override_constants/v_separation", 0)
-
-	# Iterate over the chunk size to create and add TextureRects for each tile.
-	for y in range(chunk_size):
-		for x in range(chunk_size):
-			var tile = get_pooled_tile()
-			var local_pos = Vector2(x * tile_size, y * tile_size)
-			var global_pos = grid_position + Vector2(x, y)
-
-			# Use the new function to update the tile based on map cell data
-			update_tile_with_map_cell(tile, global_pos)
-
-			tile.set_meta("global_pos", global_pos)
-			tile.set_meta("local_pos", local_pos)
-			
-			# Handle visibility of text if needed
-			if text_visible_by_coord.has(global_pos) and text_visible_by_coord[global_pos]:
-				tile.set_text_visible(true)
-			else:
-				tile.set_text_visible(false)
-
-			if global_pos == Vector2.ZERO:
-				tile.set_color(Color(0.3, 0.3, 1))  # blue color
-			else:
-				tile.set_color(Color(1,1,1))
-
-			grid_container.add_child(tile)
-
-	grid_container.position = chunk_position
-	return grid_container
-
-
 # This function will be connected to the signal of the tiles
 func _on_tile_clicked(clicked_tile):
 	if clicked_tile.has_meta("map_file"):

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -25,7 +25,7 @@ signal position_coord_changed(delta: Vector2)
 class Target:
 	var map_id: String
 	var coordinate: Vector2
-	
+
 	# Constructor to initialize the map_id and coordinate
 	func _init(mymap_id: String, mycoordinate: Vector2):
 		self.map_id = mymap_id
@@ -50,6 +50,9 @@ func connect_signals():
 	Helper.overmap_manager.player_coord_changed.connect(on_player_coord_changed)
 	# Connect the visibility toggling signal
 	visibility_changed.connect(on_overmap_visibility_toggled)
+	# Connect to the target_map_changed signal from the quest helper
+	Helper.quest_helper.target_map_changed.connect(on_target_map_changed)
+
 
 # Center the map on the player's last known position
 func center_map_on_player():
@@ -455,3 +458,17 @@ func clamp_arrow_to_container_bounds(arrow: Control, direction: Vector2) -> Vect
 	arrow_position.y = clamp(arrow_position.y, 0, container_size.y - arrow.rect_size.y)
 
 	return arrow_position
+
+
+# Respond to the target_map_changed signal
+func on_target_map_changed(map_id: String):
+	if map_id == null or map_id == "":
+		target = null  # Clear the target if no valid map_id is provided
+	else:
+		# Find the closest cell for the provided map_id
+		var closest_cell = Helper.overmap_manager.find_closest_map_cell_with_id(map_id)
+		if closest_cell and target == null:
+			# Set the new target if it hasn't been set
+			target = Target.new(map_id, Vector2(closest_cell.coordinate_x, closest_cell.coordinate_y))
+			# Ensure that the coordinates do not change once set
+			find_location_on_overmap(target)

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -331,7 +331,7 @@ func update_chunks():
 	var grid_position: Vector2 = (Helper.position_coord / chunk_size).floor() * chunk_size
 
 	for x in range(-3, 4):
-		for y in range(-3, 2):
+		for y in range(-2, 3):
 			var chunk_grid_position: Vector2 = grid_position + Vector2(x, y) * chunk_size
 
 			# If the chunk doesn't exist, reuse from pool or create a new one
@@ -357,12 +357,12 @@ func update_chunks():
 
 
 func unload_chunks():
-	var range_limit = 9 * chunk_size
+	var range_limit = 7 * chunk_size
 	var chunks_to_remove: Array = []
 
 	# Find chunks that are too far away
 	for chunk_position in grid_chunks.keys():
-		if chunk_position.distance_to(Helper.position_coord + Vector2(24, 24)) > range_limit:
+		if chunk_position.distance_to(Helper.position_coord) > range_limit:
 			var gridchunk: GridChunk = grid_chunks[chunk_position]
 			# Reset the chunk and move it to the pool
 			chunk_pool.append(gridchunk)  # Add to the pool for reuse

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -440,7 +440,8 @@ func find_location_on_overmap(mytarget: Target):
 		print_debug("Using existing target coordinates: ", mytarget.coordinate)
 
 	# Calculate the pixel position of the target's coordinate relative to the overmap center in pixel coordinates
-	var target_position = (mytarget.coordinate * tile_size) - (Helper.position_coord * tile_size)
+	# We subtract the `current_offset` to account for the overmap's visual shift
+	var target_position = (mytarget.coordinate * tile_size) - (Helper.position_coord * tile_size) - current_offset
 
 	# Get the current visible area of the overmap (position and size of the TilesContainer)
 	var visible_rect = Rect2(tilesContainer.position, tilesContainer.size)
@@ -453,6 +454,7 @@ func find_location_on_overmap(mytarget: Target):
 	else:
 		# Case 2: The target is not visible, show an arrow pointing to its direction
 		show_directional_arrow_to_cell(mytarget.coordinate)
+
 
 
 
@@ -511,7 +513,6 @@ func clamp_arrow_to_container_bounds(arrow_position: Vector2) -> Vector2:
 
 	print_debug("Clamped Arrow Position: ", arrow_position)
 	return arrow_position
-
 
 
 # Respond to the target_map_changed signal

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -4,6 +4,10 @@ extends Control
 @export var tilesContainer: Control = null
 @export var overmapTile: PackedScene = null
 @export var overmapTileLabel: Label = null
+@export var controls_container: VBoxContainer = null
+@export var margin_container: MarginContainer = null
+
+
 var noise = FastNoiseLite.new()
 var grid_chunks: Dictionary = {} # Stores references to grid containers (visual tile grids)
 var chunk_width: int = 8  # Smaller chunk sizes improve performance
@@ -384,12 +388,6 @@ func set_target(map_id: String, coordinate: Vector2):
 		target = Target.new(map_id, coordinate)  # Create a new target
 
 
-# Calculates the screen center offset based on the tilesContainer size
-func calculate_screen_center_offset() -> Vector2:
-	var container_center_offset = tilesContainer.size / tile_size * 0.5
-	return container_center_offset.round()
-
-
 
 # Function to handle overmap visibility toggling
 func on_overmap_visibility_toggled():
@@ -514,3 +512,25 @@ func on_target_map_changed(map_id: String):
 			target = Target.new(map_id, Vector2(closest_cell.coordinate_x, closest_cell.coordinate_y))
 			# Ensure that the coordinates do not change once set
 			find_location_on_overmap(target)
+
+
+
+# Calculates the screen center offset based on the margin_container and controls_container sizes
+func calculate_screen_center_offset() -> Vector2:
+	if margin_container and controls_container:
+		# Use the height of the controls_container directly for the available height
+		var available_height = margin_container.size.y
+
+		# Subtract the width of the controls_container from the margin_container for the available width
+		var available_width = margin_container.size.x - controls_container.size.x
+
+		# Create a Vector2 for the available size
+		var available_size = Vector2(available_width, available_height)
+
+		# Calculate the center offset using the available size
+		var new_offset = (available_size) * 0.5
+
+		return new_offset
+	else:
+		print("Error: Either margin_container or controls_container is not set or has no size.")
+		return Vector2.ZERO

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -108,6 +108,9 @@ class GridChunk:
 				# Use the same function to update tile based on its position and player location
 				update_tile_texture_and_reveal(tile, global_pos, Helper.overmap_manager.player_last_cell)
 
+	func on_position_coord_changed():
+		update_absolute_position()
+
 	# Function inside GridChunk to calculate and set its absolute position in pixels based on the player's position
 	func update_absolute_position():
 		# Calculate the chunk's absolute position in pixels
@@ -124,14 +127,6 @@ class GridChunk:
 	func update_offset(new_offset: Vector2):
 		offset = new_offset
 		update_absolute_position()
-
-	# Function inside GridChunk to update its grid_container position by a delta
-	func update_grid_position(delta: Vector2):
-		# Update the grid container position by subtracting the delta scaled by tile_size
-		grid_container.position -= delta * tile_size
-		
-		# Update the chunk position based on the new grid container position
-		chunk_position = grid_container.position
 
 	# Function to find a tile within this chunk based on a global position
 	func get_tile_at_position(global_pos: Vector2) -> Control:
@@ -171,7 +166,6 @@ class GridChunk:
 				var tile = tile_dictionary[local_pos]
 				tile.set_text_visible(true)
 				visible_tile = tile  # Store the reference to the new visible tile
-
 
 	func _on_player_coord_changed(_player: CharacterBody3D, _old_pos: Vector2, new_pos: Vector2):
 		# Update tile text visibility based on the player's new position
@@ -291,7 +285,7 @@ func update_chunks():
 					# Create a new chunk if the pool is empty
 					new_chunk = GridChunk.new(chunk_grid_position, get_localized_position(chunk_grid_position), tile_size, overmapTile)
 					# Connect the position_coord_changed signal to the GridChunk's update_absolute_position function
-					position_coord_changed.connect(new_chunk.update_absolute_position)
+					position_coord_changed.connect(new_chunk.on_position_coord_changed)
 
 				# Check if the grid_container is already a child before adding it
 				if new_chunk.grid_container.get_parent() == null:
@@ -418,7 +412,6 @@ func on_player_coord_changed(_player: CharacterBody3D, _old_pos: Vector2, new_po
 func set_target(map_id: String, coordinate: Vector2):
 	if target == null:
 		target = Target.new(map_id, coordinate)  # Create a new target
-
 
 
 # Function to handle overmap visibility toggling

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -430,9 +430,7 @@ func find_location_on_overmap(mytarget: Target):
 		$ArrowLabel.visible = false  # Hide arrow
 	else:
 		# Case 2: The target is not visible, show an arrow pointing to its direction
-		show_directional_arrow_to_cell(target_position)
-
-
+		show_directional_arrow_to_cell(mytarget.coordinate)
 
 
 # Marks the overmap tile with a symbol at the given position
@@ -448,43 +446,42 @@ func mark_overmap_tile(cell_position: Vector2):
 # Displays an arrow at the edge of the overmap window pointing towards the direction of the cell
 func show_directional_arrow_to_cell(cell_position: Vector2):
 	# Use Helper.position_coord as the center of the overmap
-	var overmap_center = Helper.position_coord  # Convert to pixel coordinates
+	var overmap_center = Helper.position_coord
 	var direction_to_cell = (cell_position - overmap_center).normalized()
 
-	# Combined debug print for relevant values
 	print_debug("Cell Position: ", cell_position, ", Overmap Center (Helper.position_coord): ", overmap_center, ", Direction to Cell: ", direction_to_cell)
 
-	# Create or update the arrow Control
-	var arrow = $ArrowLabel  # Node named ArrowLabel for showing direction
+	# Get the arrow Control
+	var arrow = $ArrowLabel
 	arrow.rotation = direction_to_cell.angle()
 
-	# Debug print for the arrow's rotation
 	print_debug("Arrow Rotation (radians): ", arrow.rotation)
 
-	# Position the arrow on the edge of the TilesContainer, clamped within its dimensions
-	var arrow_position = clamp_arrow_to_container_bounds(arrow, direction_to_cell)
-	arrow.position = arrow_position
-	arrow.visible = true  # Show arrow only when target is off-screen
+	# Start positioning the arrow at the center of tilesContainer
+	var center_of_container = tilesContainer.size / 2
 
-	# Debug print for the arrow's final position
+	# Apply directional offset to position the arrow
+	var arrow_position = center_of_container + direction_to_cell * (tilesContainer.size / 2)
+
+	# Clamp the position to the container's bounds
+	arrow_position = clamp_arrow_to_container_bounds(arrow_position)
+
+	# Set arrow position and make it visible
+	arrow.position = arrow_position
+	arrow.visible = true
+
 	print_debug("Arrow Position: ", arrow.position)
 
-# Helper function to clamp the arrow to the edge of the TilesContainer
-func clamp_arrow_to_container_bounds(arrow: Control, direction: Vector2) -> Vector2:
-	# Calculate the edge position based on the direction and container size
+
+# Helper function to clamp the arrow to the edges of the TilesContainer
+func clamp_arrow_to_container_bounds(arrow_position: Vector2) -> Vector2:
 	var container_size = tilesContainer.size
-	var arrow_position = direction * (container_size / 2)
 
-	# Combined debug print for container size and arrow position
-	print_debug("Container Size: ", container_size, ", Initial Arrow Position (before clamping): ", arrow_position)
+	# Clamp the arrow position within the bounds of the tilesContainer
+	arrow_position.x = clamp(arrow_position.x, 0, container_size.x)
+	arrow_position.y = clamp(arrow_position.y, 0, container_size.y)
 
-	# Clamp the position to the edges of the container
-	arrow_position.x = clamp(arrow_position.x, 0, container_size.x - arrow.size.x)
-	arrow_position.y = clamp(arrow_position.y, 0, container_size.y - arrow.size.y)
-
-	# Debug print for clamped arrow position
 	print_debug("Clamped Arrow Position: ", arrow_position)
-
 	return arrow_position
 
 

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -54,12 +54,19 @@ func connect_signals():
 	# Connect to the target_map_changed signal from the quest helper
 	Helper.quest_helper.target_map_changed.connect(on_target_map_changed)
 
-
-# Center the map on the player's last known position
+# Center the map on the player's last known position visually, but keep the logical position at (0,0)
 func center_map_on_player():
-	var center_offset = calculate_screen_center_offset()
-	move_overmap(Helper.overmap_manager.player_last_cell - center_offset)
+	var visual_offset = calculate_screen_center_offset()
+
+	# Instead of changing Helper.position_coord, we adjust the visual position
+	move_overmap_visual(Helper.overmap_manager.player_last_cell, visual_offset)
 	update_overmap_tile_visibility(Helper.overmap_manager.player_last_cell)
+
+# This moves the overmap visually without affecting the logical position_coord
+func move_overmap_visual(target_position: Vector2, visual_offset: Vector2):
+	var delta = target_position - visual_offset
+	update_tiles_position(delta)
+
 
 # This function updates the chunks.
 # It loops through a 4x4 grid centered on the current position
@@ -377,11 +384,11 @@ func set_target(map_id: String, coordinate: Vector2):
 		target = Target.new(map_id, coordinate)  # Create a new target
 
 
-# Calculates the center of the window. We subtract 50% because the
-# overmap doesn't cover the whole screen, only about 50%
+# Calculates the screen center offset based on the tilesContainer size
 func calculate_screen_center_offset() -> Vector2:
-	var screen_center_offset = get_viewport_rect().size * 0.5 / tile_size
-	return screen_center_offset * 0.5  # Reduce by 50%
+	var container_center_offset = tilesContainer.size / tile_size * 0.5
+	return container_center_offset.round()
+
 
 
 # Function to handle overmap visibility toggling

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -81,15 +81,6 @@ class GridChunk:
 				grid_container.add_child(tile)
 				tile_dictionary[Vector2(x, y)] = tile  # Store tile by its x, y coordinates
 
-				# Prepare tooltip information about the chunk and tile
-				var tooltip_text = "Chunk Position: " + str(chunk_position) + "\n" + \
-								   "grid_position: " + str(grid_position) + "\n" + \
-								   "Tile Position in Chunk: " + str(Vector2(x, y)) + "\n" + \
-								   "Global Position: " + str(calculate_global_pos(x, y))
-
-				# Set the tooltip for the tile
-				tile.tooltip_text = tooltip_text
-
 	# Reset chunk to a new position and redraw its tiles
 	func reset_chunk(new_grid_position: Vector2, new_chunk_position: Vector2):
 		self.grid_position = new_grid_position
@@ -127,9 +118,6 @@ class GridChunk:
 		# Calculate the local position within the chunk
 		return (global_pos - chunk_position) / tile_size
 		
-	func calculate_global_pos(x: int, y: int) -> Vector2:
-		return chunk_position + Vector2(x, y) * tile_size
-		
 	func _on_player_coord_changed(_player: CharacterBody3D, _old_pos: Vector2, new_pos: Vector2):
 		# Step 1: Check if the chunk is within the player's range
 		if is_within_player_range():
@@ -138,13 +126,8 @@ class GridChunk:
 				for x in range(chunk_size):
 					var global_pos = grid_position + Vector2(x, y)
 					var tile = tile_dictionary[Vector2(x, y)]
-
-					# Get the map cell for the current tile
-					var map_cell = Helper.overmap_manager.get_map_cell_by_local_coordinate(global_pos)
-
-					if map_cell:
-						# Call the combined function to update the tile and reveal the map cell
-						update_tile_texture_and_reveal(tile, global_pos, new_pos)
+					# Call the combined function to update the tile and reveal the map cell
+					update_tile_texture_and_reveal(tile, global_pos, new_pos)
 
 	# This function handles both revealing the map cell and updating the tile's texture
 	# It is used by both the player position update and regular map tile updates
@@ -188,7 +171,6 @@ class GridChunk:
 		if player_last_cell.x >= chunk_start.x - 8 and player_last_cell.x <= chunk_end.x + 8 and \
 		   player_last_cell.y >= chunk_start.y - 8 and player_last_cell.y <= chunk_end.y + 8:
 			return true
-
 		return false
 
 

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -185,6 +185,8 @@ func on_position_coord_changed(delta: Vector2):
 	# Check and update the marker or arrow if the target is set
 	if target != null:
 		find_location_on_overmap(target)
+	else:
+		$ArrowLabel.visible = false  # Hide arrow if there's no target
 
 
 # This function creates and populates a GridContainer with tiles based on chunk size and position.
@@ -404,18 +406,19 @@ func find_location_on_overmap(mytarget: Target):
 	var closest_cell = Helper.overmap_manager.find_closest_map_cell_with_id(mytarget.map_id)
 
 	if not closest_cell:
+		$ArrowLabel.visible = false  # Hide arrow if no target is found
 		return
 
 	# Get the current visible area of the overmap (position and size of the TilesContainer)
-	var visible_rect = Rect2(tilesContainer.position, tilesContainer.rect_size)
 
 	# Calculate the pixel position of the closest cell by multiplying its coordinates by tile_size
 	var cell_position = Vector2(closest_cell.coordinate_x, closest_cell.coordinate_y) * tile_size
 	var is_cell_visible = visible_rect.has_point(cell_position)
 
 	if is_cell_visible:
-		# Case 1: The cell is visible, mark the tile
+		# Case 1: The cell is visible, mark the tile and hide the arrow
 		mark_overmap_tile(cell_position)
+		$ArrowLabel.visible = false  # Hide arrow
 	else:
 		# Case 2: The cell is not visible, show an arrow pointing to its direction
 		show_directional_arrow_to_cell(cell_position)
@@ -434,7 +437,7 @@ func mark_overmap_tile(cell_position: Vector2):
 # Displays an arrow at the edge of the overmap window pointing towards the direction of the cell
 func show_directional_arrow_to_cell(cell_position: Vector2):
 	# Calculate the direction from the center of the visible area to the cell
-	var overmap_center = tilesContainer.rect_size * 0.5
+	var overmap_center = tilesContainer.size * 0.5
 	var direction_to_cell = (cell_position - overmap_center).normalized()
 
 	# Create or update the arrow Control (arrow must already be part of your scene)
@@ -464,6 +467,7 @@ func clamp_arrow_to_container_bounds(arrow: Control, direction: Vector2) -> Vect
 func on_target_map_changed(map_id: String):
 	if map_id == null or map_id == "":
 		target = null  # Clear the target if no valid map_id is provided
+		$ArrowLabel.visible = false  # Hide arrow when no target
 	else:
 		# Find the closest cell for the provided map_id
 		var closest_cell = Helper.overmap_manager.find_closest_map_cell_with_id(map_id)

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -416,21 +416,21 @@ func find_location_on_overmap(mytarget: Target):
 	else:
 		print_debug("Using existing target coordinates: ", mytarget.coordinate)
 
+	# Calculate the pixel position of the target's coordinate relative to the overmap center in pixel coordinates
+	var target_position = (mytarget.coordinate * tile_size) - (Helper.position_coord * tile_size)
+
 	# Get the current visible area of the overmap (position and size of the TilesContainer)
 	var visible_rect = Rect2(tilesContainer.position, tilesContainer.size)
-
-	# Calculate the pixel position of the target's coordinate relative to Helper.position_coord (the map center)
-	# Convert the target's coordinates from the world grid to the view, adjusting for map panning
-	var target_position = (mytarget.coordinate - Helper.position_coord) * tile_size
 	var is_cell_visible = visible_rect.has_point(target_position + tilesContainer.position)
 
 	if is_cell_visible:
 		# Case 1: The target is visible, mark the tile and hide the arrow
-		mark_overmap_tile(target_position)
+		mark_overmap_tile(mytarget.coordinate)
 		$ArrowLabel.visible = false  # Hide arrow
 	else:
 		# Case 2: The target is not visible, show an arrow pointing to its direction
 		show_directional_arrow_to_cell(mytarget.coordinate)
+
 
 
 # Marks the overmap tile with a symbol at the given position
@@ -445,11 +445,16 @@ func mark_overmap_tile(cell_position: Vector2):
 
 # Displays an arrow at the edge of the overmap window pointing towards the direction of the cell
 func show_directional_arrow_to_cell(cell_position: Vector2):
-	# Use Helper.position_coord as the center of the overmap
-	var overmap_center = Helper.position_coord
-	var direction_to_cell = (cell_position - overmap_center).normalized()
+	# Calculate overmap center in pixels using Helper.position_coord, which now refers to the center tile
+	var overmap_center_in_pixels = (Helper.position_coord * tile_size)
 
-	print_debug("Cell Position: ", cell_position, ", Overmap Center (Helper.position_coord): ", overmap_center, ", Direction to Cell: ", direction_to_cell)
+	# Calculate the target position in pixels
+	var target_position_in_pixels = cell_position * tile_size
+
+	# Calculate the direction from the center of the overmap to the target
+	var direction_to_cell = (target_position_in_pixels - overmap_center_in_pixels).normalized()
+
+	print_debug("Cell Position (pixels): ", target_position_in_pixels, ", Overmap Center (pixels): ", overmap_center_in_pixels, ", Direction to Cell: ", direction_to_cell)
 
 	# Get the arrow Control
 	var arrow = $ArrowLabel
@@ -457,10 +462,10 @@ func show_directional_arrow_to_cell(cell_position: Vector2):
 
 	print_debug("Arrow Rotation (radians): ", arrow.rotation)
 
-	# Start positioning the arrow at the center of tilesContainer
+	# Position the arrow at the center of tilesContainer
 	var center_of_container = tilesContainer.size / 2
 
-	# Apply directional offset to position the arrow
+	# Apply directional offset to position the arrow based on the direction and container size
 	var arrow_position = center_of_container + direction_to_cell * (tilesContainer.size / 2)
 
 	# Clamp the position to the container's bounds
@@ -471,6 +476,8 @@ func show_directional_arrow_to_cell(cell_position: Vector2):
 	arrow.visible = true
 
 	print_debug("Arrow Position: ", arrow.position)
+
+
 
 
 # Helper function to clamp the arrow to the edges of the TilesContainer

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -112,7 +112,6 @@ class GridChunk:
 		return tile_dictionary.has(global_pos)
 
 
-
 # Modify add_chunk_to_grid to use the new GridChunk class
 func add_chunk_to_grid(chunk_grid_position: Vector2):
 	var localized_position = get_localized_position(chunk_grid_position)
@@ -121,13 +120,6 @@ func add_chunk_to_grid(chunk_grid_position: Vector2):
 	tilesContainer.add_child(new_chunk.grid_container)  # Add to tilesContainer
 	grid_chunks[chunk_grid_position] = new_chunk  # Store the chunk
 
-# Modify redraw_existing_chunks to use the new GridChunk class
-func redraw_existing_chunks():
-	for chunk_position in grid_chunks.keys():
-		var chunk = grid_chunks[chunk_position]
-		var localized_position = get_localized_position(chunk_position)
-		chunk.set_position(localized_position)  # Update chunk position
-		print("Updated Chunk Position: ", chunk.grid_container.position)
 
 # Update other functions accordingly
 func get_localized_position(chunk_grid_position: Vector2) -> Vector2:
@@ -366,7 +358,6 @@ func update_overmap_tile_visibility(new_pos: Vector2):
 						tile.set_text_visible(false)
 
 
-
 func update_tile_with_map_cell(tile: Control, global_pos: Vector2):
 	# Get map_cell from overmap_manager
 	var map_cell = Helper.overmap_manager.get_map_cell_by_local_coordinate(global_pos)
@@ -403,8 +394,6 @@ func get_overmap_tile_at_position(myposition: Vector2) -> Control:
 	
 	# Return null if the tile is not found in the corresponding chunk
 	return null
-
-
 
 
 # When the player moves a coordinate on the map, i.e. when crossing the chunk border.

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -379,8 +379,8 @@ func find_location_on_overmap(map_id: String):
 	# Get the current visible area of the overmap (position and size of the TilesContainer)
 	var visible_rect = Rect2(tilesContainer.position, tilesContainer.rect_size)
 
-	# Check if the closest cell is within the visible area
-	var cell_position = Vector2(closest_cell.coordinate_x, closest_cell.coordinate_y)
+	# Calculate the pixel position of the closest cell by multiplying its coordinates by tile_size
+	var cell_position = Vector2(closest_cell.coordinate_x, closest_cell.coordinate_y) * tile_size
 	var is_cell_visible = visible_rect.has_point(cell_position)
 
 	if is_cell_visible:

--- a/Scripts/Gamedata/DMaps.gd
+++ b/Scripts/Gamedata/DMaps.gd
@@ -47,6 +47,11 @@ func delete_by_id(mapid: String) -> void:
 func by_id(mapid: String) -> DMap:
 	return mapdict[mapid.replace(".json","")]
 
+
+func has_id(mapid: String) -> bool:
+	return mapdict.has(mapid.replace(".json",""))
+
+
 # Returns the sprite of the map
 func sprite_by_id(mapid: String) -> Texture:
 	return by_id(mapid).sprite

--- a/Scripts/Gamedata/DQuest.gd
+++ b/Scripts/Gamedata/DQuest.gd
@@ -89,12 +89,14 @@ func changed(olddata: DQuest):
 	# Get items and mobs from the old steps
 	var old_quest_items: Array = olddata.steps.filter(func(step): return step.has("item"))
 	var old_quest_mobs: Array = olddata.steps.filter(func(step): return step.has("mob"))
+	var old_quest_maps: Array = olddata.steps.filter(func(step): return step.has("map_id"))
 	# Get rewards from the old data
 	var old_quest_rewards: Array = olddata.rewards.filter(func(reward): return reward.has("item_id"))
 
 	# Get items and mobs from the new steps
 	var new_quest_items: Array = steps.filter(func(step): return step.has("item"))
 	var new_quest_mobs: Array = steps.filter(func(step): return step.has("mob"))
+	var new_quest_maps: Array = steps.filter(func(step): return step.has("map_id"))
 	# Get rewards from the new data
 	var new_quest_rewards: Array = rewards.filter(func(reward): return reward.has("item_id"))
 
@@ -107,6 +109,10 @@ func changed(olddata: DQuest):
 		if old_reward not in new_quest_rewards:
 			Gamedata.items.remove_reference(old_reward.item_id, "core", "quests", quest_id)
 
+	for old_map in old_quest_maps:
+		if old_map not in new_quest_maps:
+			Gamedata.maps.remove_reference_from_map(old_map.map_id, "core", "quests", quest_id)
+
 	# Remove references for old mobs that are not in the new data
 	for old_mob in old_quest_mobs:
 		if old_mob not in new_quest_mobs:
@@ -118,6 +124,9 @@ func changed(olddata: DQuest):
 
 	for new_reward in new_quest_rewards:
 		Gamedata.items.add_reference(new_reward.item_id, "core", "quests", quest_id)
+
+	for new_map in new_quest_maps:
+		Gamedata.maps.add_reference_to_map(new_map.map_id, "core", "quests", quest_id)
 
 	# Add references for new mobs
 	for new_mob in new_quest_mobs:

--- a/Scripts/Helper/overmap_manager.gd
+++ b/Scripts/Helper/overmap_manager.gd
@@ -253,13 +253,28 @@ func generate_cells_for_grid(grid: map_grid):
 			# Add the cell to the grid's cells dictionary
 			grid.cells[cell_key] = cell
 
-			# Update the map_id_to_coordinates dictionary
-			if not grid.map_id_to_coordinates.has(cell.map_id):
-				grid.map_id_to_coordinates[cell.map_id] = []
-			
-			grid.map_id_to_coordinates[cell.map_id].append(cell_key)
-
+	# Place tactical maps on the grid, which may overwrite some cells
 	place_tactical_maps_on_grid(grid)
+
+	# After all modifications, rebuild the map_id_to_coordinates dictionary
+	build_map_id_to_coordinates(grid)
+
+
+func build_map_id_to_coordinates(grid: map_grid):
+	# Clear the existing dictionary to avoid stale data
+	grid.map_id_to_coordinates.clear()
+
+	# Iterate over all cells in the grid
+	for cell_key in grid.cells.keys():
+		var cell = grid.cells[cell_key]
+		var map_id = cell.map_id
+
+		# Initialize the list for this map_id if not already done
+		if not grid.map_id_to_coordinates.has(map_id):
+			grid.map_id_to_coordinates[map_id] = []
+
+		# Append the cell's key (coordinate) to the list
+		grid.map_id_to_coordinates[map_id].append(cell_key)
 
 
 # Helper function to convert Region enum to string

--- a/Scripts/Helper/overmap_manager.gd
+++ b/Scripts/Helper/overmap_manager.gd
@@ -53,7 +53,7 @@ var loaded_segments: Dictionary = {}
 var loaded_chunk_data: Dictionary = {"chunks": {}}
 
 var player
-var player_last_cell = Vector2.ZERO # Player's position per cell, updated regularly
+var player_current_cell = Vector2.ZERO # Player's position per cell, updated regularly
 var loaded_chunks = {}
 enum Region {
 	CITY,
@@ -189,7 +189,8 @@ func _on_player_spawned(playernode):
 	var player_position = player.position
 	load_cells_around(player_position)
 	var cellpos: Vector2 = get_cell_pos_from_global_pos(Vector2(player_position.x, player_position.z))
-	player_coord_changed.emit(player, player_last_cell, cellpos)
+	player_coord_changed.emit(player, player_current_cell, cellpos)
+	player_current_cell = cellpos
 
 
 # Function for handling game loaded signal
@@ -470,9 +471,10 @@ func get_segment_pos(chunk_pos: Vector2) -> Vector2:
 # If the player's position has changed, it updates the player position and calls functions to load and unload segments.
 func update_player_position_and_manage_segments(force_update: bool = false):
 	var new_position = get_player_cell_position()
-	if new_position != player_last_cell or force_update:
-		player_coord_changed.emit(player, player_last_cell, new_position)
-		player_last_cell = new_position
+	if new_position != player_current_cell or force_update:
+		var last_cell: Vector2 = player_current_cell
+		player_current_cell = new_position
+		player_coord_changed.emit(player, last_cell, player_current_cell)
 		
 		# Load segments around the player
 		var segments_to_load = load_segments_around_player()

--- a/Scripts/Helper/quest_helper.gd
+++ b/Scripts/Helper/quest_helper.gd
@@ -248,18 +248,23 @@ func _on_craft_successful(item: DItem, _recipe: DItem.CraftRecipe):
 # Function to handle player entering a map
 # map_id: The ID of the map that the player has entered
 func _on_map_entered(_player: CharacterBody3D, _old_pos: Vector2, new_pos: Vector2):
-	# Retrieve the map_cell based on the new player's position
-	var map_cell = Helper.overmap_manager.get_map_cell_by_global_coordinate(new_pos)
 	# Get the current quests in progress
 	var quests_in_progress = QuestManager.get_quests_in_progress()
 	# Update each of the current quests with the entered map information
 	for quest in quests_in_progress.values():
 		var step = QuestManager.get_current_step(quest.quest_name)
-		if step.step_type == "enter":
-			var stepmeta: Dictionary = step.meta_data.get("stepjson", {})
-			if stepmeta.map_id == map_cell.map_id:
-				# The player has entered the correct map for the quest step
-				QuestManager.progress_quest(quest.quest_name)
+		
+		# Check for the step_type for this step according to the QuestManager
+		if step.step_type == "action_step":
+			var stepmeta: Dictionary = step.get("meta_data", {}).get("stepjson", {})
+			# Check the type of the stepjson, which is set in the quest editor
+			if stepmeta.get("type", "") == "enter":
+				# Retrieve the map_cell based on the new player's position
+				var map_cell = Helper.overmap_manager.get_map_cell_by_local_coordinate(new_pos)
+				var map_id: String = stepmeta.get("map_id", "")
+				if map_id == map_cell.map_id:
+					# The player has entered the correct map for the quest step
+					QuestManager.progress_quest(quest.quest_name)
 
 
 # Get the current state of all quests to save.

--- a/Scripts/Helper/quest_helper.gd
+++ b/Scripts/Helper/quest_helper.gd
@@ -65,7 +65,7 @@ func _on_game_ended():
 
 # Function to handle quest completion
 func _on_quest_complete(quest: Dictionary):
-	target_map_changed.emit(null)  # No more target when quest is complete
+	target_map_changed.emit("")  # No more target when quest is complete
 	var rewards: Array = quest.get("quest_rewards").get("rewards", [])
 	for reward in rewards:
 		var item_id: String = reward.get("item_id")
@@ -75,7 +75,7 @@ func _on_quest_complete(quest: Dictionary):
 
 # Function to handle quest failure
 func _on_quest_failed(_quest: Dictionary):
-	target_map_changed.emit(null)  # No more target when quest is complete
+	target_map_changed.emit("")  # No more target when quest is complete
 
 # When a step is complete.
 # step: the step dictionary
@@ -276,12 +276,18 @@ func set_state(state: Dictionary) -> void:
 	QuestManager.load_saved_quest_data(player_quests)
 
 
-# Helper function to check if the step has the "enter" type and emit the target_map_changed signal
+# Helper function to check if the step has the "enter" type within "action_step" and emit the target_map_changed signal
 func check_and_emit_target_map(step: Dictionary):
 	var step_type = step.get("step_type", "")
-	if step_type == "enter":
+
+	# Check for the step_type for this step according to the QuestManager
+	if step_type == "action_step":
 		var stepmeta: Dictionary = step.get("meta_data", {}).get("stepjson", {})
-		var map_id: String = stepmeta.get("map_id", "")
-		target_map_changed.emit(map_id)  # Emit the map_id for "enter" type steps
+		# Check the type of the stepjson, which is set in the quest editor
+		if stepmeta.get("type", "") == "enter":
+			var map_id: String = stepmeta.get("map_id", "")
+			target_map_changed.emit(map_id)  # Emit the map_id if the stepmeta.type is "enter"
+		else:
+			target_map_changed.emit("")  # No target if the type is not "enter"
 	else:
-		target_map_changed.emit(null)  # Emit null if no target is present
+		target_map_changed.emit("")  # No target if step_type is not "action_step"

--- a/Scripts/Mob.gd
+++ b/Scripts/Mob.gd
@@ -84,7 +84,7 @@ func create_navigation_agent():
 	nav_agent.target_desired_distance = 0.5
 	nav_agent.path_max_distance = 0.5
 	nav_agent.avoidance_enabled = true
-	nav_agent.debug_enabled = true
+	nav_agent.debug_enabled = false
 	add_child.call_deferred(nav_agent)
 
 # Create and configure StateMachine


### PR DESCRIPTION
Fixes #350 

Implements the requirements listed in  #350. Implementing these requirements does not take much code, but since I required precise coordinate and position control, I had to basically rewrite the entire overmap script. The overmap is now more responsive to signals and adjusts accordingly. 

An arrow points to the target location if the location is outside of the visible area. The arrow is not quite as accurate as I'd like it to be but it does the job for now. With this implementation, you can send players to the nearest overmap location that has the given map id and complete the quest step when entering it. 

Additional functionality could allow one to send the player only to unexplored areas, but I haven't implemented this yet.