### PR TITLE
Fix overmap issues and add clickable tile

### DIFF
--- a/LevelManager.gd
+++ b/LevelManager.gd
@@ -20,13 +20,8 @@ func _process(_delta):
 func update_visibility(player_y: float):
 	# Update level visibility
 	for level in get_tree().get_nodes_in_group("maplevels"):
-		var is_above_player = level.y > player_y
+		var is_above_player = level.y-0.2 > player_y
 		level.visible = not is_above_player
-
-	# Update furniture visibility
-	for furniture in get_tree().get_nodes_in_group("furniture"):
-		var is_above_player = furniture.global_position.y > player_y
-		furniture.visible = not is_above_player
 
 	# Update mob visibility
 	for mob in get_tree().get_nodes_in_group("mobs"):

--- a/Mods/Core/Furniture/Furniture.json
+++ b/Mods/Core/Furniture/Furniture.json
@@ -1183,7 +1183,7 @@
 		"support_shape": {
 			"color": "869bcdff",
 			"depth_scale": 100,
-			"height": 1,
+			"height": 0.98,
 			"shape": "Box",
 			"transparent": true,
 			"width_scale": 100

--- a/Mods/Core/Maps/RockyHill_SW.json
+++ b/Mods/Core/Maps/RockyHill_SW.json
@@ -27841,6 +27841,9 @@
 	"name": "Rocky Hill (Southwest)",
 	"references": {
 		"core": {
+			"quests": [
+				"starter_tutorial_00"
+			],
 			"tacticalmaps": [
 				"RockyHill_00.json"
 			]

--- a/Mods/Core/Quests/Quests.json
+++ b/Mods/Core/Quests/Quests.json
@@ -35,6 +35,11 @@
 				"type": "kill"
 			},
 			{
+				"map_id": "RockyHill_SW",
+				"tip": "Press m to open the overmap. A red arrow and/or red X will mark the target location.",
+				"type": "enter"
+			},
+			{
 				"amount": 1,
 				"item": "rifle_m4a1",
 				"tip": "Go to the mountain and enter the cave from the south",

--- a/Scenes/ContentManager/Custom_Editors/FurnitureEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/FurnitureEditor.tscn
@@ -410,7 +410,7 @@ the shape. It also increases the height of the furniture sprite
 and the container (if this furniture is marked as a container). 0 
 means it has no height. 1 means it's as high as a wall."
 max_value = 1.0
-step = 0.1
+step = 0.01
 value = 0.5
 
 [node name="ColorLabel" type="Label" parent="VBoxContainer/TabContainer/Shape"]

--- a/Scenes/Overmap/Overmap.tscn
+++ b/Scenes/Overmap/Overmap.tscn
@@ -50,13 +50,17 @@ size_flags_stretch_ratio = 0.8
 
 [node name="ControlsVBoxContainer" type="VBoxContainer" parent="MarginContainer/HBoxContainer"]
 layout_mode = 2
+size_flags_horizontal = 8
 size_flags_stretch_ratio = 0.2
 
 [node name="OvermapTileLabel" type="Label" parent="MarginContainer/HBoxContainer/ControlsVBoxContainer"]
+custom_minimum_size = Vector2(120, 160)
 layout_mode = 2
+theme_override_font_sizes/font_size = 13
 text = "Name: Urbanroad
 Environment: Forest
 Challenge: Easy"
+autowrap_mode = 3
 
 [node name="Label" type="Label" parent="MarginContainer/HBoxContainer/ControlsVBoxContainer"]
 layout_mode = 2

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -13,7 +13,6 @@ var chunk_size: int = 8
 var tile_size: int = 32
 var grid_pixel_size: int = chunk_size * tile_size
 var selected_overmap_tile: Control = null
-var previous_visible_tile: Control = null  # Stores the previously visible tile
 var chunk_pool: Array = []  # Pool to store unloaded GridChunks
 var text_visible_by_coord: Dictionary = {}  # Tracks text visibility
 var target: Target = null  # Holds the target location as an instance of the Target class
@@ -438,11 +437,6 @@ func set_target(map_id: String, coordinate: Vector2):
 # Function to handle overmap visibility toggling
 func on_overmap_visibility_toggled():
 	if visible:
-		# Hide the previous tile marker when the overmap is opened
-		if previous_visible_tile:
-			previous_visible_tile.set_text("")
-			previous_visible_tile = null
-
 		# Force update of the player position and chunks
 		# This will cause the player_coord_changed signal to be emitted,
 		# triggering on_position_coord_changed and centering the map on the player's position
@@ -556,11 +550,7 @@ func update_offset_for_all_chunks(new_offset: Vector2):
 func on_target_map_changed(map_id: String):
 	if map_id == null or map_id == "":
 		if target:
-			if Helper.overmap_manager.player_current_cell == target.coordinate:
-				# The player is in this location. Update the string to the player marker
-				set_coordinate_text(target.coordinate, "✠")
-			else:
-				set_coordinate_text(target.coordinate, "")
+			set_coordinate_text(target.coordinate, "")
 		target = null  # Clear the target if no valid map_id is provided
 		$ArrowLabel.visible = false  # Hide arrow when no target
 	else:

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -212,8 +212,8 @@ class GridChunk:
 		var map_cell = Helper.overmap_manager.get_map_cell_by_local_coordinate(global_pos)
 		
 		if not map_cell:
-			# If no map cell found, reset the texture
-			tile.set_texture(null)
+			# If no map cell is found, reset the map_cell on the tile and clear the texture
+			tile.map_cell = null  # Reset map_cell to an empty dictionary
 			return
 
 		# Calculate distance to player
@@ -223,15 +223,9 @@ class GridChunk:
 			# Reveal the map cell if within the player's range
 			map_cell.reveal()
 
-		# Set texture based on whether the map cell is revealed
-		if map_cell.revealed:
-			var texture: Texture = map_cell.get_sprite()
-			tile.set_texture(texture)
-			# Set the tile's rotation based on the map cell's rotation property
-			tile.set_texture_rotation(map_cell.rotation)
-		else:
-			# If outside the range and not revealed, reset the texture
-			tile.set_texture(null)
+		# Assign the map_cell to the tile and let the tile handle texture and rotation
+		tile.map_cell = map_cell
+
 
 	# Function to check if the player's last position falls within the range of this chunk's grid area
 	func is_within_player_range() -> bool:
@@ -392,17 +386,8 @@ func on_position_coord_changed():
 
 # This function will be connected to the signal of the tiles
 func _on_tile_clicked(clicked_tile):
-	if clicked_tile.has_meta("map_file"):
-		selected_overmap_tile = clicked_tile
-		var mapFile = clicked_tile.get_meta("map_file")
-		var tilePos = clicked_tile.get_meta("global_pos")
-		var posString: String = "Pos: (" + str(tilePos.x)+","+str(tilePos.y)+")"
-		var nameString: String = "\nName: " + mapFile
-		var envString: String = clicked_tile.tileData.texture
-		envString = envString.replace("res://Mods/Core/OvermapTiles/","")
-		envString = "\nEnvironment: " + envString
-		var challengeString: String = "\nChallenge: Easy"
-		overmapTileLabel.text = posString + nameString + envString + challengeString
+	if clicked_tile.map_cell:
+		overmapTileLabel.text = clicked_tile.map_cell.get_info_string()
 	else: 
 		selected_overmap_tile = null
 		overmapTileLabel.text = "Select a valid target"

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -389,9 +389,10 @@ func _on_tile_clicked(clicked_tile):
 		overmapTileLabel.text = "Select a valid target"
 
 
+# The player presses the home button, sending the overmap view to (0,0)
 func _on_home_button_button_up():
 	# Update position_coord to the new position
-	Helper.position_coord = Vector2(0,0)#new_position_coord
+	Helper.position_coord = Vector2(0,0)
 	# Emit the signal to update the overmap's position and tiles
 	position_coord_changed.emit()
 
@@ -423,7 +424,7 @@ func on_player_coord_changed(_player: CharacterBody3D, _old_pos: Vector2, new_po
 	move_overmap(delta)
 
 
-# Set the target
+# Set the target. The target comes from the player reaching a "travel" step in a quest
 func set_target(map_id: String, coordinate: Vector2):
 	if target == null:
 		target = Target.new(map_id, coordinate)  # Create a new target
@@ -489,14 +490,19 @@ func show_directional_arrow_to_cell(cell_position: Vector2):
 	arrow.visible = true
 
 
-# Helper function to clamp the arrow to the edges of the TilesContainer with a margin
+# Helper function to clamp the arrow to the edges of the TilesContainer with 
+# extra margin on the left side
 func clamp_arrow_to_container_bounds(arrow_position: Vector2) -> Vector2:
 	var container_size = tilesContainer.size
 	var arrow_size = $ArrowLabel.size  # Get the size of the arrow label to use as the margin
 
-	# Clamp the arrow position within the bounds of the tilesContainer, adding the arrow size as a margin
-	arrow_position.x = clamp(arrow_position.x, arrow_size.x / 2, container_size.x - arrow_size.x / 2)
+	# Apply extra margin on the left side
+	var left_margin = arrow_size.x  # Extra margin is the size of the arrow label
+
+	# Clamp the arrow position within the bounds of the tilesContainer, adding extra margin on the left
+	arrow_position.x = clamp(arrow_position.x, left_margin, container_size.x - arrow_size.x / 2)
 	arrow_position.y = clamp(arrow_position.y, arrow_size.y / 2, container_size.y - arrow_size.y / 2)
+	
 	return arrow_position
 
 
@@ -509,6 +515,8 @@ func _on_tiles_container_resized() -> void:
 	check_target_tile_visibility.call_deferred()
 
 
+# Updates the target display to be an arrow or an X depending on wheter or not
+# the target is in visible area of the overmap
 func check_target_tile_visibility() -> void:
 	if target:
 		# Try to get the tile at the target's coordinate
@@ -530,7 +538,6 @@ func check_target_tile_visibility() -> void:
 		else:
 			# If no tile found, treat it as invisible and show the arrow
 			show_directional_arrow_to_cell(target.coordinate)
-
 
 
 # Updates the current offset globally, called when the window is resized

--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -114,7 +114,7 @@ class GridChunk:
 					tile.set_color(Color(0.3, 0.3, 1))  # Blue color for tile at (0,0)
 				else:
 					tile.set_color(Color(1, 1, 1))  # White color for other tiles
-
+				tile.set_text("")
 				# Use the same function to update tile based on its position and player location
 				update_tile_texture_and_reveal(tile, global_pos, Helper.overmap_manager.player_current_cell)
 
@@ -176,7 +176,7 @@ class GridChunk:
 	func update_tile_text_visibility():
 		# Hide the text on the previously visible tile, if any
 		if visible_tile:
-			visible_tile.set_text_visible(false)
+			visible_tile.set_text("")
 			visible_tile = null
 
 		# Check if the player's last known position is within this chunk's bounds
@@ -184,8 +184,9 @@ class GridChunk:
 			# Calculate the local position of the player within the chunk
 			var local_pos = Helper.overmap_manager.player_current_cell - grid_position
 			if tile_dictionary.has(local_pos):
+				# The player is on this tile, so we put the player marker as text
 				var tile = tile_dictionary[local_pos]
-				tile.set_text_visible(true)
+				tile.set_text("✠")
 				visible_tile = tile  # Store the reference to the new visible tile
 
 	func _on_player_coord_changed(_player: CharacterBody3D, _old_pos: Vector2, new_pos: Vector2):
@@ -439,7 +440,7 @@ func on_overmap_visibility_toggled():
 	if visible:
 		# Hide the previous tile marker when the overmap is opened
 		if previous_visible_tile:
-			previous_visible_tile.set_text_visible(false)
+			previous_visible_tile.set_text("")
 			previous_visible_tile = null
 
 		# Force update of the player position and chunks
@@ -534,7 +535,7 @@ func check_target_tile_visibility() -> void:
 			# Check if the target tile is now visible
 			if visible_rect.has_point(tile_pos):
 				# If the tile is visible, hide the arrow and show the tile text
-				set_tile_text(target_tile, "X")
+				target_tile.set_text("X")
 				$ArrowLabel.visible = false
 			else:
 				# If the tile is still not visible, ensure the arrow is displayed
@@ -572,23 +573,10 @@ func on_target_map_changed(map_id: String):
 			find_location_on_overmap(target)
 
 
-# Function to set a tile's text to a provided string and make it visible
-func set_tile_text(tile: Control, text: String) -> void:
-	if text == "":
-		# Clear the marker by hiding the text
-		tile.set_text_visible(false)
-		tile.set_text("")  # Clear any marker text
-		return
-	# Set the tile's text visible
-	tile.set_text_visible(true)
-	# Set the provided text on the tile
-	tile.set_text(text)
-
-
 # Updates a tile based on the coordinate and text
 # mycoordinate: A Vector2 using the global grid coordinate. Coordinates are managed by overmap_manager
 # mytext: The text to set on the tile at the coordinate
 func set_coordinate_text(mycoordinate: Vector2, mytext: String):
 	var tile = get_overmap_tile_at_position(mycoordinate)
 	if tile:
-		set_tile_text(tile, mytext)
+		tile.set_text(mytext)

--- a/Scenes/Overmap/Scripts/OvermapTile.gd
+++ b/Scenes/Overmap/Scripts/OvermapTile.gd
@@ -57,6 +57,10 @@ func set_text_visible(isvisible: bool):
 # Set the text on the tile
 func set_text(newtext: String):
 	$TextLabel.text = newtext
+	if newtext == "":
+		$TextLabel.visible = false
+		return
+	$TextLabel.text = newtext
 	$TextLabel.visible = true
 
 # Set the rotation of the TextureRect based on the given rotation angle

--- a/Scenes/Overmap/Scripts/OvermapTile.gd
+++ b/Scenes/Overmap/Scripts/OvermapTile.gd
@@ -4,11 +4,12 @@ extends Control
 const defaultTexture: String = "./Scenes/ContentManager/Mapeditor/Images/emptyTile.png"
 
 # Declare the map_cell variable, replacing tileData
-var map_cell: Dictionary = {}:
+# the map_cell is of the map_cell class defined in Helper.overmap_manager
+var map_cell:
 	set(cell):
 		map_cell = cell
-		if map_cell.revealed:
-			set_texture(map_cell.sprite)  # Set the texture if revealed
+		if map_cell and map_cell.revealed:
+			set_texture(map_cell.get_sprite())  # Set the texture if revealed
 			set_texture_rotation(map_cell.rotation)  # Apply the rotation
 		else:
 			set_texture(null)  # Clear the texture if not revealed

--- a/Scenes/Overmap/Scripts/OvermapTile.gd
+++ b/Scenes/Overmap/Scripts/OvermapTile.gd
@@ -1,16 +1,22 @@
 extends Control
 
-const defaultTileData: Dictionary = {"texture": ""}
+# Define the default texture to show when no map_cell is revealed
 const defaultTexture: String = "./Scenes/ContentManager/Mapeditor/Images/emptyTile.png"
-var tileData: Dictionary = defaultTileData.duplicate():
-	set(data):
-		tileData = data
-		if tileData.texture != "":
-			$TextureRect.texture = load("./Mods/Core/OvermapTiles/" + tileData.texture)
+
+# Declare the map_cell variable, replacing tileData
+var map_cell: Dictionary = {}:
+	set(cell):
+		map_cell = cell
+		if map_cell.revealed:
+			set_texture(map_cell.sprite)  # Set the texture if revealed
+			set_texture_rotation(map_cell.rotation)  # Apply the rotation
 		else:
-			$TextureRect.texture = load(defaultTexture)
+			set_texture(null)  # Clear the texture if not revealed
+
+
 signal tile_clicked(clicked_tile: Control)
 
+# Handle mouse input to emit the tile_clicked signal
 func _on_texture_rect_gui_input(event: InputEvent) -> void:
 	if event is InputEventMouseButton:
 		match event.button_index:
@@ -18,47 +24,43 @@ func _on_texture_rect_gui_input(event: InputEvent) -> void:
 				if event.pressed:
 					tile_clicked.emit(self)
 
+# Set the texture for the TextureRect
 func set_texture(res: Resource) -> void:
 	if res:
 		$TextureRect.texture = res
 	else:
-		$TextureRect.texture = load(defaultTexture)
-		
+		$TextureRect.texture = load(defaultTexture)  # Set to default texture if none provided
 
-func set_default() -> void:
-	tileData = defaultTileData.duplicate()
-
+# Highlight the tile
 func highlight() -> void:
 	$TextureRect.modulate = Color(0.227, 0.635, 0.757)
-	
+
+# Unhighlight the tile
 func unhighlight() -> void:
-	$TextureRect.modulate = Color(1,1,1)
-	
+	$TextureRect.modulate = Color(1, 1, 1)
+
+# Set the color of the TextureRect
 func set_color(myColor: Color) -> void:
 	$TextureRect.modulate = myColor
-	
+
+# Set the tile to be clickable or not
 func set_clickable(clickable: bool):
-	if !clickable:
+	if not clickable:
 		mouse_filter = MOUSE_FILTER_IGNORE
 		$TextureRect.mouse_filter = MOUSE_FILTER_IGNORE
 
-
-# Useful for alerting the player about this location by using a symbol
-func set_text(newtext: String):
-	$TextLabel.text = newtext
-	$TextLabel.visible = true
-	
-
-# Hide or show the textlabel
+# Show or hide the text on the tile
 func set_text_visible(isvisible: bool):
 	$TextLabel.visible = isvisible
 
+# Set the text on the tile
+func set_text(newtext: String):
+	$TextLabel.text = newtext
+	$TextLabel.visible = true
 
 # Set the rotation of the TextureRect based on the given rotation angle
 func set_texture_rotation(myrotation: int) -> void:
-	# Set the rotation pivot to the center of the TextureRect
-	$TextureRect.pivot_offset = size / 2
-	# Set the rotation of the TextureRect based on the given rotation angle
+	$TextureRect.pivot_offset = size / 2  # Set the pivot to the center of the TextureRect
 	match myrotation:
 		0:
 			$TextureRect.rotation_degrees = 0

--- a/Scripts/BuildManager.gd
+++ b/Scripts/BuildManager.gd
@@ -31,6 +31,13 @@ func start_building():
 	General.is_allowed_to_shoot = false
 
 func on_construction_clicked(construction_data: Dictionary):
+	var numberofplanks: int = ItemManager.get_accessibleitem_amount("plank_2x4")
+	if numberofplanks < 2:
+		print_debug("tried to construct, but not enough planks")
+		return
+		
+	if not ItemManager.remove_resource("plank_2x4",2):
+		return
 	var chunk: Chunk = LevelGenerator.get_chunk_from_position(construction_data.pos)
 	if chunk:
 		var local_position = calculate_local_position(construction_data.pos, chunk.position)

--- a/Scripts/FurniturePhysicsSrv.gd
+++ b/Scripts/FurniturePhysicsSrv.gd
@@ -246,39 +246,12 @@ func create_visual_instance() -> void:
 func create_furniture_shader_material(albedo_texture: Texture) -> ShaderMaterial:
 	# Create a new ShaderMaterial
 	var shader_material = ShaderMaterial.new()
-
-	# Create the shader code
-	var shader_code = """
-		shader_type spatial;
-
-		uniform sampler2D texture_albedo;
-		global uniform float player_y_level;
-
-		void fragment() {
-			// Compute the world position using the built-in MODELVIEW_MATRIX
-			vec4 world_pos = INV_VIEW_MATRIX * vec4(VERTEX, 1.0);
-
-			// Discard the fragment if it's above the player y-level
-			if (world_pos.y-0.5 > player_y_level) {
-				discard;
-			} else {
-				ALBEDO = texture(texture_albedo, UV).rgb;
-				ALPHA = texture(texture_albedo, UV).a;
-			}
-		}
-	"""
-	
-	# Assign the shader code to the ShaderMaterial
-	var shader = Shader.new()
-	shader.code = shader_code
-	shader_material.shader = shader
+	shader_material.shader = Gamedata.shared_furniture_shader
 
 	# Assign the texture to the material
 	shader_material.set_shader_parameter("texture_albedo", albedo_texture)
 
 	return shader_material
-
-
 
 
 # Set the new rotation for the furniture

--- a/Scripts/FurniturePhysicsSrv.gd
+++ b/Scripts/FurniturePhysicsSrv.gd
@@ -246,7 +246,7 @@ func create_visual_instance() -> void:
 func create_furniture_shader_material(albedo_texture: Texture) -> ShaderMaterial:
 	# Create a new ShaderMaterial
 	var shader_material = ShaderMaterial.new()
-	shader_material.shader = Gamedata.shared_furniture_shader
+	shader_material.shader = Gamedata.hide_above_player_shader
 
 	# Assign the texture to the material
 	shader_material.set_shader_parameter("texture_albedo", albedo_texture)

--- a/Scripts/FurniturePhysicsSrv.gd
+++ b/Scripts/FurniturePhysicsSrv.gd
@@ -222,8 +222,8 @@ func create_visual_instance() -> void:
 	sprite_mesh = PlaneMesh.new()
 	sprite_mesh.size = sprite_size
 
-	# Use the helper function to create the ShaderMaterial
-	sprite_material = create_furniture_shader_material(dfurniture.sprite)
+	# Get the ShaderMaterial from Gamedata.furnitures
+	sprite_material = Gamedata.furnitures.get_shader_material_by_id(furnitureJSON.id)
 
 	sprite_mesh.material = sprite_material
 

--- a/Scripts/FurniturePhysicsSrv.gd
+++ b/Scripts/FurniturePhysicsSrv.gd
@@ -13,7 +13,7 @@ var dfurniture: DFurniture
 var collider: RID
 var shape: RID
 var mesh_instance: RID
-var sprite_material: StandardMaterial3D
+var sprite_material: Material
 var sprite_mesh: PlaneMesh
 var myworld3d: World3D
 var container: ContainerItem = null
@@ -23,7 +23,6 @@ var original_material_color: Color = Color(1, 1, 1)  # Store the original materi
 # Variables to manage the container if this furniture is a container
 var inventory: InventoryStacked  # Holds the inventory for the container
 var itemgroup: String  # The ID of an itemgroup that it creates loot from
-var i_am_visible: bool = true # keep track of general visibility
 
 
 signal about_to_be_destroyed(me: FurniturePhysicsSrv)
@@ -131,7 +130,6 @@ func _init(furniturepos: Vector3, newFurnitureJSON: Dictionary, world3d: World3D
 
 
 func connect_signals():
-	Helper.signal_broker.player_y_level_updated.connect(_on_player_y_level_updated)
 	furniture_transform.chunk_changed.connect(_on_chunk_changed)
 
 
@@ -216,7 +214,6 @@ func calculate_sprite_size() -> Vector2:
 	return Vector2(0.5, 0.5)  # Default size if texture is not set
 
 
-# Create the visual instance using RenderingServer
 func create_visual_instance() -> void:
 	# Calculate the sprite size based on the texture dimensions
 	var sprite_size = calculate_sprite_size()
@@ -225,11 +222,8 @@ func create_visual_instance() -> void:
 	sprite_mesh = PlaneMesh.new()
 	sprite_mesh.size = sprite_size
 
-	# Initialize the sprite material with the sprite texture
-	sprite_material = StandardMaterial3D.new()
-	sprite_material.albedo_texture = dfurniture.sprite
-	# Ensure transparency is correctly set (debugging transparency issues)
-	sprite_material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
+	# Use the helper function to create the ShaderMaterial
+	sprite_material = create_furniture_shader_material(dfurniture.sprite)
 
 	sprite_mesh.material = sprite_material
 
@@ -244,8 +238,46 @@ func create_visual_instance() -> void:
 	# Set the transform for the mesh instance in the RenderingServer
 	RenderingServer.instance_set_transform(mesh_instance, mytransform)
 
-	# Ensure the sprite is visible and not being culled
+	# Ensure the sprite is visible
 	RenderingServer.instance_set_visible(mesh_instance, true)
+
+
+# Helper function to create a ShaderMaterial for the furniture
+func create_furniture_shader_material(albedo_texture: Texture) -> ShaderMaterial:
+	# Create a new ShaderMaterial
+	var shader_material = ShaderMaterial.new()
+
+	# Create the shader code
+	var shader_code = """
+		shader_type spatial;
+
+		uniform sampler2D texture_albedo;
+		global uniform float player_y_level;
+
+		void fragment() {
+			// Compute the world position using the built-in MODELVIEW_MATRIX
+			vec4 world_pos = INV_VIEW_MATRIX * vec4(VERTEX, 1.0);
+
+			// Discard the fragment if it's above the player y-level
+			if (world_pos.y-0.5 > player_y_level) {
+				discard;
+			} else {
+				ALBEDO = texture(texture_albedo, UV).rgb;
+				ALPHA = texture(texture_albedo, UV).a;
+			}
+		}
+	"""
+	
+	# Assign the shader code to the ShaderMaterial
+	var shader = Shader.new()
+	shader.code = shader_code
+	shader_material.shader = shader
+
+	# Assign the texture to the material
+	shader_material.set_shader_parameter("texture_albedo", albedo_texture)
+
+	return shader_material
+
 
 
 
@@ -517,34 +549,3 @@ func get_data() -> Dictionary:
 		newfurniturejson["Function"]["container"] = containerobject
 
 	return newfurniturejson
-
-
-# Function to hide visual elements
-func hide_visual_elements():
-	if not i_am_visible:
-		return # I am already inivisble
-	# Check if instances exist before hiding
-	if mesh_instance:
-		RenderingServer.instance_set_visible(mesh_instance, false)
-	i_am_visible = false
-
-
-# Function to show visual elements
-func show_visual_elements():
-	if i_am_visible:
-		return # I am already visible
-	# Check if instances exist before showing
-	if mesh_instance:
-		RenderingServer.instance_set_visible(mesh_instance, true)
-	i_am_visible = true
-
-
-# Function to handle the player's Y level change
-func _on_player_y_level_updated(new_y: float):
-	# Check if the furniture is above the player's new Y level
-	if furniture_transform.posy > new_y:
-		# Hide the furniture if it is above the player's level
-		hide_visual_elements()
-	else:
-		# Show the furniture if it is at or below the player's level
-		show_visual_elements()

--- a/Scripts/FurnitureStaticSpawner.gd
+++ b/Scripts/FurnitureStaticSpawner.gd
@@ -12,12 +12,7 @@ var chunk: Chunk
 var furniture_json_list: Array = []:
 	set(value):
 		furniture_json_list = value
-		await Helper.task_manager.create_task(_spawn_all_furniture).completed
-		# INFO Important to connect the signals outside the task_manager.create_task
-		# since the furniture will start engaging with the game world when they are connected
-		# If they are connected inside task_manager.create_task, there will be a conflict in threads
-		for furniture in collider_to_furniture.values():
-			furniture.connect_signals()
+		Helper.task_manager.create_task(_spawn_all_furniture)
 
 
 # Initialize with reference to the chunk

--- a/Scripts/FurnitureStaticSrv.gd
+++ b/Scripts/FurnitureStaticSrv.gd
@@ -221,9 +221,12 @@ func create_visual_instance(shape_type: String):
 	var material: ShaderMaterial = ShaderMaterial.new()
 	material.shader = Gamedata.hide_above_player_shader  # Assign the shader to the material
 
-	#if dfurniture.support_shape.transparent:
-		#material.flags_transparent = true
-		#material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
+	# Set the color and transparency in the shader material
+	material.set_shader_parameter("object_color", color)
+	if dfurniture.support_shape.transparent:
+		material.set_shader_parameter("alpha", 0.5)
+	else:
+		material.set_shader_parameter("alpha", 1.0)
 
 	if shape_type == "Box":
 		support_mesh = BoxMesh.new()

--- a/Scripts/FurnitureStaticSrv.gd
+++ b/Scripts/FurnitureStaticSrv.gd
@@ -416,8 +416,14 @@ func free_resources():
 
 # Function to check if this furniture acts as a door
 func check_door_functionality():
-	is_door = not dfurniture.function.door == "None"
-	door_state = dfurniture.function.door
+	is_door = dfurniture.function.door != "None"
+	
+	# Ensure the door_state is properly set
+	if furnitureJSON.has("Function") and furnitureJSON["Function"].has("door"):
+		door_state = furnitureJSON["Function"]["door"]
+	else:
+		door_state = "Closed"  # Default if not found in saved data
+
 
 # Function to interact with the furniture (e.g., toggling door state)
 func interact():

--- a/Scripts/FurnitureStaticSrv.gd
+++ b/Scripts/FurnitureStaticSrv.gd
@@ -271,32 +271,7 @@ func create_sprite_instance():
 func create_furniture_shader_material(albedo_texture: Texture) -> ShaderMaterial:
 	# Create a new ShaderMaterial
 	var shader_material = ShaderMaterial.new()
-
-	# Shader code to handle visibility based on player's Y level
-	var shader_code = """
-		shader_type spatial;
-
-		uniform sampler2D texture_albedo;
-		global uniform float player_y_level;
-
-		void fragment() {
-			// Compute the world position using the built-in INV_VIEW_MATRIX
-			vec4 world_pos = INV_VIEW_MATRIX * vec4(VERTEX, 1.0);
-
-			// Discard the fragment if it's above the player y-level
-			if (world_pos.y - 0.5 > player_y_level) {
-				discard;
-			} else {
-				ALBEDO = texture(texture_albedo, UV).rgb;
-				ALPHA = texture(texture_albedo, UV).a;
-			}
-		}
-	"""
-	
-	# Assign the shader code to the ShaderMaterial
-	var shader = Shader.new()
-	shader.code = shader_code
-	shader_material.shader = shader
+	shader_material.shader = Gamedata.shared_furniture_shader
 
 	# Assign the texture to the shader material
 	shader_material.set_shader_parameter("texture_albedo", albedo_texture)

--- a/Scripts/FurnitureStaticSrv.gd
+++ b/Scripts/FurnitureStaticSrv.gd
@@ -25,8 +25,8 @@ var i_am_visible: bool = true # keep track of general visibility
 # We have to keep a reference or it will be auto deleted
 var support_mesh: PrimitiveMesh
 var sprite_texture: Texture2D  # Variable to store the sprite texture
-var sprite_material: Material
-var container_material: StandardMaterial3D
+var sprite_material: ShaderMaterial
+var container_material: ShaderMaterial
 var quad_mesh: PlaneMesh
 var container_sprite_mesh: PlaneMesh
 
@@ -156,7 +156,7 @@ func connect_signals():
 func add_container():
 	if is_container():
 		_create_inventory()
-		container_material = StandardMaterial3D.new()
+		container_material = Gamedata.materials.container_filled
 		if is_new_furniture():
 			create_loot()
 		else:
@@ -271,7 +271,7 @@ func create_sprite_instance():
 func create_furniture_shader_material(albedo_texture: Texture) -> ShaderMaterial:
 	# Create a new ShaderMaterial
 	var shader_material = ShaderMaterial.new()
-	shader_material.shader = Gamedata.shared_furniture_shader
+	shader_material.shader = Gamedata.hide_above_player_shader
 
 	# Assign the texture to the shader material
 	shader_material.set_shader_parameter("texture_albedo", albedo_texture)
@@ -512,16 +512,6 @@ func deserialize_container_data():
 # Function to deserialize inventory and apply the correct sprite
 func deserialize_and_apply_items(items_data: Dictionary):
 	inventory.deserialize(items_data)
-	
-	#var default_texture: Texture = Gamedata.textures.container
-	
-	#if inventory.get_items().size() > 0:
-		#if sprite_3d.texture == default_texture:
-			#sprite_3d.texture = Gamedata.textures.container_filled
-		## Else, some other texture has been set so we keep that
-	#else:
-		#sprite_3d.texture = default_texture
-		#_on_item_removed(null)
 
 
 # Function to hide visual elements

--- a/Scripts/Gamedata/DFurnitures.gd
+++ b/Scripts/Gamedata/DFurnitures.gd
@@ -130,11 +130,6 @@ func create_furniture_shader_material(furniture_id: String) -> ShaderMaterial:
 
 	# Assign the texture to the material
 	shader_material.set_shader_parameter("texture_albedo", albedo_texture)
-	if not dfurniture.moveable:
-		shader_material.set_shader_parameter("y_offset", 0.5)
-		#shader_material.set_shader_parameter("y_offset", dfurniture.support_shape.height + 0.01)
-	else:
-		shader_material.set_shader_parameter("y_offset", 0.0)
 
 	return shader_material
 
@@ -142,8 +137,5 @@ func create_furniture_shader_material(furniture_id: String) -> ShaderMaterial:
 # Handle the game ended signal. We need to clear the shader materials because they
 # need to be re-created on game start since some of them may have changed in between.
 func _on_game_ended():
-	# Loop through all shader materials and free them
-	for material in shader_materials.values():
-		material.free()
 	# Clear the dictionary
 	shader_materials.clear()

--- a/Scripts/Gamedata/DFurnitures.gd
+++ b/Scripts/Gamedata/DFurnitures.gd
@@ -125,7 +125,7 @@ func get_shader_material_by_id(furniture_id: String) -> ShaderMaterial:
 func create_furniture_shader_material(albedo_texture: Texture) -> ShaderMaterial:
 	# Create a new ShaderMaterial
 	var shader_material = ShaderMaterial.new()
-	shader_material.shader = Gamedata.shared_furniture_shader  # Use the shared shader
+	shader_material.shader = Gamedata.hide_above_player_shader  # Use the shared shader
 
 	# Assign the texture to the material
 	shader_material.set_shader_parameter("texture_albedo", albedo_texture)

--- a/Scripts/Gamedata/DFurnitures.gd
+++ b/Scripts/Gamedata/DFurnitures.gd
@@ -10,14 +10,14 @@ var dataPath: String = "./Mods/Core/Furniture/Furniture.json"
 var spritePath: String = "./Mods/Core/Furniture/"
 var furnituredict: Dictionary = {}
 var sprites: Dictionary = {}
-
+var shader_materials: Dictionary = {}  # Cache for shader materials by furniture ID
 
 func _init():
 	load_sprites()
 	load_furnitures_from_disk()
+	Helper.signal_broker.game_ended.connect(_on_game_ended)
 
 
-# Load all furnituredata from disk into memory
 func load_furnitures_from_disk() -> void:
 	var furniturelist: Array = Helper.json_helper.load_json_array_file(dataPath)
 	for furnitureitem in furniturelist:
@@ -105,3 +105,39 @@ func add_reference_to_furniture(furnitureid: String, module: String, type: Strin
 
 func is_moveable(id: String) -> bool:
 	return by_id(id).moveable
+
+
+# New function to get or create a ShaderMaterial for a furniture ID
+func get_shader_material_by_id(furniture_id: String) -> ShaderMaterial:
+	# Check if the material already exists
+	if shader_materials.has(furniture_id):
+		return shader_materials[furniture_id]
+	else:
+		# Create a new ShaderMaterial
+		var albedo_texture: Texture = sprite_by_id(furniture_id)
+		var shader_material: ShaderMaterial = create_furniture_shader_material(albedo_texture)
+		# Store it in the dictionary
+		shader_materials[furniture_id] = shader_material
+		return shader_material
+
+
+# Helper function to create a ShaderMaterial for the furniture
+func create_furniture_shader_material(albedo_texture: Texture) -> ShaderMaterial:
+	# Create a new ShaderMaterial
+	var shader_material = ShaderMaterial.new()
+	shader_material.shader = Gamedata.shared_furniture_shader  # Use the shared shader
+
+	# Assign the texture to the material
+	shader_material.set_shader_parameter("texture_albedo", albedo_texture)
+
+	return shader_material
+
+
+# Handle the game ended signal. We need to clear the shader materials because they
+# need to be re-created on game start since some of them may have changed in between.
+func _on_game_ended():
+	# Loop through all shader materials and free them
+	for material in shader_materials.values():
+		material.free()
+	# Clear the dictionary
+	shader_materials.clear()

--- a/Scripts/Gamedata/DFurnitures.gd
+++ b/Scripts/Gamedata/DFurnitures.gd
@@ -114,21 +114,27 @@ func get_shader_material_by_id(furniture_id: String) -> ShaderMaterial:
 		return shader_materials[furniture_id]
 	else:
 		# Create a new ShaderMaterial
-		var albedo_texture: Texture = sprite_by_id(furniture_id)
-		var shader_material: ShaderMaterial = create_furniture_shader_material(albedo_texture)
+		var shader_material: ShaderMaterial = create_furniture_shader_material(furniture_id)
 		# Store it in the dictionary
 		shader_materials[furniture_id] = shader_material
 		return shader_material
 
 
 # Helper function to create a ShaderMaterial for the furniture
-func create_furniture_shader_material(albedo_texture: Texture) -> ShaderMaterial:
+func create_furniture_shader_material(furniture_id: String) -> ShaderMaterial:
 	# Create a new ShaderMaterial
+	var dfurniture: DFurniture = by_id(furniture_id)
+	var albedo_texture: Texture = dfurniture.sprite
 	var shader_material = ShaderMaterial.new()
 	shader_material.shader = Gamedata.hide_above_player_shader  # Use the shared shader
 
 	# Assign the texture to the material
 	shader_material.set_shader_parameter("texture_albedo", albedo_texture)
+	if not dfurniture.moveable:
+		shader_material.set_shader_parameter("y_offset", 0.5)
+		#shader_material.set_shader_parameter("y_offset", dfurniture.support_shape.height + 0.01)
+	else:
+		shader_material.set_shader_parameter("y_offset", 0.0)
 
 	return shader_material
 

--- a/Scripts/Gamedata/DItems.gd
+++ b/Scripts/Gamedata/DItems.gd
@@ -10,6 +10,7 @@ var dataPath: String = "./Mods/Core/Items/Items.json"
 var spritePath: String = "./Mods/Core/Items/"
 var itemdict: Dictionary = {}
 var sprites: Dictionary = {}
+var shader_materials: Dictionary = {}  # Cache for shader materials by item ID
 
 
 func _init():
@@ -138,3 +139,39 @@ func get_items_by_type(item_type: String) -> Array[DItem]:
 		if not item.get(item_type) == null:
 			filtered_items.append(item)
 	return filtered_items
+
+
+# New function to get or create a ShaderMaterial for a item ID
+func get_shader_material_by_id(item_id: String) -> ShaderMaterial:
+	# Check if the material already exists
+	if shader_materials.has(item_id):
+		return shader_materials[item_id]
+	else:
+		# Create a new ShaderMaterial
+		var albedo_texture: Texture = sprite_by_id(item_id)
+		var shader_material: ShaderMaterial = create_item_shader_material(albedo_texture)
+		# Store it in the dictionary
+		shader_materials[item_id] = shader_material
+		return shader_material
+
+
+# Helper function to create a ShaderMaterial for the item
+func create_item_shader_material(albedo_texture: Texture) -> ShaderMaterial:
+	# Create a new ShaderMaterial
+	var shader_material = ShaderMaterial.new()
+	shader_material.shader = Gamedata.shared_item_shader  # Use the shared shader
+
+	# Assign the texture to the material
+	shader_material.set_shader_parameter("texture_albedo", albedo_texture)
+
+	return shader_material
+
+
+# Handle the game ended signal. We need to clear the shader materials because they
+# need to be re-created on game start since some of them may have changed in between.
+func _on_game_ended():
+	# Loop through all shader materials and free them
+	for material in shader_materials.values():
+		material.free()
+	# Clear the dictionary
+	shader_materials.clear()

--- a/Scripts/Gamedata/DItems.gd
+++ b/Scripts/Gamedata/DItems.gd
@@ -159,7 +159,7 @@ func get_shader_material_by_id(item_id: String) -> ShaderMaterial:
 func create_item_shader_material(albedo_texture: Texture) -> ShaderMaterial:
 	# Create a new ShaderMaterial
 	var shader_material = ShaderMaterial.new()
-	shader_material.shader = Gamedata.shared_item_shader  # Use the shared shader
+	shader_material.shader = Gamedata.hide_above_player_shader  # Use the shared shader
 
 	# Assign the texture to the material
 	shader_material.set_shader_parameter("texture_albedo", albedo_texture)

--- a/Scripts/Helper/overmap_manager.gd
+++ b/Scripts/Helper/overmap_manager.gd
@@ -604,6 +604,7 @@ func process_loaded_grid_data(grid_data: Dictionary):
 		var grid = map_grid.new()
 		grid.set_data(grid_data)
 		loaded_grids[grid.pos] = grid
+		build_map_id_to_coordinates(grid)
 		print_debug("Grid loaded from file at " + str(grid.pos))
 	else:
 		print_debug("Failed to parse grid file")

--- a/Scripts/Helper/overmap_manager.gd
+++ b/Scripts/Helper/overmap_manager.gd
@@ -77,11 +77,11 @@ class map_cell:
 	var region = Region.PLAINS
 	var coordinate_x: int = 0
 	var coordinate_y: int = 0
-	var sprite: Texture = null
+	var dmap: DMap = null
 	var map_id: String = "field_grass_basic_00.json":
 		set(value):
 			map_id = value
-			sprite = Gamedata.maps.by_id(map_id).sprite
+			dmap = Gamedata.maps.by_id(map_id)
 	var tacticalmapname: String = "town_00.json"
 	var revealed: bool = false # This cell will be obfuscated on the overmap if false (unexplored)
 	var rotation: int = 0  # Will be any of [0, 90, 180, 270]
@@ -109,10 +109,42 @@ class map_cell:
 		rotation = newdata.get("rotation", 0)
 
 	func get_sprite() -> Texture:
-		return sprite
+		return dmap.sprite
 
 	func reveal():
 		revealed = true
+	
+	# Function to return formatted information about the map cell
+	func get_info_string() -> String:
+		# If the cell is not revealed, notify the player
+		if not revealed:
+			return "This area has not \nbeen explored yet."
+		
+		# If revealed, display the detailed information
+		var pos_string: String = "Pos: (" + str(coordinate_x) + ", " + str(coordinate_y) + ")"
+		
+		# Use dmap's name and description instead of map_id
+		var map_name_string: String = "\nName: " + dmap.name
+		#var map_description_string: String = "\nDescription: " + dmap.description
+		
+		var region_string: String = "\nRegion: " + region_type_to_string(region)
+		var challenge_string: String = "\nChallenge: Easy"  # Placeholder for now
+		
+		# Combine all the information into one formatted string
+		return pos_string + map_name_string + region_string + challenge_string
+		#return pos_string + map_name_string + map_description_string + region_string + challenge_string
+
+
+	# Helper function to convert Region enum to string
+	func region_type_to_string(region_type: int) -> String:
+		match region_type:
+			Region.PLAINS:
+				return "Plains"
+			Region.CITY:
+				return "City"
+			Region.FOREST:
+				return "Forest"
+		return "Unknown"
 
 
 # A grid that holds grid_width by grid_height of cells

--- a/Scripts/Helper/quest_helper.gd
+++ b/Scripts/Helper/quest_helper.gd
@@ -55,7 +55,7 @@ func _on_game_started():
 
 # Function for handling game loaded signal
 func _on_game_loaded():
-	# To be developed later
+	connect_inventory_signals()
 	pass
 
 # Function for handling game ended signal
@@ -286,7 +286,7 @@ func check_and_emit_target_map(step: Dictionary):
 	var step_type = step.get("step_type", "")
 
 	# Check for the step_type for this step according to the QuestManager
-	if step_type == "action_step":
+	if step_type == "action_step" and not step.complete:
 		var stepmeta: Dictionary = step.get("meta_data", {}).get("stepjson", {})
 		# Check the type of the stepjson, which is set in the quest editor
 		if stepmeta.get("type", "") == "enter":

--- a/Scripts/Helper/signal_broker.gd
+++ b/Scripts/Helper/signal_broker.gd
@@ -108,9 +108,6 @@ signal game_ended() # When the game is completely exited and everything is unloa
 signal game_terminated() # When the user presses 'main menu' button on the escape menu
 @warning_ignore("unused_signal")
 signal player_spawned(player: CharacterBody3D) # When the player has spawned in-game
-# When the playerhas moved up or down a level
-@warning_ignore("unused_signal")
-signal player_y_level_updated(new_y:float) 
 
 # When a mob was killed
 @warning_ignore("unused_signal")

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -16,6 +16,8 @@ var stats: DStats
 var skills: DSkills
 var quests: DQuests
 
+# Load the shader resource
+static var shared_furniture_shader := preload("res://Shaders/HideAbovePlayer.gdshader")
 
 # Dictionary to store loaded textures
 var textures: Dictionary = {

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -17,13 +17,14 @@ var skills: DSkills
 var quests: DQuests
 
 # Load the shader resource
-static var shared_furniture_shader := preload("res://Shaders/HideAbovePlayer.gdshader")
+static var hide_above_player_shader := preload("res://Shaders/HideAbovePlayer.gdshader")
 
 # Dictionary to store loaded textures
 var textures: Dictionary = {
 	"container": load("res://Textures/container_32.png"),
 	"container_filled": load("res://Textures/container_filled_32.png")
 }
+var materials: Dictionary = {}
 
 # Enums to define the different content types
 enum ContentType {
@@ -78,8 +79,20 @@ func _ready():
 	}
 
 	load_sprites()
+	materials["container"] = create_item_shader_material(textures.container)
+	materials["container_filled"] = create_item_shader_material(textures.container_filled)
 
 
+# Helper function to create a ShaderMaterial for the item
+func create_item_shader_material(albedo_texture: Texture) -> ShaderMaterial:
+	# Create a new ShaderMaterial
+	var shader_material = ShaderMaterial.new()
+	shader_material.shader = hide_above_player_shader  # Use the shared shader
+
+	# Assign the texture to the material
+	shader_material.set_shader_parameter("texture_albedo", albedo_texture)
+
+	return shader_material
 
 
 # Loads sprites and assigns them to the proper dictionary

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -473,7 +473,7 @@ func _on_craft_successful(_item: DItem, recipe: DItem.CraftRecipe):
 # Function to initialize the timer for checking Y level changes
 func initialize_y_level_check():
 	var y_check_timer = Timer.new()
-	y_check_timer.wait_time = 0.5
+	y_check_timer.wait_time = 0.2
 	y_check_timer.autostart = true
 	y_check_timer.one_shot = false
 	y_check_timer.timeout.connect(_emit_y_level)

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -61,7 +61,6 @@ func _ready():
 	Helper.save_helper.load_quest_state()
 	_connect_signals()
 	Helper.signal_broker.player_spawned.emit(self)
-	initialize_y_level_check()
 
 
 # Connect necessary signals for interaction and updates
@@ -118,6 +117,8 @@ func _process(_delta):
 	sprite.rotation.y = -angle  # Inverts the angle for rotation
 	$CollisionShape3D.rotation.y = -angle  # Inverts the angle for rotation
 
+	var current_y_level = global_position.y
+	RenderingServer.global_shader_parameter_set("player_y_level", current_y_level)
 
 #	if is_progress_bar_well_progressing_i_guess:
 #		get_node(progress_bar_filling).scale.x = lerp(1, 0, get_node(progress_bar_timer).time_left / progress_bar_timer_max_time)
@@ -470,20 +471,6 @@ func _on_craft_successful(_item: DItem, recipe: DItem.CraftRecipe):
 		add_skill_xp(recipe.skill_progression.id, recipe.skill_progression.xp)
 
 
-# Function to initialize the timer for checking Y level changes
-func initialize_y_level_check():
-	var y_check_timer = Timer.new()
-	y_check_timer.wait_time = 0.2
-	y_check_timer.autostart = true
-	y_check_timer.one_shot = false
-	y_check_timer.timeout.connect(_emit_y_level)
-	add_child(y_check_timer)
-
-# Function to emit the current Y level
-func _emit_y_level():
-	var current_y_level = global_position.y
-	RenderingServer.global_shader_parameter_set("player_y_level", current_y_level)
-	Helper.signal_broker.player_y_level_updated.emit(current_y_level)
 
 
 # Method to retrieve the current state of the player as a dictionary

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -482,6 +482,7 @@ func initialize_y_level_check():
 # Function to emit the current Y level
 func _emit_y_level():
 	var current_y_level = global_position.y
+	RenderingServer.global_shader_parameter_set("player_y_level", current_y_level)
 	Helper.signal_broker.player_y_level_updated.emit(current_y_level)
 
 

--- a/Shaders/HideAbovePlayer.gdshader
+++ b/Shaders/HideAbovePlayer.gdshader
@@ -1,17 +1,26 @@
 shader_type spatial;
 
+// Uniforms for texture, color, and alpha transparency
 uniform sampler2D texture_albedo;
+uniform vec4 object_color : source_color = vec4(1.0, 1.0, 1.0, 1.0);  // Default color is white with full alpha
+uniform float alpha : hint_range(0.0, 1.0) = 1.0;  // Default alpha is 1.0 (fully opaque)
+uniform float y_offset = 0.0;
+
 global uniform float player_y_level;
 
 void fragment() {
-	// Compute the world position using the built-in INV_VIEW_MATRIX
-	vec4 world_pos = INV_VIEW_MATRIX * vec4(VERTEX, 1.0);
+    // Compute the world position using INV_VIEW_MATRIX (camera space to world space)
+    vec4 world_pos = INV_VIEW_MATRIX * vec4(VERTEX, 1.0);
 
-	// Discard the fragment if it's above the player y-level
-	if (world_pos.y - 0.5 > player_y_level) {
-		discard;
-	} else {
-		ALBEDO = texture(texture_albedo, UV).rgb;
-		ALPHA = texture(texture_albedo, UV).a;
-	}
+    // Discard the fragment if it's above the player y-level
+    if (world_pos.y - y_offset > player_y_level) {
+        discard;
+    } else {
+        // Sample the texture color
+        vec3 albedo_color = texture(texture_albedo, UV).rgb;
+
+        // Apply the object color and transparency
+        ALBEDO = albedo_color * object_color.rgb;  // Multiply texture with object color
+        ALPHA = texture(texture_albedo, UV).a * alpha;  // Apply transparency
+    }
 }

--- a/Shaders/HideAbovePlayer.gdshader
+++ b/Shaders/HideAbovePlayer.gdshader
@@ -1,0 +1,17 @@
+shader_type spatial;
+
+uniform sampler2D texture_albedo;
+global uniform float player_y_level;
+
+void fragment() {
+	// Compute the world position using the built-in INV_VIEW_MATRIX
+	vec4 world_pos = INV_VIEW_MATRIX * vec4(VERTEX, 1.0);
+
+	// Discard the fragment if it's above the player y-level
+	if (world_pos.y - 0.5 > player_y_level) {
+		discard;
+	} else {
+		ALBEDO = texture(texture_albedo, UV).rgb;
+		ALPHA = texture(texture_albedo, UV).a;
+	}
+}

--- a/Shaders/HideAbovePlayer.gdshader
+++ b/Shaders/HideAbovePlayer.gdshader
@@ -1,10 +1,12 @@
 shader_type spatial;
 
-// Uniforms for texture, color, and alpha transparency
+// This shader hides objects above the player that have a ShaderMaterial and apply this shader
+// This is applied to furniture for example. This shader is instanced in Gamedata.gd
+
+// Uniforms for texture, color, alpha transparency, and y-offset
 uniform sampler2D texture_albedo;
 uniform vec4 object_color : source_color = vec4(1.0, 1.0, 1.0, 1.0);  // Default color is white with full alpha
 uniform float alpha : hint_range(0.0, 1.0) = 1.0;  // Default alpha is 1.0 (fully opaque)
-uniform float y_offset = 0.0;
 
 global uniform float player_y_level;
 
@@ -12,9 +14,14 @@ void fragment() {
     // Compute the world position using INV_VIEW_MATRIX (camera space to world space)
     vec4 world_pos = INV_VIEW_MATRIX * vec4(VERTEX, 1.0);
 
-    // Discard the fragment if it's above the player y-level
-    if (world_pos.y - y_offset > player_y_level) {
-        discard;
+    // Clamp the world y position to a whole number to unify the fragment evaluation
+    float clamped_y = floor(world_pos.y + 0.5);  // Clamping to the nearest integer
+
+    // If the clamped world position is above the player y-level, discard the fragment
+	// If you change the 0.2, you will see that as the player climbs the stairs, furniture
+	// sprites and mesh becomes visible earlier of later, depending on whether you raise it or lower it
+    if (clamped_y - 0.2 > player_y_level) {
+        discard;  // Hide all fragments for this mesh
     } else {
         // Sample the texture color
         vec3 albedo_color = texture(texture_albedo, UV).rgb;

--- a/hud.tscn
+++ b/hud.tscn
@@ -165,7 +165,7 @@ columns = 4
 
 [node name="Concrete" type="Button" parent="BuildingMenu"]
 layout_mode = 2
-text = "Concrete"
+text = "Concrete (2x plank)"
 
 [node name="CraftingMenu" parent="." instance=ExtResource("13_wjtvq")]
 visible = false

--- a/project.godot
+++ b/project.godot
@@ -182,3 +182,10 @@ quest_menu={
 3d_physics/layer_6="friendlyprojectiles"
 3d_physics/layer_7="containers"
 2d_physics/layer_20="Items"
+
+[shader_globals]
+
+player_y_level={
+"type": "float",
+"value": 0.1
+}


### PR DESCRIPTION
Requires #389 
Fixes #387 
Fixes #388 

This pr does three things:
1. The arrow is now contained in the overmap window
2. The player marker no longer duplicates like in #388 
3. The player is now able to get information from a tile by clicking on it