### PR TITLE
Furniture hides above player

### DIFF
--- a/LevelManager.gd
+++ b/LevelManager.gd
@@ -20,13 +20,8 @@ func _process(_delta):
 func update_visibility(player_y: float):
 	# Update level visibility
 	for level in get_tree().get_nodes_in_group("maplevels"):
-		var is_above_player = level.y > player_y
+		var is_above_player = level.y-0.2 > player_y
 		level.visible = not is_above_player
-
-	# Update furniture visibility
-	for furniture in get_tree().get_nodes_in_group("furniture"):
-		var is_above_player = furniture.global_position.y > player_y
-		furniture.visible = not is_above_player
 
 	# Update mob visibility
 	for mob in get_tree().get_nodes_in_group("mobs"):

--- a/Mods/Core/Furniture/Furniture.json
+++ b/Mods/Core/Furniture/Furniture.json
@@ -1082,7 +1082,7 @@
 		"support_shape": {
 			"color": "8b8b8bff",
 			"depth_scale": 80,
-			"height": 0.6,
+			"height": 0.7,
 			"shape": "Box",
 			"transparent": true,
 			"width_scale": 80

--- a/Mods/Core/Furniture/Furniture.json
+++ b/Mods/Core/Furniture/Furniture.json
@@ -1183,7 +1183,7 @@
 		"support_shape": {
 			"color": "869bcdff",
 			"depth_scale": 100,
-			"height": 1,
+			"height": 0.98,
 			"shape": "Box",
 			"transparent": true,
 			"width_scale": 100

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Catax:
+# Dimensionfall:
 
-Catax is a top-down real-time survival game set in a post-apocalyptic world. Survive in a strange place where you can visit multiple dimensions. Will you fight demons? Aliens? Zombies? Who knows what you will come across.
+Dimensionfall is a top-down real-time survival game set in a post-apocalyptic world. Survive in a strange place where you can visit multiple dimensions. Will you fight demons? Aliens? Zombies? Who knows what you will come across.
 
 ![Catax_basic](Media/Catax_basic.png)
 
@@ -188,7 +188,7 @@ Additional features before our first release:
 
 ## Contribute
 
-If you like Godot and want to contribute, feel free to submit a pull request or issue on your ideas, or join us on discord. To make edits, start by reading the [getting started guide](https://github.com/Khaligufzel/CataX/blob/main/Documentation/Game_development/Getting_started.md). This is and always will be a hobby project and will not be for sale. 
+If you like Godot and want to contribute, feel free to submit a pull request or issue on your ideas, or join us on discord. To make edits, start by reading the [getting started guide](https://github.com/Khaligufzel/Dimensionfall/blob/main/Documentation/Game_development/Getting_started.md). This is and always will be a hobby project and will not be for sale. 
 
 
 ## Community

--- a/Scenes/ContentManager/Custom_Editors/FurnitureEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/FurnitureEditor.tscn
@@ -410,7 +410,7 @@ the shape. It also increases the height of the furniture sprite
 and the container (if this furniture is marked as a container). 0 
 means it has no height. 1 means it's as high as a wall."
 max_value = 1.0
-step = 0.1
+step = 0.01
 value = 0.5
 
 [node name="ColorLabel" type="Label" parent="VBoxContainer/TabContainer/Shape"]

--- a/Scripts/BuildManager.gd
+++ b/Scripts/BuildManager.gd
@@ -31,6 +31,13 @@ func start_building():
 	General.is_allowed_to_shoot = false
 
 func on_construction_clicked(construction_data: Dictionary):
+	var numberofplanks: int = ItemManager.get_accessibleitem_amount("plank_2x4")
+	if numberofplanks < 2:
+		print_debug("tried to construct, but not enough planks")
+		return
+		
+	if not ItemManager.remove_resource("plank_2x4",2):
+		return
 	var chunk: Chunk = LevelGenerator.get_chunk_from_position(construction_data.pos)
 	if chunk:
 		var local_position = calculate_local_position(construction_data.pos, chunk.position)

--- a/Scripts/CraftingMenu.gd
+++ b/Scripts/CraftingMenu.gd
@@ -98,6 +98,7 @@ func _on_recipe_button_pressed(recipe: DItem.CraftRecipe):
 	# Enable or disable the start crafting button based on whether the player can craft
 	start_crafting_button.disabled = not CraftingRecipesManager.can_craft_recipe(recipe)
 
+
 # New function to update required items display
 func update_required_items_display(recipe: DItem.CraftRecipe):
 	# Clear previous required items display
@@ -181,6 +182,11 @@ func _on_allAccessibleItems_changed(items_added: Array, items_removed: Array):
 	# Update buttons for items that were removed
 	for item in items_removed:
 		_update_button_from_inventory_item(item)
+
+	# Check if the crafting menu is open and a recipe is selected
+	if self.visible and active_recipe != null:
+		# Refresh the display as though the recipe button was pressed
+		_on_recipe_button_pressed(active_recipe)
 
 
 # Function to determine if any of the item's recipes can be crafted based on player's skills

--- a/Scripts/CraftingMenu.gd
+++ b/Scripts/CraftingMenu.gd
@@ -82,15 +82,34 @@ func _on_item_button_clicked(item: DItem):
 # When a recipe button is pressed, update the required items label
 func _on_recipe_button_pressed(recipe: DItem.CraftRecipe):
 	active_recipe = recipe
+	update_required_items_display(recipe)
+	
+	# Display skill progression information if it exists
+	if recipe.skill_progression:
+		var skill_id = recipe.skill_progression.id
+		var skill_xp = recipe.skill_progression.xp
+		if skill_id and skill_xp:
+			skill_progression_label.text = "Get XP: %s: %s" % [skill_id, skill_xp]
+		else:
+			skill_progression_label.text = ""
+	else:
+		skill_progression_label.text = ""
+	
+	# Enable or disable the start crafting button based on whether the player can craft
+	start_crafting_button.disabled = not CraftingRecipesManager.can_craft_recipe(recipe)
+
+# New function to update required items display
+func update_required_items_display(recipe: DItem.CraftRecipe):
+	# Clear previous required items display
 	for element in required_items.get_children():
-		required_items.remove_child(element)
 		element.queue_free()  # Properly free the node to avoid memory leaks
 
 	for resource in recipe.required_resources:
 		var item_id = resource["id"]
-		var amount = resource["amount"]
+		var required_amount = resource["amount"]
+		var current_amount = ItemManager.get_accessibleitem_amount(item_id)
+
 		var resource_container = HBoxContainer.new()
-		var item_name: String = Gamedata.items.by_id(item_id).name
 		required_items.add_child(resource_container)
 
 		var item_icon_texture = Gamedata.items.sprite_by_id(item_id)
@@ -100,20 +119,23 @@ func _on_recipe_button_pressed(recipe: DItem.CraftRecipe):
 			icon.custom_minimum_size = Vector2(32, 32)  # Set a fixed size for icons
 			resource_container.add_child(icon)
 
+		var item_name: String = Gamedata.items.by_id(item_id).name
+
 		var label = Label.new()
-		label.text = " %s: %d" % [item_name, amount]
+
+		# Check if the player has enough of the resource
+		if current_amount < required_amount:
+			var missing_amount = required_amount - current_amount
+			label.text = " %s: %d/%d (Missing %d)" % [item_name, current_amount, required_amount, missing_amount]
+			label.modulate = Color.RED  # Set the text color
+		else:
+			label.text = " %s: %d/%d" % [item_name, current_amount, required_amount]
+			label.modulate = Color.GREEN  # Set the text color
+
 		resource_container.add_child(label)
 
-	# Display skill progression information if it exists
-	if recipe.skill_progression:
-		var skill_id = recipe.skill_progression.id
-		var skill_xp = recipe.skill_progression.xp
-		if skill_id and skill_xp:
-			skill_progression_label.text = "Get XP: %s: %s" % [skill_id, skill_xp]
-		else:
-			skill_progression_label.text = ""
 
-
+# The user has pressed the start crafting button
 func _on_start_crafting_button_pressed():
 	start_craft.emit(active_item, active_recipe)
 

--- a/Scripts/FurniturePhysicsSrv.gd
+++ b/Scripts/FurniturePhysicsSrv.gd
@@ -246,39 +246,12 @@ func create_visual_instance() -> void:
 func create_furniture_shader_material(albedo_texture: Texture) -> ShaderMaterial:
 	# Create a new ShaderMaterial
 	var shader_material = ShaderMaterial.new()
-
-	# Create the shader code
-	var shader_code = """
-		shader_type spatial;
-
-		uniform sampler2D texture_albedo;
-		global uniform float player_y_level;
-
-		void fragment() {
-			// Compute the world position using the built-in MODELVIEW_MATRIX
-			vec4 world_pos = INV_VIEW_MATRIX * vec4(VERTEX, 1.0);
-
-			// Discard the fragment if it's above the player y-level
-			if (world_pos.y-0.5 > player_y_level) {
-				discard;
-			} else {
-				ALBEDO = texture(texture_albedo, UV).rgb;
-				ALPHA = texture(texture_albedo, UV).a;
-			}
-		}
-	"""
-	
-	# Assign the shader code to the ShaderMaterial
-	var shader = Shader.new()
-	shader.code = shader_code
-	shader_material.shader = shader
+	shader_material.shader = Gamedata.shared_furniture_shader
 
 	# Assign the texture to the material
 	shader_material.set_shader_parameter("texture_albedo", albedo_texture)
 
 	return shader_material
-
-
 
 
 # Set the new rotation for the furniture

--- a/Scripts/FurniturePhysicsSrv.gd
+++ b/Scripts/FurniturePhysicsSrv.gd
@@ -246,7 +246,7 @@ func create_visual_instance() -> void:
 func create_furniture_shader_material(albedo_texture: Texture) -> ShaderMaterial:
 	# Create a new ShaderMaterial
 	var shader_material = ShaderMaterial.new()
-	shader_material.shader = Gamedata.shared_furniture_shader
+	shader_material.shader = Gamedata.hide_above_player_shader
 
 	# Assign the texture to the material
 	shader_material.set_shader_parameter("texture_albedo", albedo_texture)

--- a/Scripts/FurniturePhysicsSrv.gd
+++ b/Scripts/FurniturePhysicsSrv.gd
@@ -222,8 +222,8 @@ func create_visual_instance() -> void:
 	sprite_mesh = PlaneMesh.new()
 	sprite_mesh.size = sprite_size
 
-	# Use the helper function to create the ShaderMaterial
-	sprite_material = create_furniture_shader_material(dfurniture.sprite)
+	# Get the ShaderMaterial from Gamedata.furnitures
+	sprite_material = Gamedata.furnitures.get_shader_material_by_id(furnitureJSON.id)
 
 	sprite_mesh.material = sprite_material
 

--- a/Scripts/FurniturePhysicsSrv.gd
+++ b/Scripts/FurniturePhysicsSrv.gd
@@ -13,7 +13,7 @@ var dfurniture: DFurniture
 var collider: RID
 var shape: RID
 var mesh_instance: RID
-var sprite_material: StandardMaterial3D
+var sprite_material: Material
 var sprite_mesh: PlaneMesh
 var myworld3d: World3D
 var container: ContainerItem = null
@@ -23,7 +23,6 @@ var original_material_color: Color = Color(1, 1, 1)  # Store the original materi
 # Variables to manage the container if this furniture is a container
 var inventory: InventoryStacked  # Holds the inventory for the container
 var itemgroup: String  # The ID of an itemgroup that it creates loot from
-var i_am_visible: bool = true # keep track of general visibility
 
 
 signal about_to_be_destroyed(me: FurniturePhysicsSrv)
@@ -131,7 +130,6 @@ func _init(furniturepos: Vector3, newFurnitureJSON: Dictionary, world3d: World3D
 
 
 func connect_signals():
-	Helper.signal_broker.player_y_level_updated.connect(_on_player_y_level_updated)
 	furniture_transform.chunk_changed.connect(_on_chunk_changed)
 
 
@@ -216,7 +214,6 @@ func calculate_sprite_size() -> Vector2:
 	return Vector2(0.5, 0.5)  # Default size if texture is not set
 
 
-# Create the visual instance using RenderingServer
 func create_visual_instance() -> void:
 	# Calculate the sprite size based on the texture dimensions
 	var sprite_size = calculate_sprite_size()
@@ -225,11 +222,8 @@ func create_visual_instance() -> void:
 	sprite_mesh = PlaneMesh.new()
 	sprite_mesh.size = sprite_size
 
-	# Initialize the sprite material with the sprite texture
-	sprite_material = StandardMaterial3D.new()
-	sprite_material.albedo_texture = dfurniture.sprite
-	# Ensure transparency is correctly set (debugging transparency issues)
-	sprite_material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
+	# Use the helper function to create the ShaderMaterial
+	sprite_material = create_furniture_shader_material(dfurniture.sprite)
 
 	sprite_mesh.material = sprite_material
 
@@ -244,8 +238,46 @@ func create_visual_instance() -> void:
 	# Set the transform for the mesh instance in the RenderingServer
 	RenderingServer.instance_set_transform(mesh_instance, mytransform)
 
-	# Ensure the sprite is visible and not being culled
+	# Ensure the sprite is visible
 	RenderingServer.instance_set_visible(mesh_instance, true)
+
+
+# Helper function to create a ShaderMaterial for the furniture
+func create_furniture_shader_material(albedo_texture: Texture) -> ShaderMaterial:
+	# Create a new ShaderMaterial
+	var shader_material = ShaderMaterial.new()
+
+	# Create the shader code
+	var shader_code = """
+		shader_type spatial;
+
+		uniform sampler2D texture_albedo;
+		global uniform float player_y_level;
+
+		void fragment() {
+			// Compute the world position using the built-in MODELVIEW_MATRIX
+			vec4 world_pos = INV_VIEW_MATRIX * vec4(VERTEX, 1.0);
+
+			// Discard the fragment if it's above the player y-level
+			if (world_pos.y-0.5 > player_y_level) {
+				discard;
+			} else {
+				ALBEDO = texture(texture_albedo, UV).rgb;
+				ALPHA = texture(texture_albedo, UV).a;
+			}
+		}
+	"""
+	
+	# Assign the shader code to the ShaderMaterial
+	var shader = Shader.new()
+	shader.code = shader_code
+	shader_material.shader = shader
+
+	# Assign the texture to the material
+	shader_material.set_shader_parameter("texture_albedo", albedo_texture)
+
+	return shader_material
+
 
 
 
@@ -517,34 +549,3 @@ func get_data() -> Dictionary:
 		newfurniturejson["Function"]["container"] = containerobject
 
 	return newfurniturejson
-
-
-# Function to hide visual elements
-func hide_visual_elements():
-	if not i_am_visible:
-		return # I am already inivisble
-	# Check if instances exist before hiding
-	if mesh_instance:
-		RenderingServer.instance_set_visible(mesh_instance, false)
-	i_am_visible = false
-
-
-# Function to show visual elements
-func show_visual_elements():
-	if i_am_visible:
-		return # I am already visible
-	# Check if instances exist before showing
-	if mesh_instance:
-		RenderingServer.instance_set_visible(mesh_instance, true)
-	i_am_visible = true
-
-
-# Function to handle the player's Y level change
-func _on_player_y_level_updated(new_y: float):
-	# Check if the furniture is above the player's new Y level
-	if furniture_transform.posy > new_y:
-		# Hide the furniture if it is above the player's level
-		hide_visual_elements()
-	else:
-		# Show the furniture if it is at or below the player's level
-		show_visual_elements()

--- a/Scripts/FurnitureStaticSpawner.gd
+++ b/Scripts/FurnitureStaticSpawner.gd
@@ -12,12 +12,7 @@ var chunk: Chunk
 var furniture_json_list: Array = []:
 	set(value):
 		furniture_json_list = value
-		await Helper.task_manager.create_task(_spawn_all_furniture).completed
-		# INFO Important to connect the signals outside the task_manager.create_task
-		# since the furniture will start engaging with the game world when they are connected
-		# If they are connected inside task_manager.create_task, there will be a conflict in threads
-		for furniture in collider_to_furniture.values():
-			furniture.connect_signals()
+		Helper.task_manager.create_task(_spawn_all_furniture)
 
 
 # Initialize with reference to the chunk

--- a/Scripts/FurnitureStaticSrv.gd
+++ b/Scripts/FurnitureStaticSrv.gd
@@ -221,9 +221,12 @@ func create_visual_instance(shape_type: String):
 	var material: ShaderMaterial = ShaderMaterial.new()
 	material.shader = Gamedata.hide_above_player_shader  # Assign the shader to the material
 
-	#if dfurniture.support_shape.transparent:
-		#material.flags_transparent = true
-		#material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
+	# Set the color and transparency in the shader material
+	material.set_shader_parameter("object_color", color)
+	if dfurniture.support_shape.transparent:
+		material.set_shader_parameter("alpha", 0.5)
+	else:
+		material.set_shader_parameter("alpha", 1.0)
 
 	if shape_type == "Box":
 		support_mesh = BoxMesh.new()

--- a/Scripts/FurnitureStaticSrv.gd
+++ b/Scripts/FurnitureStaticSrv.gd
@@ -271,32 +271,7 @@ func create_sprite_instance():
 func create_furniture_shader_material(albedo_texture: Texture) -> ShaderMaterial:
 	# Create a new ShaderMaterial
 	var shader_material = ShaderMaterial.new()
-
-	# Shader code to handle visibility based on player's Y level
-	var shader_code = """
-		shader_type spatial;
-
-		uniform sampler2D texture_albedo;
-		global uniform float player_y_level;
-
-		void fragment() {
-			// Compute the world position using the built-in INV_VIEW_MATRIX
-			vec4 world_pos = INV_VIEW_MATRIX * vec4(VERTEX, 1.0);
-
-			// Discard the fragment if it's above the player y-level
-			if (world_pos.y - 0.5 > player_y_level) {
-				discard;
-			} else {
-				ALBEDO = texture(texture_albedo, UV).rgb;
-				ALPHA = texture(texture_albedo, UV).a;
-			}
-		}
-	"""
-	
-	# Assign the shader code to the ShaderMaterial
-	var shader = Shader.new()
-	shader.code = shader_code
-	shader_material.shader = shader
+	shader_material.shader = Gamedata.shared_furniture_shader
 
 	# Assign the texture to the shader material
 	shader_material.set_shader_parameter("texture_albedo", albedo_texture)

--- a/Scripts/FurnitureStaticSrv.gd
+++ b/Scripts/FurnitureStaticSrv.gd
@@ -25,8 +25,8 @@ var i_am_visible: bool = true # keep track of general visibility
 # We have to keep a reference or it will be auto deleted
 var support_mesh: PrimitiveMesh
 var sprite_texture: Texture2D  # Variable to store the sprite texture
-var sprite_material: Material
-var container_material: StandardMaterial3D
+var sprite_material: ShaderMaterial
+var container_material: ShaderMaterial
 var quad_mesh: PlaneMesh
 var container_sprite_mesh: PlaneMesh
 
@@ -156,7 +156,7 @@ func connect_signals():
 func add_container():
 	if is_container():
 		_create_inventory()
-		container_material = StandardMaterial3D.new()
+		container_material = Gamedata.materials.container_filled
 		if is_new_furniture():
 			create_loot()
 		else:
@@ -271,7 +271,7 @@ func create_sprite_instance():
 func create_furniture_shader_material(albedo_texture: Texture) -> ShaderMaterial:
 	# Create a new ShaderMaterial
 	var shader_material = ShaderMaterial.new()
-	shader_material.shader = Gamedata.shared_furniture_shader
+	shader_material.shader = Gamedata.hide_above_player_shader
 
 	# Assign the texture to the shader material
 	shader_material.set_shader_parameter("texture_albedo", albedo_texture)
@@ -512,16 +512,6 @@ func deserialize_container_data():
 # Function to deserialize inventory and apply the correct sprite
 func deserialize_and_apply_items(items_data: Dictionary):
 	inventory.deserialize(items_data)
-	
-	#var default_texture: Texture = Gamedata.textures.container
-	
-	#if inventory.get_items().size() > 0:
-		#if sprite_3d.texture == default_texture:
-			#sprite_3d.texture = Gamedata.textures.container_filled
-		## Else, some other texture has been set so we keep that
-	#else:
-		#sprite_3d.texture = default_texture
-		#_on_item_removed(null)
 
 
 # Function to hide visual elements

--- a/Scripts/Gamedata/DFurnitures.gd
+++ b/Scripts/Gamedata/DFurnitures.gd
@@ -130,11 +130,6 @@ func create_furniture_shader_material(furniture_id: String) -> ShaderMaterial:
 
 	# Assign the texture to the material
 	shader_material.set_shader_parameter("texture_albedo", albedo_texture)
-	if not dfurniture.moveable:
-		shader_material.set_shader_parameter("y_offset", 0.5)
-		#shader_material.set_shader_parameter("y_offset", dfurniture.support_shape.height + 0.01)
-	else:
-		shader_material.set_shader_parameter("y_offset", 0.0)
 
 	return shader_material
 
@@ -142,8 +137,5 @@ func create_furniture_shader_material(furniture_id: String) -> ShaderMaterial:
 # Handle the game ended signal. We need to clear the shader materials because they
 # need to be re-created on game start since some of them may have changed in between.
 func _on_game_ended():
-	# Loop through all shader materials and free them
-	for material in shader_materials.values():
-		material.free()
 	# Clear the dictionary
 	shader_materials.clear()

--- a/Scripts/Gamedata/DFurnitures.gd
+++ b/Scripts/Gamedata/DFurnitures.gd
@@ -125,7 +125,7 @@ func get_shader_material_by_id(furniture_id: String) -> ShaderMaterial:
 func create_furniture_shader_material(albedo_texture: Texture) -> ShaderMaterial:
 	# Create a new ShaderMaterial
 	var shader_material = ShaderMaterial.new()
-	shader_material.shader = Gamedata.shared_furniture_shader  # Use the shared shader
+	shader_material.shader = Gamedata.hide_above_player_shader  # Use the shared shader
 
 	# Assign the texture to the material
 	shader_material.set_shader_parameter("texture_albedo", albedo_texture)

--- a/Scripts/Gamedata/DFurnitures.gd
+++ b/Scripts/Gamedata/DFurnitures.gd
@@ -10,14 +10,14 @@ var dataPath: String = "./Mods/Core/Furniture/Furniture.json"
 var spritePath: String = "./Mods/Core/Furniture/"
 var furnituredict: Dictionary = {}
 var sprites: Dictionary = {}
-
+var shader_materials: Dictionary = {}  # Cache for shader materials by furniture ID
 
 func _init():
 	load_sprites()
 	load_furnitures_from_disk()
+	Helper.signal_broker.game_ended.connect(_on_game_ended)
 
 
-# Load all furnituredata from disk into memory
 func load_furnitures_from_disk() -> void:
 	var furniturelist: Array = Helper.json_helper.load_json_array_file(dataPath)
 	for furnitureitem in furniturelist:
@@ -105,3 +105,39 @@ func add_reference_to_furniture(furnitureid: String, module: String, type: Strin
 
 func is_moveable(id: String) -> bool:
 	return by_id(id).moveable
+
+
+# New function to get or create a ShaderMaterial for a furniture ID
+func get_shader_material_by_id(furniture_id: String) -> ShaderMaterial:
+	# Check if the material already exists
+	if shader_materials.has(furniture_id):
+		return shader_materials[furniture_id]
+	else:
+		# Create a new ShaderMaterial
+		var albedo_texture: Texture = sprite_by_id(furniture_id)
+		var shader_material: ShaderMaterial = create_furniture_shader_material(albedo_texture)
+		# Store it in the dictionary
+		shader_materials[furniture_id] = shader_material
+		return shader_material
+
+
+# Helper function to create a ShaderMaterial for the furniture
+func create_furniture_shader_material(albedo_texture: Texture) -> ShaderMaterial:
+	# Create a new ShaderMaterial
+	var shader_material = ShaderMaterial.new()
+	shader_material.shader = Gamedata.shared_furniture_shader  # Use the shared shader
+
+	# Assign the texture to the material
+	shader_material.set_shader_parameter("texture_albedo", albedo_texture)
+
+	return shader_material
+
+
+# Handle the game ended signal. We need to clear the shader materials because they
+# need to be re-created on game start since some of them may have changed in between.
+func _on_game_ended():
+	# Loop through all shader materials and free them
+	for material in shader_materials.values():
+		material.free()
+	# Clear the dictionary
+	shader_materials.clear()

--- a/Scripts/Gamedata/DFurnitures.gd
+++ b/Scripts/Gamedata/DFurnitures.gd
@@ -114,21 +114,27 @@ func get_shader_material_by_id(furniture_id: String) -> ShaderMaterial:
 		return shader_materials[furniture_id]
 	else:
 		# Create a new ShaderMaterial
-		var albedo_texture: Texture = sprite_by_id(furniture_id)
-		var shader_material: ShaderMaterial = create_furniture_shader_material(albedo_texture)
+		var shader_material: ShaderMaterial = create_furniture_shader_material(furniture_id)
 		# Store it in the dictionary
 		shader_materials[furniture_id] = shader_material
 		return shader_material
 
 
 # Helper function to create a ShaderMaterial for the furniture
-func create_furniture_shader_material(albedo_texture: Texture) -> ShaderMaterial:
+func create_furniture_shader_material(furniture_id: String) -> ShaderMaterial:
 	# Create a new ShaderMaterial
+	var dfurniture: DFurniture = by_id(furniture_id)
+	var albedo_texture: Texture = dfurniture.sprite
 	var shader_material = ShaderMaterial.new()
 	shader_material.shader = Gamedata.hide_above_player_shader  # Use the shared shader
 
 	# Assign the texture to the material
 	shader_material.set_shader_parameter("texture_albedo", albedo_texture)
+	if not dfurniture.moveable:
+		shader_material.set_shader_parameter("y_offset", 0.5)
+		#shader_material.set_shader_parameter("y_offset", dfurniture.support_shape.height + 0.01)
+	else:
+		shader_material.set_shader_parameter("y_offset", 0.0)
 
 	return shader_material
 

--- a/Scripts/Gamedata/DItems.gd
+++ b/Scripts/Gamedata/DItems.gd
@@ -10,6 +10,7 @@ var dataPath: String = "./Mods/Core/Items/Items.json"
 var spritePath: String = "./Mods/Core/Items/"
 var itemdict: Dictionary = {}
 var sprites: Dictionary = {}
+var shader_materials: Dictionary = {}  # Cache for shader materials by item ID
 
 
 func _init():
@@ -138,3 +139,39 @@ func get_items_by_type(item_type: String) -> Array[DItem]:
 		if not item.get(item_type) == null:
 			filtered_items.append(item)
 	return filtered_items
+
+
+# New function to get or create a ShaderMaterial for a item ID
+func get_shader_material_by_id(item_id: String) -> ShaderMaterial:
+	# Check if the material already exists
+	if shader_materials.has(item_id):
+		return shader_materials[item_id]
+	else:
+		# Create a new ShaderMaterial
+		var albedo_texture: Texture = sprite_by_id(item_id)
+		var shader_material: ShaderMaterial = create_item_shader_material(albedo_texture)
+		# Store it in the dictionary
+		shader_materials[item_id] = shader_material
+		return shader_material
+
+
+# Helper function to create a ShaderMaterial for the item
+func create_item_shader_material(albedo_texture: Texture) -> ShaderMaterial:
+	# Create a new ShaderMaterial
+	var shader_material = ShaderMaterial.new()
+	shader_material.shader = Gamedata.shared_item_shader  # Use the shared shader
+
+	# Assign the texture to the material
+	shader_material.set_shader_parameter("texture_albedo", albedo_texture)
+
+	return shader_material
+
+
+# Handle the game ended signal. We need to clear the shader materials because they
+# need to be re-created on game start since some of them may have changed in between.
+func _on_game_ended():
+	# Loop through all shader materials and free them
+	for material in shader_materials.values():
+		material.free()
+	# Clear the dictionary
+	shader_materials.clear()

--- a/Scripts/Gamedata/DItems.gd
+++ b/Scripts/Gamedata/DItems.gd
@@ -159,7 +159,7 @@ func get_shader_material_by_id(item_id: String) -> ShaderMaterial:
 func create_item_shader_material(albedo_texture: Texture) -> ShaderMaterial:
 	# Create a new ShaderMaterial
 	var shader_material = ShaderMaterial.new()
-	shader_material.shader = Gamedata.shared_item_shader  # Use the shared shader
+	shader_material.shader = Gamedata.hide_above_player_shader  # Use the shared shader
 
 	# Assign the texture to the material
 	shader_material.set_shader_parameter("texture_albedo", albedo_texture)

--- a/Scripts/Helper/signal_broker.gd
+++ b/Scripts/Helper/signal_broker.gd
@@ -108,9 +108,6 @@ signal game_ended() # When the game is completely exited and everything is unloa
 signal game_terminated() # When the user presses 'main menu' button on the escape menu
 @warning_ignore("unused_signal")
 signal player_spawned(player: CharacterBody3D) # When the player has spawned in-game
-# When the playerhas moved up or down a level
-@warning_ignore("unused_signal")
-signal player_y_level_updated(new_y:float) 
 
 # When a mob was killed
 @warning_ignore("unused_signal")

--- a/Scripts/crafting_recipes_manager.gd
+++ b/Scripts/crafting_recipes_manager.gd
@@ -1,14 +1,14 @@
 extends Node
 
 # Items that have the "craft" property and can be crafted
-var craftable_items
+var craftable_items: Array[DItem]
 
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	get_crafting_recipes_from_json()
 
-func get_crafting_recipes_from_json():
+func get_crafting_recipes_from_json() -> void:
 	craftable_items = Gamedata.items.get_items_by_type("craft")
 
 

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -16,6 +16,8 @@ var stats: DStats
 var skills: DSkills
 var quests: DQuests
 
+# Load the shader resource
+static var shared_furniture_shader := preload("res://Shaders/HideAbovePlayer.gdshader")
 
 # Dictionary to store loaded textures
 var textures: Dictionary = {

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -17,13 +17,14 @@ var skills: DSkills
 var quests: DQuests
 
 # Load the shader resource
-static var shared_furniture_shader := preload("res://Shaders/HideAbovePlayer.gdshader")
+static var hide_above_player_shader := preload("res://Shaders/HideAbovePlayer.gdshader")
 
 # Dictionary to store loaded textures
 var textures: Dictionary = {
 	"container": load("res://Textures/container_32.png"),
 	"container_filled": load("res://Textures/container_filled_32.png")
 }
+var materials: Dictionary = {}
 
 # Enums to define the different content types
 enum ContentType {
@@ -78,8 +79,20 @@ func _ready():
 	}
 
 	load_sprites()
+	materials["container"] = create_item_shader_material(textures.container)
+	materials["container_filled"] = create_item_shader_material(textures.container_filled)
 
 
+# Helper function to create a ShaderMaterial for the item
+func create_item_shader_material(albedo_texture: Texture) -> ShaderMaterial:
+	# Create a new ShaderMaterial
+	var shader_material = ShaderMaterial.new()
+	shader_material.shader = hide_above_player_shader  # Use the shared shader
+
+	# Assign the texture to the material
+	shader_material.set_shader_parameter("texture_albedo", albedo_texture)
+
+	return shader_material
 
 
 # Loads sprites and assigns them to the proper dictionary

--- a/Scripts/item_manager.gd
+++ b/Scripts/item_manager.gd
@@ -11,7 +11,7 @@ var playerInventory: InventoryStacked = null
 var proximityInventory: InventoryStacked = null
 
 var proximityInventories = {}  # Dictionary to hold inventories and their items
-var allAccessibleItems = []  # List to hold all accessible InventoryItems
+var allAccessibleItems: Array[InventoryItem] = []  # List to hold all accessible InventoryItems
 var player_max_inventory_volume: int = 1000
 var item_protosets: Resource = preload("res://ItemProtosets.tres")
  # Keeps track of player equipment, used for saving
@@ -104,12 +104,12 @@ func _ready():
 # This emits a signal with two lists bounded to it
 # items_added = All items that were added, or had their count increased
 # items_removed = all items that were removed, or had their count decreased
-func update_accessible_items_list():
+func update_accessible_items_list() -> void:
 	var old_items = allAccessibleItems.duplicate(true)  # Make a deep copy of the current list
-	var new_items = []
+	var new_items: Array[InventoryItem] = []
 
 	new_items += playerInventory.get_items()
-	for inventory in proximityInventories.values():
+	for inventory: InventoryStacked in proximityInventories.values():
 		if is_instance_valid(inventory):
 			new_items += inventory.get_items()
 
@@ -121,14 +121,14 @@ func update_accessible_items_list():
 	var items_removed = []
 
 	# Determine what's been added
-	for item in new_items:
+	for item: InventoryItem in new_items:
 		var item_id = item.prototype_id  # uniquely identify items
 		if old_count.get(item_id, 0) < new_count[item_id]:
 			items_added.append(item)
 			old_count[item_id] = old_count.get(item_id, 0) + 1
 
 	# Determine what's been removed
-	for item in old_items:
+	for item: InventoryItem in old_items:
 		var item_id = item.prototype_id  # uniquely identify items
 		if new_count.get(item_id, 0) < old_count[item_id]:
 			items_removed.append(item)
@@ -604,10 +604,31 @@ func _on_game_ended():
 func count_player_inventory_items_by_id() -> Dictionary:
 	var item_counts = {}
 
-	for inv_item in playerInventory.get_items():
+	for inv_item: InventoryItem in playerInventory.get_items():
 		var item_id = inv_item.prototype_id
 		var stack_size = InventoryStacked.get_item_stack_size(inv_item)
 
 		item_counts[item_id] = item_counts.get(item_id, 0) + stack_size
 
 	return item_counts
+
+
+# Gets the total item amount of the provided id
+func get_item_amount(item_id: String) -> int:
+	var total_amount = 0
+	for inv_item: InventoryItem in playerInventory.get_items():
+		if inv_item.prototype_id == item_id:
+			var stack_size = InventoryStacked.get_item_stack_size(inv_item)
+			total_amount += stack_size
+
+	return total_amount
+
+# Gets the total item amount of the provided id using allAccessibleItems
+func get_accessibleitem_amount(item_id: String) -> int:
+	var total_amount = 0
+	for inv_item: InventoryItem in allAccessibleItems:
+		if inv_item.prototype_id == item_id:
+			var stack_size = InventoryStacked.get_item_stack_size(inv_item)
+			total_amount += stack_size
+
+	return total_amount

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -473,7 +473,7 @@ func _on_craft_successful(_item: DItem, recipe: DItem.CraftRecipe):
 # Function to initialize the timer for checking Y level changes
 func initialize_y_level_check():
 	var y_check_timer = Timer.new()
-	y_check_timer.wait_time = 0.5
+	y_check_timer.wait_time = 0.2
 	y_check_timer.autostart = true
 	y_check_timer.one_shot = false
 	y_check_timer.timeout.connect(_emit_y_level)

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -61,7 +61,6 @@ func _ready():
 	Helper.save_helper.load_quest_state()
 	_connect_signals()
 	Helper.signal_broker.player_spawned.emit(self)
-	initialize_y_level_check()
 
 
 # Connect necessary signals for interaction and updates
@@ -118,6 +117,8 @@ func _process(_delta):
 	sprite.rotation.y = -angle  # Inverts the angle for rotation
 	$CollisionShape3D.rotation.y = -angle  # Inverts the angle for rotation
 
+	var current_y_level = global_position.y
+	RenderingServer.global_shader_parameter_set("player_y_level", current_y_level)
 
 #	if is_progress_bar_well_progressing_i_guess:
 #		get_node(progress_bar_filling).scale.x = lerp(1, 0, get_node(progress_bar_timer).time_left / progress_bar_timer_max_time)
@@ -470,20 +471,6 @@ func _on_craft_successful(_item: DItem, recipe: DItem.CraftRecipe):
 		add_skill_xp(recipe.skill_progression.id, recipe.skill_progression.xp)
 
 
-# Function to initialize the timer for checking Y level changes
-func initialize_y_level_check():
-	var y_check_timer = Timer.new()
-	y_check_timer.wait_time = 0.2
-	y_check_timer.autostart = true
-	y_check_timer.one_shot = false
-	y_check_timer.timeout.connect(_emit_y_level)
-	add_child(y_check_timer)
-
-# Function to emit the current Y level
-func _emit_y_level():
-	var current_y_level = global_position.y
-	RenderingServer.global_shader_parameter_set("player_y_level", current_y_level)
-	Helper.signal_broker.player_y_level_updated.emit(current_y_level)
 
 
 # Method to retrieve the current state of the player as a dictionary

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -482,6 +482,7 @@ func initialize_y_level_check():
 # Function to emit the current Y level
 func _emit_y_level():
 	var current_y_level = global_position.y
+	RenderingServer.global_shader_parameter_set("player_y_level", current_y_level)
 	Helper.signal_broker.player_y_level_updated.emit(current_y_level)
 
 

--- a/Shaders/HideAbovePlayer.gdshader
+++ b/Shaders/HideAbovePlayer.gdshader
@@ -1,17 +1,26 @@
 shader_type spatial;
 
+// Uniforms for texture, color, and alpha transparency
 uniform sampler2D texture_albedo;
+uniform vec4 object_color : source_color = vec4(1.0, 1.0, 1.0, 1.0);  // Default color is white with full alpha
+uniform float alpha : hint_range(0.0, 1.0) = 1.0;  // Default alpha is 1.0 (fully opaque)
+uniform float y_offset = 0.0;
+
 global uniform float player_y_level;
 
 void fragment() {
-	// Compute the world position using the built-in INV_VIEW_MATRIX
-	vec4 world_pos = INV_VIEW_MATRIX * vec4(VERTEX, 1.0);
+    // Compute the world position using INV_VIEW_MATRIX (camera space to world space)
+    vec4 world_pos = INV_VIEW_MATRIX * vec4(VERTEX, 1.0);
 
-	// Discard the fragment if it's above the player y-level
-	if (world_pos.y - 0.5 > player_y_level) {
-		discard;
-	} else {
-		ALBEDO = texture(texture_albedo, UV).rgb;
-		ALPHA = texture(texture_albedo, UV).a;
-	}
+    // Discard the fragment if it's above the player y-level
+    if (world_pos.y - y_offset > player_y_level) {
+        discard;
+    } else {
+        // Sample the texture color
+        vec3 albedo_color = texture(texture_albedo, UV).rgb;
+
+        // Apply the object color and transparency
+        ALBEDO = albedo_color * object_color.rgb;  // Multiply texture with object color
+        ALPHA = texture(texture_albedo, UV).a * alpha;  // Apply transparency
+    }
 }

--- a/Shaders/HideAbovePlayer.gdshader
+++ b/Shaders/HideAbovePlayer.gdshader
@@ -1,0 +1,17 @@
+shader_type spatial;
+
+uniform sampler2D texture_albedo;
+global uniform float player_y_level;
+
+void fragment() {
+	// Compute the world position using the built-in INV_VIEW_MATRIX
+	vec4 world_pos = INV_VIEW_MATRIX * vec4(VERTEX, 1.0);
+
+	// Discard the fragment if it's above the player y-level
+	if (world_pos.y - 0.5 > player_y_level) {
+		discard;
+	} else {
+		ALBEDO = texture(texture_albedo, UV).rgb;
+		ALPHA = texture(texture_albedo, UV).a;
+	}
+}

--- a/Shaders/HideAbovePlayer.gdshader
+++ b/Shaders/HideAbovePlayer.gdshader
@@ -1,10 +1,12 @@
 shader_type spatial;
 
-// Uniforms for texture, color, and alpha transparency
+// This shader hides objects above the player that have a ShaderMaterial and apply this shader
+// This is applied to furniture for example. This shader is instanced in Gamedata.gd
+
+// Uniforms for texture, color, alpha transparency, and y-offset
 uniform sampler2D texture_albedo;
 uniform vec4 object_color : source_color = vec4(1.0, 1.0, 1.0, 1.0);  // Default color is white with full alpha
 uniform float alpha : hint_range(0.0, 1.0) = 1.0;  // Default alpha is 1.0 (fully opaque)
-uniform float y_offset = 0.0;
 
 global uniform float player_y_level;
 
@@ -12,9 +14,14 @@ void fragment() {
     // Compute the world position using INV_VIEW_MATRIX (camera space to world space)
     vec4 world_pos = INV_VIEW_MATRIX * vec4(VERTEX, 1.0);
 
-    // Discard the fragment if it's above the player y-level
-    if (world_pos.y - y_offset > player_y_level) {
-        discard;
+    // Clamp the world y position to a whole number to unify the fragment evaluation
+    float clamped_y = floor(world_pos.y + 0.5);  // Clamping to the nearest integer
+
+    // If the clamped world position is above the player y-level, discard the fragment
+	// If you change the 0.2, you will see that as the player climbs the stairs, furniture
+	// sprites and mesh becomes visible earlier of later, depending on whether you raise it or lower it
+    if (clamped_y - 0.2 > player_y_level) {
+        discard;  // Hide all fragments for this mesh
     } else {
         // Sample the texture color
         vec3 albedo_color = texture(texture_albedo, UV).rgb;

--- a/hud.tscn
+++ b/hud.tscn
@@ -165,7 +165,7 @@ columns = 4
 
 [node name="Concrete" type="Button" parent="BuildingMenu"]
 layout_mode = 2
-text = "Concrete"
+text = "Concrete (2x plank)"
 
 [node name="CraftingMenu" parent="." instance=ExtResource("13_wjtvq")]
 visible = false

--- a/project.godot
+++ b/project.godot
@@ -182,3 +182,10 @@ quest_menu={
 3d_physics/layer_6="friendlyprojectiles"
 3d_physics/layer_7="containers"
 2d_physics/layer_20="Items"
+
+[shader_globals]
+
+player_y_level={
+"type": "float",
+"value": 0.1
+}


### PR DESCRIPTION
Requires #384 
Fixes #353

Instead of making each instance invisible, the visual fragments are now discarded by the shader. This should improve reliability and performance. The downside is that due to the shader, all furniture is very bright when the player is close. I don't know enough about shaders to fix this. I see Khaligufzel has plans for lighting so maybe it will be different afterwards. I might update the shader if I learn more bout it.

The shader I made is applied to:
- FurniturePhysicsSrv planemesh that shows the furniture sprite
- FurnitureStaticSrv planemesh, container planemesh and shapemesh. 

I could also apply it to 'level' nodes for chunks and for sprite3d that represent single containers, but I didn't want to put it all in this pr. 

Since every furniture and item has a different sprite, I had to make a new material for each of them (but they all share the same shader). I didn't know where to create them, so I put the function in DFurnitures and DItems. They will make new materials if they do not exist yet and free them after the game ends. I am a bit worried this will get in the way of threads running while furniture spawns. We can solve this by creating all materials beforehand if needed.