### PR TITLE
Change how mapdata.levels is used in the mapeditor

### DIFF
--- a/Mods/Core/Furniture/Furniture.json
+++ b/Mods/Core/Furniture/Furniture.json
@@ -762,7 +762,8 @@
 			"core": {
 				"maps": [
 					"Generichouse_00",
-					"generichouse_t"
+					"generichouse_t",
+					"generichouse_cross"
 				]
 			}
 		},

--- a/Mods/Core/Furniture/Furniture.json
+++ b/Mods/Core/Furniture/Furniture.json
@@ -829,7 +829,8 @@
 					"Generichouse",
 					"Generichouse_00",
 					"store_electronic_clothing",
-					"store_groceries"
+					"store_groceries",
+					"generichouse_t"
 				]
 			}
 		},

--- a/Mods/Core/Furniture/Furniture.json
+++ b/Mods/Core/Furniture/Furniture.json
@@ -761,7 +761,8 @@
 		"references": {
 			"core": {
 				"maps": [
-					"Generichouse_00"
+					"Generichouse_00",
+					"generichouse_t"
 				]
 			}
 		},

--- a/Mods/Core/Maps/Generichouse_00.json
+++ b/Mods/Core/Maps/Generichouse_00.json
@@ -25,7 +25,7 @@
 		},
 		{
 			"entities": [],
-			"id": "floor_nw_0_hallway",
+			"id": "floor_hallway",
 			"pick_one": true,
 			"rotate_random": true,
 			"spawn_chance": 100,
@@ -93,6 +93,95 @@
 				{
 					"count": 1,
 					"id": "linoleum_blue_00"
+				}
+			]
+		},
+		{
+			"entities": [],
+			"id": "floor_livingroom",
+			"pick_one": true,
+			"rotate_random": true,
+			"spawn_chance": 100,
+			"tiles": [
+				{
+					"count": 1,
+					"id": "red_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "blue_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "orange_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_00"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_01"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_04"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_05"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_06"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_08"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_07"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_blue_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_brown_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_brown_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_02"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_greyblue_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_02"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_00"
 				}
 			]
 		}
@@ -3423,6 +3512,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -3511,7 +3606,7 @@
 						"rotation": 0
 					},
 					{
-						"id": "floor_nw_0_hallway",
+						"id": "floor_hallway",
 						"rotation": 0
 					}
 				],
@@ -3527,6 +3622,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -3535,6 +3636,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
@@ -3542,6 +3649,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 90
@@ -3570,6 +3683,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "sofa"
 				},
@@ -3577,6 +3696,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "lamp_standing"
 				},
@@ -3584,6 +3709,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -3592,6 +3723,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 180
@@ -3600,6 +3737,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -3612,14 +3755,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
@@ -3690,7 +3851,7 @@
 						"rotation": 0
 					},
 					{
-						"id": "floor_nw_0_hallway",
+						"id": "floor_hallway",
 						"rotation": 0
 					}
 				],
@@ -3708,7 +3869,7 @@
 						"rotation": 0
 					},
 					{
-						"id": "floor_nw_0_hallway",
+						"id": "floor_hallway",
 						"rotation": 0
 					}
 				],
@@ -3722,7 +3883,7 @@
 						"rotation": 0
 					},
 					{
-						"id": "floor_nw_0_hallway",
+						"id": "floor_hallway",
 						"rotation": 0
 					}
 				],
@@ -3734,10 +3895,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_office",
 					"rotation": 270
@@ -3746,6 +3919,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "desk",
 					"rotation": 90
@@ -3778,22 +3957,52 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 90
 			},
@@ -3802,6 +4011,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "lamp_standing",
 					"rotation": 270
@@ -3810,14 +4025,32 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 90
@@ -3860,6 +4093,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 270
@@ -3868,14 +4107,32 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_06",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_06",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "lamp_standing",
 					"rotation": 90
@@ -3894,7 +4151,7 @@
 						"rotation": 0
 					},
 					{
-						"id": "floor_nw_0_hallway",
+						"id": "floor_hallway",
 						"rotation": 0
 					}
 				],
@@ -3934,6 +4191,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -3942,6 +4205,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 180
@@ -3950,6 +4219,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 180
@@ -3958,6 +4233,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 180
@@ -3966,10 +4247,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 270
@@ -3978,14 +4271,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 180
 			},
@@ -4030,10 +4341,22 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_06",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -4042,10 +4365,22 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_06",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -4064,7 +4399,7 @@
 						"rotation": 0
 					},
 					{
-						"id": "floor_nw_0_hallway",
+						"id": "floor_hallway",
 						"rotation": 0
 					}
 				],
@@ -4146,6 +4481,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 180
 			},
@@ -4189,6 +4530,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -4197,6 +4544,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 270
@@ -4205,6 +4558,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -4213,6 +4572,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -4231,7 +4596,7 @@
 						"rotation": 0
 					},
 					{
-						"id": "floor_nw_0_hallway",
+						"id": "floor_hallway",
 						"rotation": 0
 					}
 				],
@@ -4286,10 +4651,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 0
@@ -4297,9 +4674,21 @@
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "lamp_standing"
 				},
@@ -4307,6 +4696,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 0
@@ -4318,6 +4713,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 180
 			},
@@ -4383,7 +4784,7 @@
 						"rotation": 0
 					},
 					{
-						"id": "floor_nw_0_hallway",
+						"id": "floor_hallway",
 						"rotation": 0
 					}
 				],
@@ -4443,14 +4844,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -4458,10 +4877,22 @@
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08"
 			},
 			{
@@ -4469,6 +4900,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 180
 			},
@@ -4538,7 +4975,7 @@
 						"rotation": 0
 					},
 					{
-						"id": "floor_nw_0_hallway",
+						"id": "floor_hallway",
 						"rotation": 0
 					}
 				],
@@ -4551,7 +4988,7 @@
 						"rotation": 0
 					},
 					{
-						"id": "floor_nw_0_hallway",
+						"id": "floor_hallway",
 						"rotation": 0
 					}
 				],
@@ -4565,7 +5002,7 @@
 						"rotation": 0
 					},
 					{
-						"id": "floor_nw_0_hallway",
+						"id": "floor_hallway",
 						"rotation": 0
 					}
 				],
@@ -4621,9 +5058,21 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -4632,6 +5081,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 90
@@ -4640,6 +5095,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -4648,6 +5109,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08"
 			},
 			{
@@ -4655,6 +5122,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 180
 			},
@@ -4717,7 +5190,7 @@
 						"rotation": 0
 					},
 					{
-						"id": "floor_nw_0_hallway",
+						"id": "floor_hallway",
 						"rotation": 0
 					}
 				],
@@ -4731,7 +5204,7 @@
 						"rotation": 0
 					},
 					{
-						"id": "floor_nw_0_hallway",
+						"id": "floor_hallway",
 						"rotation": 0
 					}
 				],
@@ -4745,7 +5218,7 @@
 						"rotation": 0
 					},
 					{
-						"id": "floor_nw_0_hallway",
+						"id": "floor_hallway",
 						"rotation": 0
 					}
 				],
@@ -4801,14 +5274,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 0
@@ -4817,10 +5308,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08"
 			},
 			{
@@ -4828,6 +5331,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 180
 			},
@@ -4893,7 +5402,7 @@
 						"rotation": 0
 					},
 					{
-						"id": "floor_nw_0_hallway",
+						"id": "floor_hallway",
 						"rotation": 0
 					}
 				],
@@ -4906,7 +5415,7 @@
 						"rotation": 0
 					},
 					{
-						"id": "floor_nw_0_hallway",
+						"id": "floor_hallway",
 						"rotation": 0
 					}
 				],
@@ -4920,7 +5429,7 @@
 						"rotation": 0
 					},
 					{
-						"id": "floor_nw_0_hallway",
+						"id": "floor_hallway",
 						"rotation": 0
 					}
 				],
@@ -4976,6 +5485,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "lamp_standing",
 					"rotation": 180
@@ -4984,6 +5499,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
@@ -4991,13 +5512,31 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 180
 			},
@@ -5010,6 +5549,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 180
 			},
@@ -5158,6 +5703,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -7551,6 +8102,12 @@
 				"id": "rocky_earth_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood"
 				},
@@ -7674,6 +8231,12 @@
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00"
 			},
 			{
@@ -7685,19 +8248,49 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "lamp_standing"
 				},
@@ -7742,6 +8335,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "lamp_standing"
 				},
@@ -7749,10 +8348,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 180
 			},
@@ -7802,20 +8413,44 @@
 				"id": "rocky_earth_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00"
 			},
 			{
 				"id": "rocky_earth_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -7824,10 +8459,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 270
 			},
@@ -7873,12 +8520,30 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 270
 			},
@@ -7924,16 +8589,34 @@
 				"id": "rocky_earth_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00"
 			},
 			{
 				"id": "rocky_earth_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -7942,6 +8625,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 270
@@ -7950,6 +8639,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -7958,6 +8653,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 180
 			},
@@ -8003,14 +8704,32 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 180
 			},
@@ -8064,20 +8783,44 @@
 				"id": "rocky_earth_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00"
 			},
 			{
 				"id": "rocky_earth_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood"
 				},
@@ -8085,10 +8828,22 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 270
 			},
@@ -8139,6 +8894,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 270
 			},
@@ -8185,12 +8946,24 @@
 				"id": "rocky_earth_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00"
 			},
 			{
 				"id": "rocky_earth_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 180
@@ -8199,16 +8972,34 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -8217,6 +9008,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08"
 			},
 			{
@@ -8261,6 +9058,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 90
 			},
@@ -8268,6 +9071,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -8275,6 +9084,12 @@
 				"id": "floor_wood_boards_06"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -8282,6 +9097,12 @@
 				"id": "floor_wood_boards_06"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 90
@@ -8289,6 +9110,12 @@
 				"id": "floor_wood_boards_06"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -8327,6 +9154,12 @@
 				"id": "rocky_earth_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00"
 			},
 			{
@@ -8399,6 +9232,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 180
 			},
@@ -8406,6 +9245,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -8413,15 +9258,33 @@
 				"id": "floor_wood_boards_06"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_06"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood"
 				},
 				"id": "floor_wood_boards_06"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_06"
 			},
 			{
@@ -8456,17 +9319,41 @@
 				"id": "rocky_earth_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 90
@@ -8475,10 +9362,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00"
 				},
@@ -8486,6 +9385,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00"
 				},
@@ -8493,6 +9398,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00"
 				},
@@ -8500,6 +9411,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00"
 				},
@@ -8532,6 +9449,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 90
 			},
@@ -8539,6 +9462,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "lamp_standing",
 					"rotation": 270
@@ -8546,12 +9475,30 @@
 				"id": "floor_wood_boards_06"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_06"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_06"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 90
@@ -8592,6 +9539,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 270
@@ -8600,14 +9553,32 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "lamp_standing",
 					"rotation": 90
@@ -8620,22 +9591,52 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 270
 			},
@@ -8661,6 +9662,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "desk",
 					"rotation": 270
@@ -8668,6 +9675,12 @@
 				"id": "floor_wood_boards_03"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_office",
 					"rotation": 90
@@ -8675,9 +9688,21 @@
 				"id": "floor_wood_boards_03"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 270
@@ -8686,10 +9711,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 90
@@ -8752,14 +9789,32 @@
 				"id": "rocky_earth_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
@@ -8768,6 +9823,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -8776,6 +9837,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood"
 				},
@@ -8783,6 +9850,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -8791,6 +9864,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "lamp_standing",
 					"rotation": 180
@@ -8799,6 +9878,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "sofa",
 					"rotation": 180
@@ -8824,6 +9909,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 270
@@ -8831,12 +9922,24 @@
 				"id": "floor_wood_boards_03"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
 				"id": "floor_wood_boards_03"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -8847,6 +9950,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 180
@@ -8913,6 +10022,12 @@
 				"id": "rocky_earth_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -12563,6 +13678,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -12604,6 +13725,7 @@
 				"rotation": 180
 			},
 			{
+				"areas": [],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -12615,6 +13737,7 @@
 				"rotation": 180
 			},
 			{
+				"areas": [],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -12709,6 +13832,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "lamp_standing"
 				},
@@ -12750,6 +13879,7 @@
 				"rotation": 180
 			},
 			{
+				"areas": [],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 0
@@ -12758,6 +13888,7 @@
 				"rotation": 180
 			},
 			{
+				"areas": [],
 				"furniture": {
 					"id": "trash_bin"
 				},
@@ -12765,6 +13896,7 @@
 				"rotation": 180
 			},
 			{
+				"areas": [],
 				"furniture": {
 					"id": "desk"
 				},
@@ -12772,6 +13904,7 @@
 				"rotation": 180
 			},
 			{
+				"areas": [],
 				"furniture": {
 					"id": "lamp_standing"
 				},
@@ -12779,6 +13912,7 @@
 				"rotation": 270
 			},
 			{
+				"areas": [],
 				"furniture": {
 					"id": "wardrobe",
 					"rotation": 90
@@ -12869,9 +14003,21 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 90
@@ -12910,6 +14056,7 @@
 
 			},
 			{
+				"areas": [],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -12918,14 +14065,17 @@
 				"rotation": 180
 			},
 			{
+				"areas": [],
 				"id": "floor_wood_boards_00",
 				"rotation": 180
 			},
 			{
+				"areas": [],
 				"id": "floor_wood_boards_00",
 				"rotation": 90
 			},
 			{
+				"areas": [],
 				"furniture": {
 					"id": "chair_office",
 					"rotation": 180
@@ -12934,9 +14084,11 @@
 				"rotation": 180
 			},
 			{
+				"areas": [],
 				"id": "floor_wood_boards_00"
 			},
 			{
+				"areas": [],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -12953,14 +14105,32 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 90
@@ -13030,6 +14200,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07"
 			},
 			{
@@ -13064,6 +14240,7 @@
 				"rotation": 180
 			},
 			{
+				"areas": [],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 270
@@ -13072,19 +14249,29 @@
 				"rotation": 270
 			},
 			{
+				"areas": [],
 				"id": "floor_wood_boards_00"
 			},
 			{
+				"areas": [],
 				"id": "floor_wood_boards_00"
 			},
 			{
+				"areas": [],
 				"id": "floor_wood_boards_00"
 			},
 			{
+				"areas": [],
 				"id": "floor_wood_boards_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 270
@@ -13093,14 +14280,32 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
@@ -13151,6 +14356,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood"
 				},
@@ -13162,6 +14373,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 270
 			},
@@ -13221,6 +14438,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "lamp_standing",
 					"rotation": 270
@@ -13229,10 +14452,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
@@ -13289,6 +14524,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 270
 			},
@@ -13301,6 +14542,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07"
 			},
 			{
@@ -13331,6 +14578,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -13339,38 +14592,92 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
@@ -13422,6 +14729,12 @@
 				"id": "blue_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 270
@@ -13430,13 +14743,31 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 180
 			},
@@ -13472,6 +14803,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -13508,6 +14845,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -13571,6 +14914,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 90
 			},
@@ -13716,6 +15065,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 270
@@ -13724,6 +15079,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07"
 			},
 			{
@@ -13864,6 +15225,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 270
@@ -13871,6 +15238,12 @@
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -15187,6 +16560,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 0
@@ -15195,6 +16574,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 90
@@ -15350,10 +16735,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 90
@@ -15509,6 +16906,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 270
 			},
@@ -15570,6 +16973,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 0
@@ -15606,6 +17015,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 0
@@ -15645,17 +17060,41 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 90
@@ -15714,38 +17153,92 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
@@ -15789,6 +17282,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 180
 			},
@@ -15801,6 +17300,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 90
 			},
@@ -15863,14 +17368,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "lamp_standing",
 					"rotation": 90
@@ -15927,6 +17450,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 90
 			},
@@ -15935,6 +17464,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -15988,17 +17523,41 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 90
@@ -16060,6 +17619,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 180
 			},
@@ -16068,14 +17633,17 @@
 				"rotation": 270
 			},
 			{
+				"areas": [],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [],
 				"furniture": {
 					"id": "wardrobe",
 					"rotation": 0
@@ -16084,6 +17652,7 @@
 				"rotation": 270
 			},
 			{
+				"areas": [],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 0
@@ -16125,6 +17694,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 270
@@ -16133,10 +17708,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
@@ -16213,6 +17800,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 270
@@ -16221,6 +17814,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 180
 			},
@@ -16229,6 +17828,7 @@
 				"rotation": 270
 			},
 			{
+				"areas": [],
 				"furniture": {
 					"id": "chair_office",
 					"rotation": 0
@@ -16237,18 +17837,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -16376,6 +17980,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "lamp_standing",
 					"rotation": 180
@@ -16388,6 +17998,7 @@
 				"rotation": 270
 			},
 			{
+				"areas": [],
 				"furniture": {
 					"id": "desk",
 					"rotation": 180
@@ -16396,6 +18007,7 @@
 				"rotation": 270
 			},
 			{
+				"areas": [],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 0
@@ -16404,6 +18016,7 @@
 				"rotation": 270
 			},
 			{
+				"areas": [],
 				"furniture": {
 					"id": "trash_bin"
 				},
@@ -16411,6 +18024,7 @@
 				"rotation": 270
 			},
 			{
+				"areas": [],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 180
@@ -16531,6 +18145,7 @@
 				"rotation": 90
 			},
 			{
+				"areas": [],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -16547,6 +18162,7 @@
 				"rotation": 90
 			},
 			{
+				"areas": [],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180

--- a/Mods/Core/Maps/Generichouse_00.json
+++ b/Mods/Core/Maps/Generichouse_00.json
@@ -342,6 +342,99 @@
 					"id": "linoleum_white_02"
 				}
 			]
+		},
+		{
+			"entities": [],
+			"id": "floor_bedroom",
+			"pick_one": true,
+			"rotate_random": true,
+			"spawn_chance": 100,
+			"tiles": [
+				{
+					"count": 1,
+					"id": "red_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "blue_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "orange_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_00"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_01"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_02"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_04"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_05"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_06"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_08"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_07"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_blue_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_brown_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_brown_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_02"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_greyblue_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_02"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_00"
+				}
+			]
 		}
 	],
 	"categories": [
@@ -14170,6 +14263,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -14185,6 +14284,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -14243,7 +14348,12 @@
 				"rotation": 180
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -14255,7 +14365,12 @@
 				"rotation": 180
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -14316,6 +14431,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 0
@@ -14324,6 +14445,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
@@ -14331,6 +14458,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -14339,6 +14472,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "desk"
 				},
@@ -14367,14 +14506,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_blue_02",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_blue_02",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "toilet_00",
 					"rotation": 90
@@ -14397,7 +14554,12 @@
 				"rotation": 180
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 0
@@ -14406,7 +14568,12 @@
 				"rotation": 180
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
@@ -14414,7 +14581,12 @@
 				"rotation": 180
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "desk"
 				},
@@ -14422,7 +14594,12 @@
 				"rotation": 180
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "lamp_standing"
 				},
@@ -14430,7 +14607,12 @@
 				"rotation": 270
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "wardrobe",
 					"rotation": 90
@@ -14456,6 +14638,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -14464,10 +14652,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "toilet_00",
 					"rotation": 90
@@ -14489,6 +14689,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -14497,18 +14703,42 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_office",
 					"rotation": 180
@@ -14544,10 +14774,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_blue_02",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -14556,6 +14798,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -14583,17 +14831,32 @@
 				"rotation": 180
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 180
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 90
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_office",
 					"rotation": 180
@@ -14602,11 +14865,21 @@
 				"rotation": 180
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00"
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -14657,14 +14930,32 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bathtub",
 					"rotation": 90
@@ -14690,6 +14981,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 180
@@ -14698,6 +14995,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "wardrobe",
 					"rotation": 180
@@ -14706,10 +15009,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
@@ -14758,7 +15073,12 @@
 				"rotation": 180
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 270
@@ -14767,19 +15087,39 @@
 				"rotation": 270
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00"
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00"
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00"
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 270
 			},
@@ -15024,6 +15364,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "desk",
 					"rotation": 270
@@ -15031,6 +15377,12 @@
 				"id": "blue_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_office",
 					"rotation": 90
@@ -15230,6 +15582,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -15238,12 +15596,24 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
 				"id": "blue_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00"
 			},
 			{
@@ -15411,6 +15781,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 270
@@ -15418,6 +15794,12 @@
 				"id": "blue_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00"
 			},
 			{
@@ -15473,10 +15855,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_02",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 0
@@ -15485,6 +15879,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 0
@@ -15493,6 +15893,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 0
@@ -15505,6 +15911,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 270
@@ -15513,6 +15925,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
@@ -15520,6 +15938,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 0
@@ -15528,6 +15952,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 270
 			},
@@ -15566,6 +15996,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 270
@@ -15573,6 +16009,12 @@
 				"id": "blue_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00"
 			},
 			{
@@ -15633,6 +16075,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -15641,18 +16089,42 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_02",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_02",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_02",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "lamp_standing",
 					"rotation": 90
@@ -15665,6 +16137,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "lamp_standing",
 					"rotation": 270
@@ -15673,14 +16151,32 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 270
 			},
@@ -15715,6 +16211,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -15723,6 +16225,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 180
@@ -15730,6 +16238,12 @@
 				"id": "blue_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "wardrobe",
 					"rotation": 180
@@ -15801,6 +16315,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -15809,6 +16329,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "desk",
 					"rotation": 270
@@ -15817,6 +16343,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_office",
 					"rotation": 90
@@ -15825,6 +16357,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "wardrobe",
 					"rotation": 180
@@ -15837,6 +16375,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 270
@@ -15845,6 +16389,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -15853,6 +16403,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 180
@@ -15861,6 +16417,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -15903,6 +16465,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -15969,6 +16537,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -15989,6 +16563,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -16001,6 +16581,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -16839,6 +17425,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -16850,6 +17442,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -16869,6 +17467,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -16934,6 +17538,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -16975,6 +17585,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -16983,6 +17599,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 0
@@ -16991,6 +17613,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 0
@@ -16999,6 +17627,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 90
@@ -17011,6 +17645,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "wardrobe",
 					"rotation": 0
@@ -17019,6 +17659,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_office",
 					"rotation": 270
@@ -17027,6 +17673,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "desk",
 					"rotation": 90
@@ -17035,6 +17687,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 0
@@ -17043,6 +17701,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -17113,6 +17777,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "wardrobe",
 					"rotation": 0
@@ -17121,6 +17791,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 0
@@ -17129,6 +17805,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -17171,18 +17853,42 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "lamp_standing",
 					"rotation": 90
@@ -17195,6 +17901,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "lamp_standing",
 					"rotation": 270
@@ -17203,14 +17915,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_02",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_02",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
@@ -17284,10 +18014,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 90
@@ -17330,10 +18072,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -17342,6 +18096,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
@@ -17349,6 +18109,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 90
@@ -17361,6 +18127,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 180
@@ -17369,6 +18141,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 180
@@ -17377,6 +18155,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 180
@@ -17385,10 +18169,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_02",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -17445,10 +18241,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 90
@@ -17621,10 +18429,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 0
@@ -17832,6 +18652,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_office",
 					"rotation": 270
@@ -17840,6 +18666,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "desk",
 					"rotation": 90
@@ -17848,6 +18680,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -18083,22 +18921,52 @@
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 90
@@ -18151,17 +19019,32 @@
 				"rotation": 270
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "wardrobe",
 					"rotation": 0
@@ -18170,7 +19053,12 @@
 				"rotation": 270
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 0
@@ -18196,6 +19084,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bathtub",
 					"rotation": 270
@@ -18204,10 +19098,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 90
 			},
@@ -18252,6 +19158,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 0
@@ -18260,10 +19172,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_office",
 					"rotation": 0
@@ -18271,16 +19195,34 @@
 				"id": "floor_wood_boards_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
 				"id": "floor_wood_boards_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -18298,6 +19240,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -18306,6 +19254,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -18314,6 +19268,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_blue_02",
 				"rotation": 270
 			},
@@ -18346,7 +19306,12 @@
 				"rotation": 270
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_office",
 					"rotation": 0
@@ -18355,22 +19320,42 @@
 				"rotation": 270
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -18392,6 +19377,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "toilet_00",
 					"rotation": 270
@@ -18400,10 +19391,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -18428,6 +19431,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "wardrobe",
 					"rotation": 270
@@ -18436,6 +19445,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "lamp_standing",
 					"rotation": 180
@@ -18444,6 +19459,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "desk",
 					"rotation": 180
@@ -18451,6 +19472,12 @@
 				"id": "floor_wood_boards_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 0
@@ -18458,6 +19485,12 @@
 				"id": "floor_wood_boards_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 180
@@ -18478,6 +19511,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "toilet_00",
 					"rotation": 270
@@ -18486,10 +19525,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_blue_02",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_blue_02",
 				"rotation": 270
 			},
@@ -18516,7 +19567,12 @@
 				"rotation": 270
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "desk",
 					"rotation": 180
@@ -18525,7 +19581,12 @@
 				"rotation": 270
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 0
@@ -18534,7 +19595,12 @@
 				"rotation": 270
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
@@ -18542,7 +19608,12 @@
 				"rotation": 270
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 180
@@ -18602,6 +19673,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -18612,6 +19689,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -18663,7 +19746,12 @@
 				"rotation": 90
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -18680,7 +19768,12 @@
 				"rotation": 90
 			},
 			{
-				"areas": [],
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180

--- a/Mods/Core/Maps/Generichouse_00.json
+++ b/Mods/Core/Maps/Generichouse_00.json
@@ -184,6 +184,164 @@
 					"id": "linoleum_lightblue_00"
 				}
 			]
+		},
+		{
+			"entities": [],
+			"id": "floor_bathroom",
+			"pick_one": true,
+			"rotate_random": true,
+			"spawn_chance": 100,
+			"tiles": [
+				{
+					"count": 1,
+					"id": "kitchen_tiles_yellow_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_yellow_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_yellow_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_03"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_green_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_green_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_green_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_blue_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_blue_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_blue_01"
+				}
+			]
+		},
+		{
+			"entities": [],
+			"id": "floor_kitchen",
+			"pick_one": true,
+			"rotate_random": true,
+			"spawn_chance": 100,
+			"tiles": [
+				{
+					"count": 1,
+					"id": "kitchen_tiles_yellow_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_yellow_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_yellow_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_03"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_blue_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_blue_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_blue_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_green_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_green_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_green_00"
+				},
+				{
+					"count": 1,
+					"id": "bathroom_tiles_blue_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_white_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_02"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_02"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_white_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_white_02"
+				}
+			]
 		}
 	],
 	"categories": [
@@ -3565,6 +3723,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "refrigerator_00",
 					"rotation": 0
@@ -3573,6 +3737,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "stove"
 				},
@@ -3580,6 +3750,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 0
@@ -3588,6 +3764,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 0
@@ -3789,14 +3971,32 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "toilet_00",
 					"rotation": 90
@@ -3829,18 +4029,42 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "bathroom_tiles_blue_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "bathroom_tiles_blue_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "bathroom_tiles_blue_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "bathroom_tiles_blue_00",
 				"rotation": 180
 			},
@@ -4059,14 +4283,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -4636,6 +4878,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00"
 				},
@@ -4643,6 +4891,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 0
@@ -4832,6 +5086,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 270
@@ -4840,6 +5100,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_00",
 				"rotation": 90
 			},
@@ -4950,6 +5216,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "toilet_00",
 					"rotation": 0
@@ -4958,6 +5230,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "lamp_standing"
 				},
@@ -5046,6 +5324,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 270
@@ -5054,6 +5338,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_00",
 				"rotation": 90
 			},
@@ -5172,10 +5462,22 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 180
 			},
@@ -5262,6 +5564,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "stove",
 					"rotation": 270
@@ -5270,6 +5578,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_00",
 				"rotation": 90
 			},
@@ -5377,6 +5691,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 0
@@ -5385,6 +5705,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 180
 			},
@@ -5473,6 +5799,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "refrigerator_00",
 					"rotation": 270
@@ -5481,6 +5813,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_00",
 				"rotation": 90
 			},
@@ -8297,10 +8635,22 @@
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "refrigerator_00",
 					"rotation": 90
@@ -8376,9 +8726,21 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -8479,10 +8841,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "stove",
 					"rotation": 90
@@ -8551,9 +8925,21 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01"
 			},
 			{
@@ -8663,10 +9049,22 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 90
@@ -8737,6 +9135,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "standing_mirror",
 					"rotation": 180
@@ -8744,6 +9148,12 @@
 				"id": "kitchen_tiles_green_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "toilet_00",
 					"rotation": 180
@@ -8848,10 +9258,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 90
@@ -9017,6 +9439,12 @@
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -9025,6 +9453,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -9523,6 +9957,12 @@
 				"id": "rocky_earth_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -9531,10 +9971,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 270
 			},
@@ -9735,15 +10187,39 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "bathroom_tiles_blue_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "bathroom_tiles_blue_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "bathroom_tiles_blue_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "bathroom_tiles_blue_00"
 			},
 			{
@@ -9770,6 +10246,12 @@
 				"id": "rocky_earth_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "toilet_00",
 					"rotation": 270
@@ -9778,10 +10260,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 270
 			},
@@ -9967,6 +10461,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 180
@@ -9974,6 +10474,12 @@
 				"id": "bathroom_tiles_blue_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 180
@@ -9981,6 +10487,12 @@
 				"id": "bathroom_tiles_blue_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "stove",
 					"rotation": 180
@@ -9988,6 +10500,12 @@
 				"id": "bathroom_tiles_blue_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "refrigerator_00",
 					"rotation": 180

--- a/Mods/Core/Maps/Generichouse_00.json
+++ b/Mods/Core/Maps/Generichouse_00.json
@@ -14512,6 +14512,10 @@
 						"rotation": 0
 					}
 				],
+				"furniture": {
+					"id": "plant_pot_00",
+					"rotation": 270
+				},
 				"id": "kitchen_tiles_blue_02",
 				"rotation": 90
 			},
@@ -14790,10 +14794,6 @@
 						"rotation": 0
 					}
 				],
-				"furniture": {
-					"id": "plant_pot_00",
-					"rotation": 90
-				},
 				"id": "kitchen_tiles_blue_02",
 				"rotation": 90
 			},
@@ -14805,7 +14805,7 @@
 					}
 				],
 				"furniture": {
-					"id": "plant_pot_00",
+					"id": "bathtub",
 					"rotation": 90
 				},
 				"id": "kitchen_tiles_blue_02",
@@ -15404,6 +15404,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -18630,6 +18636,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 0
@@ -19247,7 +19259,7 @@
 					}
 				],
 				"furniture": {
-					"id": "plant_pot_00",
+					"id": "bathtub",
 					"rotation": 270
 				},
 				"id": "kitchen_tiles_blue_02",
@@ -19260,10 +19272,6 @@
 						"rotation": 0
 					}
 				],
-				"furniture": {
-					"id": "plant_pot_00",
-					"rotation": 270
-				},
 				"id": "kitchen_tiles_blue_02",
 				"rotation": 270
 			},
@@ -19541,6 +19549,10 @@
 						"rotation": 0
 					}
 				],
+				"furniture": {
+					"id": "plant_pot_00",
+					"rotation": 270
+				},
 				"id": "kitchen_tiles_blue_02",
 				"rotation": 270
 			},

--- a/Mods/Core/Maps/generichouse_corner.json
+++ b/Mods/Core/Maps/generichouse_corner.json
@@ -196,6 +196,95 @@
 					"id": "linoleum_lightblue_01"
 				}
 			]
+		},
+		{
+			"entities": [],
+			"id": "floor_bedroom",
+			"pick_one": true,
+			"rotate_random": true,
+			"spawn_chance": 100,
+			"tiles": [
+				{
+					"count": 1,
+					"id": "red_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "blue_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "orange_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_01"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_00"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_02"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_04"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_05"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_06"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_08"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_07"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_blue_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_brown_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_02"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_greyblue_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_02"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_00"
+				}
+			]
 		}
 	],
 	"categories": [
@@ -10465,6 +10554,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 270
@@ -10472,6 +10567,12 @@
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -10480,6 +10581,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00"
 				},
@@ -10487,6 +10594,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
@@ -10494,6 +10607,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -10618,6 +10737,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 270
@@ -10626,17 +10751,41 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood"
 				},
@@ -10752,13 +10901,31 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -10767,6 +10934,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -10774,6 +10947,12 @@
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood"
 				},
@@ -11167,10 +11346,22 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
@@ -11178,6 +11369,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00"
 				},
@@ -11185,6 +11382,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 90
 			},
@@ -11193,10 +11396,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -11205,6 +11420,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 270
@@ -11299,6 +11520,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -11307,6 +11534,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 270
@@ -11315,14 +11548,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 90
 			},
@@ -11331,6 +11582,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 270
@@ -11339,10 +11596,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood"
 				},
@@ -11350,6 +11619,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -11418,9 +11693,21 @@
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -11428,6 +11715,12 @@
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 270
@@ -11435,6 +11728,12 @@
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -11442,6 +11741,12 @@
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -11463,6 +11768,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -11471,6 +11782,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -11479,6 +11796,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 90
@@ -11487,6 +11810,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -11499,6 +11828,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
@@ -11506,6 +11841,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 180
@@ -11514,6 +11855,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -11576,6 +11923,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 270
@@ -11583,21 +11936,51 @@
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood"
 				},
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -11624,6 +12007,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -11644,6 +12033,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -11710,6 +12105,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 270
@@ -11717,15 +12118,39 @@
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 90
@@ -11822,21 +12247,51 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 90
@@ -11938,6 +12393,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -11953,6 +12414,12 @@
 				"id": "floor_wood_boards_03"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -12825,6 +13292,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -12840,6 +13313,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -12928,6 +13407,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
@@ -12935,6 +13420,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -12942,6 +13433,12 @@
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood"
 				},
@@ -12949,6 +13446,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -12957,14 +13460,32 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00"
 				},
@@ -13045,6 +13566,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -13053,30 +13580,72 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 90
@@ -13084,6 +13653,12 @@
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -13165,17 +13740,41 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -13184,6 +13783,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 180
@@ -13191,9 +13796,21 @@
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -13256,6 +13873,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -13271,6 +13894,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -13377,15 +14006,33 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00"
 				},
 				"id": "floor_wood_boards_02"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_02"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00"
 				},
@@ -13393,12 +14040,24 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00"
 				},
 				"id": "floor_wood_boards_02"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00"
 				},
@@ -13406,6 +14065,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_02"
 			},
 			{
@@ -13553,6 +14218,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -13561,6 +14232,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 270
@@ -13569,20 +14246,50 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_04"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_04"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_04",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_04",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_02",
 				"rotation": 90
 			},
@@ -13699,24 +14406,60 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_02",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_04"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_04",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -13828,6 +14571,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -13835,6 +14584,12 @@
 				"id": "floor_wood_boards_02"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -13843,16 +14598,34 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
 				"id": "floor_wood_boards_02"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_04",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -13861,6 +14634,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 180
@@ -13988,6 +14767,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -14000,6 +14785,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180

--- a/Mods/Core/Maps/generichouse_corner.json
+++ b/Mods/Core/Maps/generichouse_corner.json
@@ -285,6 +285,184 @@
 					"id": "linoleum_lightblue_00"
 				}
 			]
+		},
+		{
+			"entities": [],
+			"id": "floor_kitchen",
+			"pick_one": true,
+			"rotate_random": true,
+			"spawn_chance": 100,
+			"tiles": [
+				{
+					"count": 1,
+					"id": "kitchen_tiles_yellow_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_yellow_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_yellow_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_03"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_purple_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_purple_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_purple_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_blue_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_blue_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_blue_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_green_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_green_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_green_00"
+				},
+				{
+					"count": 1,
+					"id": "bathroom_tiles_blue_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_white_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_white_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_white_02"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_02"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_00"
+				}
+			]
+		},
+		{
+			"entities": [],
+			"id": "floor_bathroom",
+			"pick_one": true,
+			"rotate_random": true,
+			"spawn_chance": 100,
+			"tiles": [
+				{
+					"count": 1,
+					"id": "kitchen_tiles_yellow_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_yellow_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_yellow_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_03"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_purple_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_purple_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_purple_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_blue_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_blue_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_blue_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_green_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_green_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_green_00"
+				},
+				{
+					"count": 1,
+					"id": "bathroom_tiles_blue_00"
+				}
+			]
 		}
 	],
 	"categories": [
@@ -1928,6 +2106,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 270
+					}
+				],
 				"furniture": {
 					"id": "refrigerator_00"
 				},
@@ -1935,6 +2119,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 270
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood"
 				},
@@ -1942,6 +2132,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 270
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood"
 				},
@@ -1949,6 +2145,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 270
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
@@ -2023,6 +2225,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_03"
 			},
 			{
@@ -2174,22 +2382,52 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 270
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 270
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 270
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 270
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 180
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -2262,6 +2500,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "toilet_00",
 					"rotation": 180
@@ -2419,10 +2663,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 270
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 270
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 180
@@ -2431,6 +2687,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 270
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -2439,6 +2701,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 270
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 270
 			},
@@ -3636,6 +3904,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -3644,10 +3918,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_01",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_01",
 				"rotation": 270
 			},
@@ -3924,6 +4210,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "toilet_00",
 					"rotation": 270
@@ -3932,10 +4224,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_01",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -5798,6 +6102,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -5809,6 +6119,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 180
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -5968,6 +6284,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 180
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 270
@@ -5976,10 +6298,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 180
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 180
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -5988,10 +6322,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 180
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 180
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 270
 			},
@@ -6182,6 +6528,12 @@
 				"id": "grass_dirt_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -6190,6 +6542,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 180
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 270
@@ -6198,10 +6556,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 180
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 180
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 180
@@ -6210,6 +6580,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 180
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -6218,6 +6594,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 180
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 270
 			},
@@ -6386,6 +6768,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 180
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 270
@@ -6394,18 +6782,42 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 180
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 180
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 180
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 180
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 270
 			},
@@ -6414,10 +6826,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 270
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 270
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 270
 			},
@@ -6564,6 +6988,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 180
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -6572,6 +7002,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 180
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 180
@@ -6580,6 +7016,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 180
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 180
@@ -6588,6 +7030,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 180
+					}
+				],
 				"furniture": {
 					"id": "refrigerator_00",
 					"rotation": 180
@@ -6596,6 +7044,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 180
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
@@ -6607,6 +7061,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 270
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -6615,6 +7075,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 270
+					}
+				],
 				"furniture": {
 					"id": "toilet_00",
 					"rotation": 180
@@ -6764,6 +7230,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -10450,6 +10922,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 90
+					}
+				],
 				"furniture": {
 					"id": "toilet_00",
 					"rotation": 270
@@ -10458,14 +10936,32 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 90
+					}
+				],
 				"id": "kitchen_tiles_blue_01",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 90
+					}
+				],
 				"id": "kitchen_tiles_blue_01",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 90
+					}
+				],
 				"id": "kitchen_tiles_blue_01",
 				"rotation": 270
 			},
@@ -10539,12 +11035,24 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "toilet_00"
 				},
 				"id": "kitchen_tiles_blue_02"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00"
 				},
@@ -10635,6 +11143,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 90
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -10643,6 +11157,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 90
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -10651,10 +11171,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 90
+					}
+				],
 				"id": "kitchen_tiles_blue_01",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 90
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -10728,9 +11260,21 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_blue_02"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_blue_02"
 			},
 			{
@@ -10892,9 +11436,21 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_blue_02"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_blue_02"
 			},
 			{
@@ -14501,18 +15057,42 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_02",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_02",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_02",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -14685,6 +15265,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -14693,14 +15279,32 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_02",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_02",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "toilet_00",
 					"rotation": 90

--- a/Mods/Core/Maps/generichouse_corner.json
+++ b/Mods/Core/Maps/generichouse_corner.json
@@ -22,6 +22,99 @@
 					"id": "null"
 				}
 			]
+		},
+		{
+			"entities": [],
+			"id": "floor_livingroom",
+			"pick_one": true,
+			"rotate_random": true,
+			"spawn_chance": 100,
+			"tiles": [
+				{
+					"count": 1,
+					"id": "red_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "blue_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "orange_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_00"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_01"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_02"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_04"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_05"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_06"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_08"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_07"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_blue_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_brown_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_brown_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_02"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_greyblue_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_02"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_00"
+				}
+			]
 		}
 	],
 	"categories": [
@@ -211,6 +304,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -374,6 +473,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 270
@@ -381,18 +486,36 @@
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00"
 				},
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bench_wood"
 				},
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
@@ -548,6 +671,12 @@
 				"id": "grass_plain_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -555,6 +684,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 270
@@ -562,12 +697,30 @@
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07"
 			},
 			{
@@ -897,6 +1050,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 270
@@ -904,9 +1063,21 @@
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -914,6 +1085,12 @@
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
@@ -1074,6 +1251,12 @@
 				"id": "grass_plain_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -1081,12 +1264,24 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -1094,6 +1289,12 @@
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 180
@@ -1101,6 +1302,12 @@
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
@@ -1259,6 +1466,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 270
@@ -1266,15 +1479,33 @@
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood"
 				},
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
@@ -1434,6 +1665,12 @@
 				"id": "grass_plain_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -1441,6 +1678,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 270
@@ -1448,12 +1691,30 @@
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
@@ -1614,6 +1875,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -1621,6 +1888,12 @@
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 180
@@ -1628,6 +1901,12 @@
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 180
@@ -1635,6 +1914,12 @@
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "refrigerator_00",
 					"rotation": 180
@@ -1817,6 +2102,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -1968,6 +2259,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood"
 				},
@@ -2123,6 +2420,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00"
 				},
@@ -2130,6 +2433,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00"
 				},
@@ -2137,10 +2446,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 270
 			},
@@ -2369,14 +2690,32 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -2385,10 +2724,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -2612,10 +2963,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -2624,6 +2987,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood"
 				},
@@ -2631,6 +3000,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -2859,14 +3234,32 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood"
 				},
@@ -2874,10 +3267,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -3121,6 +3526,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
@@ -3128,10 +3539,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -3140,6 +3563,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 180
@@ -3365,6 +3794,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -3381,6 +3816,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -4279,6 +4720,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -4294,6 +4741,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -4400,6 +4853,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 270
@@ -4407,19 +4866,49 @@
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -4427,6 +4916,12 @@
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -4536,6 +5031,12 @@
 				"id": "grass_plain_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -4544,6 +5045,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
@@ -4551,17 +5058,41 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -4569,6 +5100,12 @@
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 270
@@ -4577,6 +5114,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -4680,6 +5223,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 270
@@ -4688,29 +5237,71 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood"
 				},
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -4840,17 +5431,41 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08"
 			},
 			{
@@ -4977,18 +5592,42 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 90
@@ -5137,6 +5776,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -5145,12 +5790,30 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 90
@@ -5280,6 +5943,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -5287,17 +5956,41 @@
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -5445,6 +6138,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -5452,6 +6151,12 @@
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood"
 				},
@@ -5459,6 +6164,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bench_wood",
 					"rotation": 180
@@ -5466,6 +6177,12 @@
 				"id": "floor_wood_boards_08"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08"
 			},
 			{
@@ -5593,6 +6310,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180

--- a/Mods/Core/Maps/generichouse_corner.json
+++ b/Mods/Core/Maps/generichouse_corner.json
@@ -115,6 +115,87 @@
 					"id": "linoleum_lightblue_00"
 				}
 			]
+		},
+		{
+			"entities": [],
+			"id": "floor_hallway",
+			"pick_one": true,
+			"rotate_random": true,
+			"spawn_chance": 100,
+			"tiles": [
+				{
+					"count": 1,
+					"id": "red_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "blue_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "orange_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_00"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_01"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_02"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_05"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_06"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_08"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_07"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_blue_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_brown_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_brown_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_greyblue_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_02"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_01"
+				}
+			]
 		}
 	],
 	"categories": [
@@ -325,6 +406,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -525,9 +612,21 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
@@ -724,6 +823,12 @@
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 270
@@ -731,12 +836,30 @@
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
@@ -894,15 +1017,33 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00"
 				},
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
@@ -1097,18 +1238,42 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00"
 				},
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -1311,6 +1476,12 @@
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 270
@@ -1318,12 +1489,30 @@
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
@@ -1425,6 +1614,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood"
 				},
@@ -1518,6 +1713,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
@@ -1614,10 +1815,22 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
@@ -1724,6 +1937,12 @@
 				"id": "kitchen_tiles_mint_03"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 270
@@ -1731,9 +1950,21 @@
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -1830,10 +2061,22 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
@@ -1940,6 +2183,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
@@ -2037,18 +2286,42 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 90
@@ -2228,14 +2501,32 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00"
 				},
@@ -2404,6 +2695,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
@@ -2662,6 +2959,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 270
@@ -2670,18 +2973,42 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 90
@@ -2951,6 +3278,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -5402,12 +5735,24 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood"
 				},
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -5562,6 +5907,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 270
@@ -5569,21 +5920,57 @@
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 90
@@ -5750,6 +6137,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -5766,9 +6159,21 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
@@ -5936,6 +6341,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
@@ -6131,6 +6542,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
@@ -9964,6 +10381,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 270
@@ -9972,6 +10395,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
@@ -10119,10 +10548,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
@@ -10241,10 +10682,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
@@ -10342,6 +10795,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 270
@@ -10350,30 +10809,72 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
@@ -10419,6 +10920,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood"
 				},
@@ -10428,6 +10935,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood"
 				},
@@ -10472,6 +10985,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -10484,6 +11003,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -10534,6 +11059,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -10542,6 +11073,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -10549,24 +11086,66 @@
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 90
@@ -10672,10 +11251,22 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 180
 			},
@@ -10804,10 +11395,22 @@
 				"id": "wood_stairs"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 90
@@ -10960,6 +11563,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 180
 			},
@@ -11088,6 +11697,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 180
 			},
@@ -11195,6 +11810,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
@@ -12679,6 +13300,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood"
 				},
@@ -12782,6 +13409,12 @@
 				"id": "floor_wood_boards_02"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 270
@@ -12789,30 +13422,84 @@
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 90
@@ -12903,9 +13590,21 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 90
@@ -12916,12 +13615,24 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -13016,9 +13727,21 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 90
@@ -13148,6 +13871,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bench_wood",
 					"rotation": 180
@@ -13155,6 +13884,12 @@
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 90

--- a/Mods/Core/Maps/generichouse_cross.json
+++ b/Mods/Core/Maps/generichouse_cross.json
@@ -14,6 +14,7 @@
 				}
 			],
 			"id": "mob_spawn",
+			"pick_one": false,
 			"rotate_random": true,
 			"spawn_chance": 100,
 			"tiles": [
@@ -26,8 +27,8 @@
 		{
 			"entities": [],
 			"id": "bathroom_floor",
-			"pick_one": false,
-			"rotate_random": false,
+			"pick_one": true,
+			"rotate_random": true,
 			"spawn_chance": 100,
 			"tiles": [
 				{
@@ -36,96 +37,79 @@
 				},
 				{
 					"count": 1,
-					"id": "kitchen_tiles_yellow_00",
-					"type": "tile"
+					"id": "kitchen_tiles_yellow_00"
 				},
 				{
 					"count": 1,
-					"id": "kitchen_tiles_yellow_01",
-					"type": "tile"
+					"id": "kitchen_tiles_yellow_01"
 				},
 				{
 					"count": 1,
-					"id": "kitchen_tiles_yellow_02",
-					"type": "tile"
+					"id": "kitchen_tiles_yellow_02"
 				},
 				{
 					"count": 1,
-					"id": "kitchen_tiles_mint_00",
-					"type": "tile"
+					"id": "kitchen_tiles_mint_00"
 				},
 				{
 					"count": 1,
-					"id": "kitchen_tiles_mint_01",
-					"type": "tile"
+					"id": "kitchen_tiles_mint_01"
 				},
 				{
 					"count": 1,
-					"id": "kitchen_tiles_mint_02",
-					"type": "tile"
+					"id": "kitchen_tiles_mint_02"
 				},
 				{
 					"count": 1,
-					"id": "kitchen_tiles_mint_03",
-					"type": "tile"
+					"id": "kitchen_tiles_mint_03"
 				},
 				{
 					"count": 1,
-					"id": "kitchen_tiles_purple_02",
-					"type": "tile"
+					"id": "kitchen_tiles_purple_02"
 				},
 				{
 					"count": 1,
-					"id": "kitchen_tiles_purple_01",
-					"type": "tile"
+					"id": "kitchen_tiles_purple_01"
 				},
 				{
 					"count": 1,
-					"id": "kitchen_tiles_purple_00",
-					"type": "tile"
+					"id": "kitchen_tiles_purple_00"
 				},
 				{
 					"count": 1,
-					"id": "kitchen_tiles_blue_02",
-					"type": "tile"
+					"id": "kitchen_tiles_blue_02"
 				},
 				{
 					"count": 1,
-					"id": "kitchen_tiles_blue_01",
-					"type": "tile"
+					"id": "kitchen_tiles_blue_01"
 				},
 				{
 					"count": 1,
-					"id": "kitchen_tiles_blue_00",
-					"type": "tile"
+					"id": "kitchen_tiles_blue_00"
 				},
 				{
 					"count": 1,
-					"id": "kitchen_tiles_green_02",
-					"type": "tile"
+					"id": "kitchen_tiles_green_02"
 				},
 				{
 					"count": 1,
-					"id": "kitchen_tiles_green_01",
-					"type": "tile"
+					"id": "kitchen_tiles_green_01"
 				},
 				{
 					"count": 1,
-					"id": "bathroom_tiles_blue_00",
-					"type": "tile"
+					"id": "bathroom_tiles_blue_00"
 				},
 				{
 					"count": 1,
-					"id": "kitchen_tiles_green_00",
-					"type": "tile"
+					"id": "kitchen_tiles_green_00"
 				}
 			]
 		},
 		{
 			"entities": [],
 			"id": "floor_hallway",
-			"pick_one": false,
-			"rotate_random": false,
+			"pick_one": true,
+			"rotate_random": true,
 			"spawn_chance": 100,
 			"tiles": [
 				{
@@ -134,108 +118,87 @@
 				},
 				{
 					"count": 1,
-					"id": "red_carpet_00",
-					"type": "tile"
+					"id": "red_carpet_00"
 				},
 				{
 					"count": 1,
-					"id": "blue_carpet_00",
-					"type": "tile"
+					"id": "blue_carpet_00"
 				},
 				{
 					"count": 1,
-					"id": "orange_carpet_00",
-					"type": "tile"
+					"id": "orange_carpet_00"
 				},
 				{
 					"count": 1,
-					"id": "kitchen_tiles_yellow_01",
-					"type": "tile"
+					"id": "kitchen_tiles_yellow_01"
 				},
 				{
 					"count": 1,
-					"id": "floor_wood_boards_00",
-					"type": "tile"
+					"id": "floor_wood_boards_00"
 				},
 				{
 					"count": 1,
-					"id": "floor_wood_boards_01",
-					"type": "tile"
+					"id": "floor_wood_boards_01"
 				},
 				{
 					"count": 1,
-					"id": "floor_wood_boards_02",
-					"type": "tile"
+					"id": "floor_wood_boards_02"
 				},
 				{
 					"count": 1,
-					"id": "floor_wood_boards_04",
-					"type": "tile"
+					"id": "floor_wood_boards_04"
 				},
 				{
 					"count": 1,
-					"id": "floor_wood_boards_05",
-					"type": "tile"
+					"id": "floor_wood_boards_05"
 				},
 				{
 					"count": 1,
-					"id": "floor_wood_boards_06",
-					"type": "tile"
+					"id": "floor_wood_boards_06"
 				},
 				{
 					"count": 1,
-					"id": "floor_wood_boards_08",
-					"type": "tile"
+					"id": "floor_wood_boards_08"
 				},
 				{
 					"count": 1,
-					"id": "floor_wood_boards_07",
-					"type": "tile"
+					"id": "floor_wood_boards_07"
 				},
 				{
 					"count": 1,
-					"id": "linoleum_blue_00",
-					"type": "tile"
+					"id": "linoleum_blue_00"
 				},
 				{
 					"count": 1,
-					"id": "linoleum_brown_00",
-					"type": "tile"
+					"id": "linoleum_brown_00"
 				},
 				{
 					"count": 1,
-					"id": "linoleum_brown_01",
-					"type": "tile"
+					"id": "linoleum_brown_01"
 				},
 				{
 					"count": 1,
-					"id": "linoleum_green_00",
-					"type": "tile"
+					"id": "linoleum_green_00"
 				},
 				{
 					"count": 1,
-					"id": "linoleum_greyblue_00",
-					"type": "tile"
+					"id": "linoleum_greyblue_00"
 				},
 				{
 					"count": 1,
-					"id": "linoleum_white_02",
-					"type": "tile"
+					"id": "linoleum_white_02"
 				},
 				{
 					"count": 1,
-					"id": "linoleum_lightblue_01",
-					"type": "tile"
+					"id": "linoleum_lightblue_01"
 				},
 				{
 					"count": 1,
-					"id": "linoleum_lightblue_00",
-					"type": "tile"
+					"id": "linoleum_lightblue_00"
 				},
 				{
 					"count": 1,
-					"id": "linoleum_lightblue_02",
-					"type": "tile"
+					"id": "linoleum_lightblue_02"
 				}
 			]
 		},
@@ -15494,6 +15457,10 @@
 						"rotation": 0
 					}
 				],
+				"furniture": {
+					"id": "plant_pot_00",
+					"rotation": 90
+				},
 				"id": "kitchen_tiles_green_01",
 				"rotation": 270
 			},
@@ -15771,7 +15738,7 @@
 					}
 				],
 				"furniture": {
-					"id": "plant_pot_00",
+					"id": "bathtub",
 					"rotation": 90
 				},
 				"id": "kitchen_tiles_green_01",
@@ -16221,6 +16188,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00"
 				},

--- a/Mods/Core/Maps/generichouse_cross.json
+++ b/Mods/Core/Maps/generichouse_cross.json
@@ -120,6 +120,124 @@
 					"type": "tile"
 				}
 			]
+		},
+		{
+			"entities": [],
+			"id": "floor_hallway",
+			"pick_one": false,
+			"rotate_random": false,
+			"spawn_chance": 100,
+			"tiles": [
+				{
+					"count": 1,
+					"id": "kitchen_tiles_yellow_00"
+				},
+				{
+					"count": 1,
+					"id": "red_carpet_00",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "blue_carpet_00",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "orange_carpet_00",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_yellow_01",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_00",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_01",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_02",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_04",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_05",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_06",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_08",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_07",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_blue_00",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_brown_00",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_brown_01",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_00",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_greyblue_00",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_white_02",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_01",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_00",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_02",
+					"type": "tile"
+				}
+			]
 		}
 	],
 	"categories": [
@@ -504,9 +622,21 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 90
@@ -697,9 +827,21 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
@@ -880,9 +1022,21 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
@@ -1064,6 +1218,12 @@
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 270
@@ -1071,9 +1231,21 @@
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
@@ -1204,6 +1376,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood"
 				},
@@ -1248,6 +1426,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 270
@@ -1255,6 +1439,12 @@
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
@@ -1373,18 +1563,42 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
@@ -1433,15 +1647,39 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -1556,18 +1794,42 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
@@ -1607,6 +1869,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
@@ -1727,6 +1995,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
@@ -1792,6 +2066,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
@@ -1901,6 +2181,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood"
 				},
@@ -1916,6 +2202,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
@@ -1982,6 +2274,12 @@
 				"id": "floor_wood_boards_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 270
@@ -1989,9 +2287,21 @@
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 90
@@ -2091,6 +2401,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 270
@@ -2099,26 +2415,62 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 90
@@ -2187,6 +2539,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -2291,6 +2649,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -2303,6 +2667,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -4721,6 +5091,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -4732,6 +5108,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 0
@@ -4841,6 +5223,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 0
@@ -4914,6 +5302,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 270
@@ -4922,26 +5316,62 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 90
@@ -5045,6 +5475,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 270
@@ -5053,10 +5489,22 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 90
@@ -5137,6 +5585,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
@@ -5149,6 +5603,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -5268,6 +5728,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 180
 			},
@@ -5344,6 +5810,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
@@ -5469,6 +5941,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 180
 			},
@@ -5517,18 +5995,42 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
@@ -5642,6 +6144,12 @@
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -5650,14 +6158,32 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 180
 			},
@@ -5710,6 +6236,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -5718,18 +6250,42 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
@@ -5851,10 +6407,22 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 90
@@ -5911,6 +6479,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -6048,14 +6622,32 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 90
@@ -6252,10 +6844,22 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 180
 			},
@@ -6449,10 +7053,22 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 180
 			},
@@ -6658,6 +7274,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 270
@@ -6666,6 +7288,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 180
 			},
@@ -10537,9 +11165,21 @@
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -10547,9 +11187,21 @@
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
@@ -10708,12 +11360,30 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 90
@@ -10838,6 +11508,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -10845,9 +11521,21 @@
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 90
@@ -10958,6 +11646,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 270
@@ -10965,24 +11659,66 @@
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 90
@@ -11024,6 +11760,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood"
 				},
@@ -11059,6 +11801,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood"
 				},
@@ -11088,6 +11836,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -11098,6 +11852,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -11149,38 +11909,92 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
@@ -11283,6 +12097,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -11319,6 +12139,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
@@ -11449,6 +12275,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -13235,6 +14067,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 0
@@ -13372,6 +14210,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
@@ -13404,6 +14248,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 0
@@ -13518,38 +14368,92 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
@@ -13602,6 +14506,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 0
@@ -13614,6 +14524,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 0
@@ -13648,6 +14564,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -13684,6 +14606,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -13727,6 +14655,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 270
@@ -13735,30 +14669,72 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 90
@@ -13872,6 +14848,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 270
@@ -13880,10 +14862,22 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -14018,6 +15012,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 270
@@ -14026,10 +15026,22 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 180
 			},
@@ -14196,14 +15208,32 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -14212,10 +15242,22 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 90
@@ -14362,6 +15404,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -14374,6 +15422,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180

--- a/Mods/Core/Maps/generichouse_cross.json
+++ b/Mods/Core/Maps/generichouse_cross.json
@@ -335,6 +335,83 @@
 					"id": "linoleum_lightblue_00"
 				}
 			]
+		},
+		{
+			"entities": [],
+			"id": "floor_kitchen",
+			"pick_one": true,
+			"rotate_random": true,
+			"spawn_chance": 100,
+			"tiles": [
+				{
+					"count": 1,
+					"id": "kitchen_tiles_yellow_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_yellow_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_yellow_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_03"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_green_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_green_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_green_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_blue_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_blue_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_blue_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_purple_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_purple_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_purple_02"
+				},
+				{
+					"count": 1,
+					"id": "bathroom_tiles_blue_00"
+				}
+			]
 		}
 	],
 	"categories": [
@@ -517,6 +594,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -631,6 +714,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -682,6 +771,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 270
@@ -689,12 +784,24 @@
 				"id": "kitchen_tiles_yellow_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood"
 				},
 				"id": "kitchen_tiles_yellow_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "refrigerator_00"
 				},
@@ -836,6 +943,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood"
 				},
@@ -843,6 +956,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood"
 				},
@@ -850,6 +969,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood"
 				},
@@ -857,6 +982,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "refrigerator_00"
 				},
@@ -932,6 +1063,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 270
@@ -939,9 +1076,21 @@
 				"id": "kitchen_tiles_yellow_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_yellow_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_yellow_01"
 			},
 			{
@@ -1069,6 +1218,12 @@
 				"id": "sidewalk_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -1077,18 +1232,42 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_01",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_01",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_01",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_01",
 				"rotation": 270
 			},
@@ -1155,6 +1334,12 @@
 				"id": "grass_plain_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -1162,6 +1347,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 270
@@ -1169,9 +1360,21 @@
 				"id": "kitchen_tiles_yellow_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_yellow_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_yellow_01"
 			},
 			{
@@ -1422,12 +1625,30 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_yellow_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_yellow_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -7381,6 +7602,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -7389,10 +7616,22 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_yellow_01",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_yellow_01",
 				"rotation": 180
 			},
@@ -7653,14 +7892,32 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_yellow_01",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_yellow_01",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 90
@@ -7669,6 +7926,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -7747,22 +8010,52 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_01",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_01",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_01",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_01",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -7904,14 +8197,32 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_yellow_01",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_yellow_01",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 90
@@ -7992,6 +8303,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "refrigerator_00",
 					"rotation": 180
@@ -8000,6 +8317,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 180
@@ -8008,6 +8331,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 180
@@ -8016,6 +8345,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 180
@@ -8169,6 +8504,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "refrigerator_00",
 					"rotation": 180
@@ -8177,6 +8518,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 180
@@ -8185,6 +8532,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 90
@@ -8247,6 +8600,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -8372,6 +8731,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180

--- a/Mods/Core/Maps/generichouse_cross.json
+++ b/Mods/Core/Maps/generichouse_cross.json
@@ -412,6 +412,95 @@
 					"id": "bathroom_tiles_blue_00"
 				}
 			]
+		},
+		{
+			"entities": [],
+			"id": "floor_bedroom",
+			"pick_one": true,
+			"rotate_random": true,
+			"spawn_chance": 100,
+			"tiles": [
+				{
+					"count": 1,
+					"id": "red_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "blue_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "orange_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_00"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_01"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_02"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_03"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_04"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_05"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_06"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_blue_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_brown_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_brown_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_02"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_greyblue_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_02"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_00"
+				}
+			]
 		}
 	],
 	"categories": [
@@ -12281,6 +12370,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -12304,6 +12399,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -12454,6 +12555,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 90
@@ -12462,6 +12569,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00"
 				},
@@ -12469,6 +12582,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -12481,6 +12600,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -12489,6 +12614,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00"
 				},
@@ -12496,10 +12627,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00"
 				},
@@ -12507,6 +12650,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00"
 				},
@@ -12639,6 +12788,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -12647,6 +12802,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood"
 				},
@@ -12654,10 +12815,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 90
@@ -12670,14 +12843,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -12686,14 +12877,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -12799,14 +13008,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 90
@@ -12819,6 +13046,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -12827,6 +13060,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -12835,6 +13074,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 180
@@ -12843,10 +13088,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 90
 			},
@@ -13234,6 +13491,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00"
 				},
@@ -13241,12 +13504,24 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00"
 				},
 				"id": "floor_wood_boards_04"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -13255,6 +13530,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_04",
 				"rotation": 270
 			},
@@ -13262,14 +13543,32 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00"
 				},
@@ -13277,6 +13576,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00"
 				},
@@ -13380,6 +13685,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 270
@@ -13387,14 +13698,32 @@
 				"id": "floor_wood_boards_04"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_04",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_04",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_04",
 				"rotation": 90
 			},
@@ -13402,6 +13731,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -13410,14 +13745,32 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
@@ -13453,10 +13806,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -13465,6 +13830,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 90
@@ -13517,6 +13888,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -13524,6 +13901,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 270
@@ -13532,14 +13915,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_04",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_04",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -13551,6 +13952,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 270
@@ -13559,14 +13966,32 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 90
@@ -13575,6 +14000,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -13606,6 +14037,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -13614,14 +14051,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood"
 				},
@@ -13700,6 +14155,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -13708,10 +14169,22 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_04",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -13720,6 +14193,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 270
@@ -13731,6 +14210,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood"
 				},
@@ -13738,6 +14223,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -13746,6 +14237,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 180
@@ -13754,6 +14251,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -13793,6 +14296,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -13801,6 +14310,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 180
@@ -13809,6 +14324,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 90
@@ -13898,6 +14419,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -13914,6 +14441,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -13962,6 +14495,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -14808,6 +15347,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -14859,6 +15404,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -14878,6 +15429,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -14969,6 +15526,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 270
@@ -14977,6 +15540,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 0
@@ -14985,6 +15554,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 0
@@ -15025,6 +15600,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -15033,6 +15614,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 0
@@ -15041,6 +15628,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -15049,6 +15642,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -15061,6 +15660,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 90
@@ -15068,6 +15673,12 @@
 				"id": "floor_wood_boards_04"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -15076,10 +15687,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_04",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -15159,6 +15782,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -15167,14 +15796,32 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -15207,6 +15854,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -15215,6 +15868,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 270
@@ -15223,14 +15882,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 90
@@ -15243,6 +15920,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 0
@@ -15251,14 +15934,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_04",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_04",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 90
@@ -15267,6 +15968,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -15319,6 +16026,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 270
@@ -15327,6 +16040,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -15335,6 +16054,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 270
 			},
@@ -15371,18 +16096,42 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 0
@@ -15395,17 +16144,41 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_04",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_04"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_04",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 90
@@ -15512,6 +16285,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -15520,6 +16299,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -15528,10 +16313,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
@@ -15540,10 +16337,22 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_04",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -15552,6 +16361,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -15560,6 +16375,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -15975,14 +16796,32 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 0
@@ -15991,6 +16830,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 0
@@ -15999,6 +16844,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 0
@@ -16011,6 +16862,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 270
@@ -16019,10 +16876,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 270
 			},
@@ -16134,6 +17003,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -16142,14 +17017,32 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 0
@@ -16158,10 +17051,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 270
 			},
@@ -16170,6 +17075,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 270
@@ -16178,10 +17089,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -16190,6 +17113,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -16330,6 +17259,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 180
@@ -16338,6 +17273,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 180
@@ -16346,10 +17287,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 180
@@ -16358,6 +17311,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -16370,6 +17329,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -16378,6 +17343,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 180
@@ -16386,6 +17357,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 270
@@ -16550,6 +17527,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -16574,6 +17557,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180

--- a/Mods/Core/Maps/generichouse_cross.json
+++ b/Mods/Core/Maps/generichouse_cross.json
@@ -22,6 +22,104 @@
 					"id": "null"
 				}
 			]
+		},
+		{
+			"entities": [],
+			"id": "bathroom_floor",
+			"pick_one": false,
+			"rotate_random": false,
+			"spawn_chance": 100,
+			"tiles": [
+				{
+					"count": 1,
+					"id": "red_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_yellow_00",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_yellow_01",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_yellow_02",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_00",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_01",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_02",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_03",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_purple_02",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_purple_01",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_purple_00",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_blue_02",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_blue_01",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_blue_00",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_green_02",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_green_01",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "bathroom_tiles_blue_00",
+					"type": "tile"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_green_00",
+					"type": "tile"
+				}
+			]
 		}
 	],
 	"categories": [
@@ -1700,6 +1798,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "toilet_00"
 				},
@@ -1820,6 +1924,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00"
 				},
@@ -1827,6 +1937,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "toilet_00"
 				},
@@ -1883,6 +1999,12 @@
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_01"
 			},
 			{
@@ -2005,10 +2127,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "bathroom_tiles_blue_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "bathroom_tiles_blue_00",
 				"rotation": 270
 			},
@@ -4760,10 +4894,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "bathroom_tiles_blue_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "bathroom_tiles_blue_00",
 				"rotation": 90
 			},
@@ -4889,6 +5035,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_01",
 				"rotation": 180
 			},
@@ -4953,6 +5105,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "toilet_00",
 					"rotation": 180
@@ -4961,6 +5119,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -5086,6 +5250,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "toilet_00",
 					"rotation": 180
@@ -10316,6 +10486,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "toilet_00",
 					"rotation": 270
@@ -10324,14 +10500,32 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 270
 			},
@@ -10463,6 +10657,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -10471,14 +10671,32 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -11365,6 +11583,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -11373,18 +11597,42 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 90
 			},
@@ -11523,6 +11771,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "toilet_00",
 					"rotation": 270
@@ -11531,18 +11785,42 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -12579,6 +12857,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -12587,18 +12871,42 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "toilet_00",
 					"rotation": 90
@@ -12743,22 +13051,52 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -13700,6 +14038,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -13708,14 +14052,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -13862,18 +14224,42 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "bathroom_floor",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "toilet_00",
 					"rotation": 90

--- a/Mods/Core/Maps/generichouse_cross.json
+++ b/Mods/Core/Maps/generichouse_cross.json
@@ -238,6 +238,103 @@
 					"type": "tile"
 				}
 			]
+		},
+		{
+			"entities": [],
+			"id": "floor_livingroom",
+			"pick_one": true,
+			"rotate_random": true,
+			"spawn_chance": 100,
+			"tiles": [
+				{
+					"count": 1,
+					"id": "red_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "blue_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "orange_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_00"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_01"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_02"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_03"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_04"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_05"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_06"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_08"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_07"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_blue_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_brown_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_brown_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_02"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_greyblue_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_02"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_00"
+				}
+			]
 		}
 	],
 	"categories": [
@@ -607,12 +704,24 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00"
 				},
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00"
 				},
@@ -759,6 +868,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -767,10 +882,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bench_wood"
 				},
@@ -778,6 +905,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -815,12 +948,24 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00"
 				},
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
@@ -952,6 +1097,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 270
@@ -960,14 +1111,32 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 270
 			},
@@ -1009,6 +1178,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bench_wood",
 					"rotation": 270
@@ -1016,6 +1191,12 @@
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
@@ -1123,6 +1304,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 270
@@ -1131,14 +1318,32 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 90
@@ -1151,6 +1356,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 270
@@ -1159,6 +1370,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -1167,6 +1384,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 270
@@ -1175,6 +1398,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 270
 			},
@@ -1209,12 +1438,24 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00"
 				},
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
@@ -1336,6 +1577,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -1344,6 +1591,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -1352,10 +1605,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 270
 			},
@@ -1405,6 +1670,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood"
 				},
@@ -1531,6 +1802,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -1539,6 +1816,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 90
@@ -1547,6 +1830,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -1555,6 +1844,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 270
 			},
@@ -1620,24 +1915,54 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00"
 				},
 				"id": "floor_wood_boards_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00"
 				},
 				"id": "floor_wood_boards_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00"
 				},
@@ -1771,10 +2096,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood"
 				},
@@ -1782,10 +2119,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 270
 			},
@@ -1847,9 +2196,21 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -1857,12 +2218,30 @@
 				"id": "floor_wood_boards_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01"
 			},
 			{
@@ -1967,6 +2346,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 270
@@ -1975,14 +2360,32 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -2034,6 +2437,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -2041,12 +2450,24 @@
 				"id": "floor_wood_boards_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood"
 				},
 				"id": "floor_wood_boards_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -2054,9 +2475,21 @@
 				"id": "floor_wood_boards_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00"
 				},
@@ -2256,21 +2689,51 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood"
 				},
 				"id": "floor_wood_boards_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01"
 			},
 			{
@@ -5513,18 +5976,42 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -5533,6 +6020,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01",
 				"rotation": 180
 			},
@@ -5742,6 +6235,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -5750,10 +6249,22 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -5762,6 +6273,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 180
@@ -5770,6 +6287,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -5824,6 +6347,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -5832,14 +6361,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 90
@@ -5955,18 +6502,42 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 0
@@ -5975,6 +6546,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01",
 				"rotation": 180
 			},
@@ -6039,14 +6616,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -6055,10 +6650,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -6192,6 +6799,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 180
@@ -6200,6 +6813,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -6208,14 +6827,32 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -6294,10 +6931,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -6306,6 +6955,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 270
@@ -6314,6 +6969,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -6451,6 +7112,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -6509,14 +7176,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 0
@@ -6525,6 +7210,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -6533,6 +7224,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -6656,10 +7353,22 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -6703,10 +7412,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 90
@@ -6715,6 +7436,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -6723,6 +7450,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 90
@@ -6735,6 +7468,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 270
@@ -6743,14 +7482,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 90
@@ -6868,10 +7625,22 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bench_wood",
 					"rotation": 90
@@ -6916,6 +7685,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -6924,18 +7699,42 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 90
@@ -7077,10 +7876,22 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -7125,6 +7936,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -7133,6 +7950,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bench_wood",
 					"rotation": 180
@@ -7141,10 +7964,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -7302,6 +8137,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 180
@@ -7310,6 +8151,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 180
@@ -7370,6 +8217,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180

--- a/Mods/Core/Maps/generichouse_t.json
+++ b/Mods/Core/Maps/generichouse_t.json
@@ -22,6 +22,382 @@
 					"id": "null"
 				}
 			]
+		},
+		{
+			"entities": [],
+			"id": "floor_livingroom",
+			"pick_one": true,
+			"rotate_random": true,
+			"spawn_chance": 100,
+			"tiles": [
+				{
+					"count": 1,
+					"id": "red_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "blue_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "orange_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_00"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_01"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_02"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_03"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_04"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_05"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_06"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_07"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_08"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_blue_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_brown_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_brown_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_02"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_greyblue_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_02"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_00"
+				}
+			]
+		},
+		{
+			"entities": [],
+			"id": "floor_kitchen",
+			"pick_one": true,
+			"rotate_random": true,
+			"spawn_chance": 100,
+			"tiles": [
+				{
+					"count": 1,
+					"id": "kitchen_tiles_yellow_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_yellow_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_yellow_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_03"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_purple_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_purple_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_purple_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_blue_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_blue_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_blue_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_green_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_green_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_green_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_white_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_white_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_white_02"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_02"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_00"
+				}
+			]
+		},
+		{
+			"entities": [],
+			"id": "floor_bathroom",
+			"pick_one": true,
+			"rotate_random": false,
+			"spawn_chance": 100,
+			"tiles": [
+				{
+					"count": 1,
+					"id": "kitchen_tiles_yellow_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_yellow_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_yellow_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_mint_03"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_purple_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_purple_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_purple_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_blue_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_blue_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_blue_00"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_green_02"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_green_01"
+				},
+				{
+					"count": 1,
+					"id": "kitchen_tiles_green_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_white_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_white_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_white_02"
+				}
+			]
+		},
+		{
+			"entities": [],
+			"id": "floor_hallway",
+			"pick_one": true,
+			"rotate_random": true,
+			"spawn_chance": 100,
+			"tiles": [
+				{
+					"count": 1,
+					"id": "red_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "blue_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "orange_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_00"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_01"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_02"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_03"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_04"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_05"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_06"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_08"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_07"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_blue_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_brown_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_brown_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_02"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_greyblue_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_02"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_00"
+				}
+			]
 		}
 	],
 	"categories": [
@@ -213,6 +589,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -222,6 +604,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -234,6 +622,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -339,6 +733,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -381,6 +781,12 @@
 				"id": "grass_plain_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -388,6 +794,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -395,15 +807,39 @@
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00"
 				},
@@ -413,15 +849,33 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00"
 				},
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00"
 				},
@@ -517,6 +971,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00"
 				},
@@ -524,14 +984,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00"
 				},
@@ -539,6 +1017,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00"
 				},
@@ -550,6 +1034,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood"
 				},
@@ -557,6 +1047,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood"
 				},
@@ -578,12 +1074,30 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -591,15 +1105,33 @@
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bench_wood",
 					"rotation": 270
@@ -607,9 +1139,21 @@
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07"
 			},
 			{
@@ -698,6 +1242,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -706,10 +1256,22 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -718,18 +1280,42 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 90
@@ -738,10 +1324,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
@@ -766,9 +1364,21 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -776,6 +1386,12 @@
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 270
@@ -783,6 +1399,12 @@
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -790,6 +1412,12 @@
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
@@ -802,6 +1430,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood"
 				},
@@ -897,6 +1531,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -905,6 +1545,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 180
@@ -913,6 +1559,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -921,10 +1573,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 90
 			},
@@ -933,10 +1597,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_00",
 				"rotation": 90
 			},
@@ -953,6 +1629,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -960,6 +1642,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -967,33 +1655,81 @@
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood"
 				},
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -1083,6 +1819,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -1091,10 +1833,22 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood"
 				},
@@ -1102,14 +1856,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 90
 			},
@@ -1118,6 +1890,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "refrigerator_00",
 					"rotation": 180
@@ -1126,6 +1904,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 180
@@ -1148,6 +1932,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 270
@@ -1155,15 +1945,39 @@
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -1174,12 +1988,30 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
@@ -1272,6 +2104,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00"
 				},
@@ -1279,18 +2117,42 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 90
 			},
@@ -1321,6 +2183,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 270
@@ -1328,18 +2196,48 @@
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 270
@@ -1347,12 +2245,30 @@
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
@@ -1461,6 +2377,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood"
 				},
@@ -1472,6 +2394,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00"
 				},
@@ -1479,6 +2407,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00"
 				},
@@ -1500,6 +2434,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 270
@@ -1507,12 +2447,30 @@
 				"id": "kitchen_tiles_mint_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
@@ -1531,6 +2489,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
@@ -1619,6 +2583,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -1627,34 +2597,82 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
@@ -1672,6 +2690,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 270
@@ -1679,18 +2703,42 @@
 				"id": "kitchen_tiles_mint_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_00"
 			},
 			{
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "toilet_00",
 					"rotation": 270
@@ -1698,15 +2746,33 @@
 				"id": "kitchen_tiles_green_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_00"
 			},
 			{
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -1800,6 +2866,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
@@ -1820,14 +2892,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
@@ -1844,6 +2934,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -1851,6 +2947,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -1858,6 +2960,12 @@
 				"id": "kitchen_tiles_mint_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 180
@@ -1865,6 +2973,12 @@
 				"id": "kitchen_tiles_mint_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 180
@@ -1872,6 +2986,12 @@
 				"id": "kitchen_tiles_mint_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "refrigerator_00",
 					"rotation": 180
@@ -1882,6 +3002,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -1889,9 +3015,21 @@
 				"id": "kitchen_tiles_green_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 270
@@ -1899,6 +3037,12 @@
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
@@ -1987,6 +3131,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 270
@@ -1995,10 +3145,22 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 90
@@ -2007,10 +3169,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "bathroom_tiles_blue_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "toilet_00",
 					"rotation": 90
@@ -2023,14 +3197,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
@@ -2055,6 +3247,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -2077,6 +3275,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -4196,6 +5400,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood"
 				},
@@ -4212,6 +5422,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -4359,14 +5575,36 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
+				"furniture": {
+					"id": "standing_mirror",
+					"rotation": 270
+				},
 				"id": "kitchen_tiles_mint_01",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_01",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 270
@@ -4375,6 +5613,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
@@ -4383,6 +5627,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -4391,10 +5641,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -4403,6 +5665,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -4495,6 +5763,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 270
@@ -4503,18 +5777,42 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 90
@@ -4523,10 +5821,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_blue_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood"
 				},
@@ -4534,6 +5844,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood"
 				},
@@ -4541,6 +5857,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_blue_00",
 				"rotation": 90
 			},
@@ -4559,10 +5881,26 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
+				"furniture": {
+					"id": "toilet_00",
+					"rotation": 270
+				},
 				"id": "kitchen_tiles_mint_01",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_mint_01",
 				"rotation": 90
 			},
@@ -4571,10 +5909,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 90
@@ -4583,10 +5933,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -4595,6 +5957,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 270
@@ -4603,6 +5971,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -4611,6 +5985,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -4703,6 +6083,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -4715,6 +6101,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
@@ -4723,18 +6115,42 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_blue_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_blue_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_blue_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_blue_00",
 				"rotation": 90
 			},
@@ -4769,6 +6185,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
@@ -4777,14 +6199,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood"
 				},
@@ -4792,6 +6232,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 90
 			},
@@ -4884,6 +6330,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 90
 			},
@@ -4892,6 +6344,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
@@ -4900,6 +6358,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "refrigerator_00",
 					"rotation": 180
@@ -4908,6 +6372,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 180
@@ -4916,6 +6386,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 180
@@ -4924,6 +6400,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_blue_00",
 				"rotation": 90
 			},
@@ -4941,18 +6423,42 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
@@ -4961,6 +6467,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -4969,6 +6481,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -4977,10 +6495,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 180
@@ -5077,6 +6607,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "toilet_00",
 					"rotation": 180
@@ -5089,6 +6625,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
@@ -5109,6 +6651,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood"
 				},
@@ -5130,18 +6678,42 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
@@ -5158,6 +6730,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -5266,6 +6844,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
@@ -5278,18 +6862,42 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
@@ -5320,6 +6928,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -5336,6 +6950,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 270
@@ -5344,10 +6964,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_yellow_02",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -5448,14 +7080,32 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
@@ -5464,6 +7114,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -5472,10 +7128,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -5484,10 +7152,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -5506,6 +7186,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 270
@@ -5514,18 +7200,42 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -5538,6 +7248,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 270
@@ -5546,10 +7262,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_yellow_02",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
@@ -5645,14 +7373,32 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -5665,10 +7411,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -5677,6 +7435,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 180
@@ -5685,6 +7449,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -5707,6 +7477,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 270
@@ -5715,18 +7491,42 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -5739,6 +7539,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -5747,10 +7553,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_yellow_02",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_yellow_02",
 				"rotation": 90
 			},
@@ -5847,6 +7665,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -5855,10 +7679,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
@@ -5867,14 +7703,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood"
 				},
@@ -5882,10 +7736,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -5900,6 +7766,12 @@
 				"id": "grass_plain_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -5907,6 +7779,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -5915,10 +7793,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "trash_bin"
 				},
@@ -5926,6 +7816,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bench_wood",
 					"rotation": 180
@@ -5934,6 +7830,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -5946,6 +7848,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 180
@@ -5954,6 +7862,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "countertop_wood",
 					"rotation": 180
@@ -5962,6 +7876,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_kitchen",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "refrigerator_00",
 					"rotation": 180
@@ -6058,6 +7978,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 180
@@ -6066,6 +7992,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bench_wood",
 					"rotation": 180
@@ -6074,6 +8006,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -6086,6 +8024,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 180
@@ -6094,6 +8038,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -6102,10 +8052,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -6134,6 +8096,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -6144,6 +8112,12 @@
 				"id": "dirt_light_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -6273,6 +8247,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_livingroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180

--- a/Mods/Core/Maps/generichouse_t.json
+++ b/Mods/Core/Maps/generichouse_t.json
@@ -398,6 +398,103 @@
 					"id": "linoleum_lightblue_00"
 				}
 			]
+		},
+		{
+			"entities": [],
+			"id": "floor_bedroom",
+			"pick_one": true,
+			"rotate_random": true,
+			"spawn_chance": 100,
+			"tiles": [
+				{
+					"count": 1,
+					"id": "red_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "blue_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "orange_carpet_00"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_00"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_01"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_02"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_03"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_04"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_05"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_06"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_08"
+				},
+				{
+					"count": 1,
+					"id": "floor_wood_boards_07"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_blue_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_brown_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_brown_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_green_02"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_greyblue_00"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_02"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_01"
+				},
+				{
+					"count": 1,
+					"id": "linoleum_lightblue_00"
+				}
+			]
 		}
 	],
 	"categories": [
@@ -11848,6 +11945,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -11871,6 +11974,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -11895,6 +12004,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -11903,6 +12018,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00"
 				},
@@ -11910,6 +12031,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -11918,10 +12045,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 90
@@ -11934,14 +12073,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 180
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 180
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 180
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 90
@@ -11984,6 +12141,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -11991,12 +12154,24 @@
 				"id": "floor_wood_boards_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00"
 				},
 				"id": "floor_wood_boards_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -12007,12 +12182,24 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00"
 				},
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -12020,6 +12207,12 @@
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -12027,6 +12220,12 @@
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood"
 				},
@@ -12050,6 +12249,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -12058,14 +12263,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01",
 				"rotation": 90
 			},
@@ -12078,6 +12301,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 270
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -12124,6 +12353,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -12132,6 +12367,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -12139,30 +12380,72 @@
 				"id": "floor_wood_boards_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01"
 			},
 			{
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood"
 				},
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -12180,6 +12463,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 180
@@ -12188,6 +12477,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 180
@@ -12196,6 +12491,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -12204,10 +12505,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 270
@@ -12216,18 +12529,42 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 270
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
@@ -12266,15 +12603,33 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood"
 				},
 				"id": "floor_wood_boards_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 90
@@ -12285,15 +12640,39 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07"
 			},
 			{
@@ -12330,6 +12709,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 180
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
@@ -12341,6 +12726,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
@@ -12383,15 +12774,33 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood"
 				},
 				"id": "floor_wood_boards_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 90
@@ -12402,6 +12811,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -12409,6 +12824,12 @@
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 180
@@ -12416,6 +12837,12 @@
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -12423,6 +12850,12 @@
 				"id": "floor_wood_boards_07"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07"
 			},
 			{
@@ -12436,6 +12869,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -12443,10 +12882,22 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -12455,14 +12906,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 270
@@ -12471,6 +12940,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 180
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 90
 			},
@@ -12521,6 +12996,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 90
+					}
+				],
 				"furniture": {
 					"id": "door_wood"
 				},
@@ -12542,6 +13023,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 270
+					}
+				],
 				"furniture": {
 					"id": "door_wood"
 				},
@@ -12561,6 +13048,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -12569,6 +13062,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood"
 				},
@@ -12576,10 +13075,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
@@ -12588,6 +13099,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 180
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -12638,6 +13155,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 90
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -12646,30 +13169,84 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 180
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 180
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 180
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 180
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 180
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 180
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 180
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 180
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -12684,6 +13261,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -12691,18 +13274,42 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 90
@@ -12715,18 +13322,42 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -12778,6 +13409,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 90
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -12788,12 +13425,24 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 90
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 270
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
@@ -12810,6 +13459,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 270
@@ -12818,14 +13473,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 90
@@ -12838,18 +13511,42 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "toilet_00",
 					"rotation": 90
@@ -12892,19 +13589,43 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 90
+					}
+				],
 				"furniture": {
-					"id": "plant_pot_00",
+					"id": "bathtub",
 					"rotation": 270
 				},
 				"id": "kitchen_tiles_purple_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 90
+					}
+				],
 				"id": "kitchen_tiles_purple_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 90
+					}
+				],
 				"id": "kitchen_tiles_purple_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 90
+					}
+				],
 				"id": "kitchen_tiles_purple_00"
 			},
 			{
@@ -12917,6 +13638,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 270
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
@@ -12933,6 +13660,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 270
@@ -12941,6 +13674,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -12949,6 +13688,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 180
@@ -12957,6 +13702,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -12969,18 +13720,46 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
+				"furniture": {
+					"id": "bathtub",
+					"rotation": 180
+				},
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_purple_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -13023,6 +13802,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 90
+					}
+				],
 				"furniture": {
 					"id": "toilet_00",
 					"rotation": 270
@@ -13030,12 +13815,30 @@
 				"id": "kitchen_tiles_purple_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 90
+					}
+				],
 				"id": "kitchen_tiles_purple_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 90
+					}
+				],
 				"id": "kitchen_tiles_purple_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 90
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -13052,6 +13855,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 270
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -13059,6 +13868,12 @@
 				"id": "orange_carpet_00"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 270
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -13079,6 +13894,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -13089,6 +13910,12 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -13987,6 +14814,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -14045,6 +14878,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -14064,6 +14903,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass"
 				},
@@ -14093,6 +14938,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 270
+					}
+				],
 				"furniture": {
 					"id": "toilet_00",
 					"rotation": 270
@@ -14101,10 +14952,26 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 270
+					}
+				],
 				"id": "kitchen_tiles_mint_01",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 270
+					}
+				],
+				"furniture": {
+					"id": "plant_pot_00",
+					"rotation": 90
+				},
 				"id": "kitchen_tiles_mint_01",
 				"rotation": 90
 			},
@@ -14113,6 +14980,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 90
@@ -14121,6 +14994,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -14129,14 +15008,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -14145,6 +15042,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -14184,6 +15087,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -14192,6 +15101,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00"
 				},
@@ -14199,6 +15114,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 90
@@ -14207,6 +15128,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood"
 				},
@@ -14218,6 +15145,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -14226,6 +15159,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00"
 				},
@@ -14233,6 +15172,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 90
@@ -14255,18 +15200,36 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 270
+					}
+				],
 				"furniture": {
-					"id": "plant_pot_00",
+					"id": "bathtub",
 					"rotation": 270
 				},
 				"id": "kitchen_tiles_mint_01",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 270
+					}
+				],
 				"id": "kitchen_tiles_mint_01",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 270
+					}
+				],
 				"id": "kitchen_tiles_mint_01",
 				"rotation": 90
 			},
@@ -14275,6 +15238,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood"
 				},
@@ -14282,18 +15251,42 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 90
@@ -14333,6 +15326,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -14341,18 +15340,42 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood"
 				},
@@ -14364,6 +15387,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -14372,10 +15401,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 90
@@ -14406,6 +15447,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood"
 				},
@@ -14420,18 +15467,42 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -14440,6 +15511,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -14479,6 +15556,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 180
@@ -14487,6 +15570,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -14495,10 +15584,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "red_carpet_00",
 				"rotation": 270
 			},
@@ -14507,6 +15608,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood"
 				},
@@ -14514,6 +15621,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -14522,6 +15635,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_03",
 				"rotation": 270
 			},
@@ -14547,14 +15666,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 270
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 270
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 90
@@ -14563,10 +15700,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -14575,6 +15724,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 180
@@ -14583,6 +15738,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_05",
 				"rotation": 90
 			},
@@ -14634,6 +15795,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 270
+					}
+				],
 				"furniture": {
 					"id": "door_wood"
 				},
@@ -14653,6 +15820,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 90
+					}
+				],
 				"furniture": {
 					"id": "door_wood"
 				},
@@ -14683,6 +15856,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 180
+					}
+				],
 				"id": "orange_carpet_00"
 			},
 			{
@@ -14741,6 +15920,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 180
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 270
@@ -14749,34 +15934,82 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 180
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 180
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 180
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 180
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 180
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 180
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 180
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 180
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -14791,6 +16024,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 90
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -14799,6 +16038,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 90
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 270
@@ -14807,18 +16052,42 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 90
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 90
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 180
+					}
+				],
 				"id": "orange_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 90
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 90
@@ -14827,10 +16096,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_02",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 180
@@ -14839,6 +16120,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -14847,6 +16134,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -14899,6 +16192,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 270
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 180
 			},
@@ -14941,6 +16240,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 180
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -14956,10 +16261,22 @@
 				"id": "brick_wall_01"
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_02",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood"
 				},
@@ -14967,10 +16284,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_02",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 90
@@ -14979,6 +16308,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -15025,14 +16360,32 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 270
+					}
+				],
 				"id": "blue_carpet_00",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 90
@@ -15041,10 +16394,22 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 180
@@ -15053,6 +16418,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00"
 				},
@@ -15074,6 +16445,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood",
 					"rotation": 270
@@ -15082,6 +16459,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -15090,6 +16473,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 90
 			},
@@ -15098,6 +16487,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00"
 				},
@@ -15105,18 +16500,42 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_02",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_02",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_02",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_02",
 				"rotation": 90
 			},
@@ -15168,6 +16587,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_hallway",
+						"rotation": 270
+					}
+				],
 				"furniture": {
 					"id": "door_wood",
 					"rotation": 180
@@ -15180,6 +16605,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 180
@@ -15188,10 +16619,22 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_08",
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 90
@@ -15200,6 +16643,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 90
@@ -15214,6 +16663,12 @@
 
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 270
@@ -15222,6 +16677,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bed_wood_single_00",
 					"rotation": 270
@@ -15230,10 +16691,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_07",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -15246,6 +16719,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "plant_pot_00",
 					"rotation": 90
@@ -15254,10 +16733,22 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"id": "floor_wood_boards_02",
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "bookcase_wood_00",
 					"rotation": 180
@@ -15266,6 +16757,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -15274,6 +16771,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -15317,6 +16820,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "toilet_00",
 					"rotation": 270
@@ -15325,14 +16834,32 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bathroom",
+						"rotation": 0
+					}
+				],
 				"id": "kitchen_tiles_green_01",
 				"rotation": 180
 			},
@@ -15341,6 +16868,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "table_round_wood"
 				},
@@ -15348,6 +16881,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "chair_wood",
 					"rotation": 270
@@ -15356,6 +16895,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "cabinet_wood_00",
 					"rotation": 180
@@ -15378,6 +16923,12 @@
 				"rotation": 270
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -15398,6 +16949,12 @@
 				"rotation": 90
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180
@@ -15481,6 +17038,12 @@
 				"rotation": 180
 			},
 			{
+				"areas": [
+					{
+						"id": "floor_bedroom",
+						"rotation": 0
+					}
+				],
 				"furniture": {
 					"id": "window_glass",
 					"rotation": 180

--- a/Mods/Core/Tiles/Tiles.json
+++ b/Mods/Core/Tiles/Tiles.json
@@ -330,7 +330,8 @@
 					"generichouse_t",
 					"Generichouse_00",
 					"Generichouse",
-					"store_groceries"
+					"store_groceries",
+					"generichouse_corner"
 				]
 			}
 		},
@@ -436,7 +437,8 @@
 			"core": {
 				"maps": [
 					"Generichouse",
-					"Generichouse_00"
+					"Generichouse_00",
+					"generichouse_corner"
 				]
 			}
 		},
@@ -845,7 +847,8 @@
 					"store_electronic_clothing",
 					"Generichouse",
 					"store_groceries",
-					"Generichouse_00"
+					"Generichouse_00",
+					"generichouse_corner"
 				]
 			}
 		},
@@ -867,7 +870,8 @@
 					"store_electronic_clothing",
 					"Generichouse",
 					"store_groceries",
-					"Generichouse_00"
+					"Generichouse_00",
+					"generichouse_corner"
 				]
 			}
 		},
@@ -889,7 +893,8 @@
 					"store_electronic_clothing",
 					"Generichouse",
 					"store_groceries",
-					"Generichouse_00"
+					"Generichouse_00",
+					"generichouse_corner"
 				]
 			}
 		},
@@ -911,7 +916,8 @@
 					"store_electronic_clothing",
 					"Generichouse",
 					"Generichouse_00",
-					"store_groceries"
+					"store_groceries",
+					"generichouse_corner"
 				]
 			}
 		},
@@ -999,7 +1005,8 @@
 					"generichouse_t",
 					"Generichouse",
 					"store_groceries",
-					"Generichouse_00"
+					"Generichouse_00",
+					"generichouse_corner"
 				]
 			}
 		},
@@ -1042,7 +1049,8 @@
 				"maps": [
 					"Generichouse",
 					"store_groceries",
-					"Generichouse_00"
+					"Generichouse_00",
+					"generichouse_corner"
 				]
 			}
 		},
@@ -1064,7 +1072,8 @@
 					"store_electronic_clothing",
 					"Generichouse",
 					"store_groceries",
-					"Generichouse_00"
+					"Generichouse_00",
+					"generichouse_corner"
 				]
 			}
 		},
@@ -1150,7 +1159,8 @@
 			"core": {
 				"maps": [
 					"Generichouse",
-					"store_groceries"
+					"store_groceries",
+					"generichouse_corner"
 				]
 			}
 		},
@@ -1169,7 +1179,8 @@
 			"core": {
 				"maps": [
 					"Generichouse",
-					"store_groceries"
+					"store_groceries",
+					"generichouse_corner"
 				]
 			}
 		},
@@ -1976,7 +1987,8 @@
 					"generichouse_t",
 					"Generichouse",
 					"Generichouse_00",
-					"store_groceries"
+					"store_groceries",
+					"generichouse_corner"
 				]
 			}
 		},
@@ -2121,7 +2133,8 @@
 				"maps": [
 					"Generichouse_00",
 					"Generichouse",
-					"store_groceries"
+					"store_groceries",
+					"generichouse_corner"
 				]
 			}
 		},
@@ -2141,7 +2154,8 @@
 				"maps": [
 					"Generichouse",
 					"store_groceries",
-					"Generichouse_00"
+					"Generichouse_00",
+					"generichouse_corner"
 				]
 			}
 		},
@@ -2161,7 +2175,8 @@
 				"maps": [
 					"Generichouse",
 					"store_groceries",
-					"Generichouse_00"
+					"Generichouse_00",
+					"generichouse_corner"
 				]
 			}
 		},
@@ -2181,7 +2196,8 @@
 				"maps": [
 					"Generichouse",
 					"store_groceries",
-					"Generichouse_00"
+					"Generichouse_00",
+					"generichouse_corner"
 				]
 			}
 		},
@@ -2201,7 +2217,8 @@
 				"maps": [
 					"Generichouse",
 					"store_groceries",
-					"Generichouse_00"
+					"Generichouse_00",
+					"generichouse_corner"
 				]
 			}
 		},
@@ -2221,7 +2238,8 @@
 				"maps": [
 					"Generichouse_00",
 					"Generichouse",
-					"store_groceries"
+					"store_groceries",
+					"generichouse_corner"
 				]
 			}
 		},
@@ -2241,7 +2259,8 @@
 				"maps": [
 					"Generichouse_00",
 					"Generichouse",
-					"store_groceries"
+					"store_groceries",
+					"generichouse_corner"
 				]
 			}
 		},
@@ -2261,7 +2280,8 @@
 				"maps": [
 					"Generichouse_00",
 					"Generichouse",
-					"store_groceries"
+					"store_groceries",
+					"generichouse_corner"
 				]
 			}
 		},
@@ -2281,7 +2301,8 @@
 				"maps": [
 					"Generichouse",
 					"store_groceries",
-					"Generichouse_00"
+					"Generichouse_00",
+					"generichouse_corner"
 				]
 			}
 		},
@@ -2301,7 +2322,8 @@
 				"maps": [
 					"Generichouse",
 					"store_groceries",
-					"Generichouse_00"
+					"Generichouse_00",
+					"generichouse_corner"
 				]
 			}
 		},
@@ -2322,7 +2344,8 @@
 					"store_electronic_clothing",
 					"Generichouse",
 					"store_groceries",
-					"Generichouse_00"
+					"Generichouse_00",
+					"generichouse_corner"
 				]
 			}
 		},
@@ -2343,7 +2366,8 @@
 					"store_electronic_clothing",
 					"Generichouse",
 					"store_groceries",
-					"Generichouse_00"
+					"Generichouse_00",
+					"generichouse_corner"
 				]
 			}
 		},

--- a/Mods/Core/Tiles/Tiles.json
+++ b/Mods/Core/Tiles/Tiles.json
@@ -2388,7 +2388,8 @@
 					"store_electronic_clothing",
 					"Generichouse",
 					"store_groceries",
-					"Generichouse_00"
+					"Generichouse_00",
+					"generichouse_corner"
 				]
 			}
 		},

--- a/Mods/Core/Tiles/Tiles.json
+++ b/Mods/Core/Tiles/Tiles.json
@@ -848,7 +848,8 @@
 					"Generichouse",
 					"store_groceries",
 					"Generichouse_00",
-					"generichouse_corner"
+					"generichouse_corner",
+					"generichouse_cross"
 				]
 			}
 		},
@@ -894,7 +895,8 @@
 					"Generichouse",
 					"store_groceries",
 					"Generichouse_00",
-					"generichouse_corner"
+					"generichouse_corner",
+					"generichouse_cross"
 				]
 			}
 		},
@@ -917,7 +919,8 @@
 					"Generichouse",
 					"Generichouse_00",
 					"store_groceries",
-					"generichouse_corner"
+					"generichouse_corner",
+					"generichouse_cross"
 				]
 			}
 		},
@@ -962,7 +965,8 @@
 					"generichouse_corner",
 					"store_electronic_clothing",
 					"Generichouse",
-					"Generichouse_00"
+					"Generichouse_00",
+					"generichouse_cross"
 				]
 			}
 		},
@@ -984,7 +988,8 @@
 					"store_electronic_clothing",
 					"Generichouse",
 					"store_groceries",
-					"Generichouse_00"
+					"Generichouse_00",
+					"generichouse_cross"
 				]
 			}
 		},
@@ -1006,7 +1011,8 @@
 					"Generichouse",
 					"store_groceries",
 					"Generichouse_00",
-					"generichouse_corner"
+					"generichouse_corner",
+					"generichouse_cross"
 				]
 			}
 		},
@@ -1050,7 +1056,8 @@
 					"Generichouse",
 					"store_groceries",
 					"Generichouse_00",
-					"generichouse_corner"
+					"generichouse_corner",
+					"generichouse_cross"
 				]
 			}
 		},
@@ -1073,7 +1080,8 @@
 					"Generichouse",
 					"store_groceries",
 					"Generichouse_00",
-					"generichouse_corner"
+					"generichouse_corner",
+					"generichouse_cross"
 				]
 			}
 		},
@@ -1094,7 +1102,8 @@
 					"generichouse_corner",
 					"Generichouse",
 					"store_groceries",
-					"Generichouse_00"
+					"Generichouse_00",
+					"generichouse_cross"
 				]
 			}
 		},
@@ -1116,7 +1125,8 @@
 					"store_electronic_clothing",
 					"Generichouse_00",
 					"Generichouse",
-					"store_groceries"
+					"store_groceries",
+					"generichouse_cross"
 				]
 			}
 		},
@@ -1160,7 +1170,8 @@
 				"maps": [
 					"Generichouse",
 					"store_groceries",
-					"generichouse_corner"
+					"generichouse_corner",
+					"generichouse_cross"
 				]
 			}
 		},
@@ -1180,7 +1191,8 @@
 				"maps": [
 					"Generichouse",
 					"store_groceries",
-					"generichouse_corner"
+					"generichouse_corner",
+					"generichouse_cross"
 				]
 			}
 		},

--- a/Mods/Core/Tiles/Tiles.json
+++ b/Mods/Core/Tiles/Tiles.json
@@ -2130,7 +2130,8 @@
 			"core": {
 				"maps": [
 					"Generichouse",
-					"store_groceries"
+					"store_groceries",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -2149,7 +2150,8 @@
 			"core": {
 				"maps": [
 					"Generichouse",
-					"store_groceries"
+					"store_groceries",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -2168,7 +2170,8 @@
 			"core": {
 				"maps": [
 					"Generichouse",
-					"store_groceries"
+					"store_groceries",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -2187,7 +2190,8 @@
 			"core": {
 				"maps": [
 					"Generichouse",
-					"store_groceries"
+					"store_groceries",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -2266,7 +2270,8 @@
 			"core": {
 				"maps": [
 					"Generichouse",
-					"store_groceries"
+					"store_groceries",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -2285,7 +2290,8 @@
 			"core": {
 				"maps": [
 					"Generichouse",
-					"store_groceries"
+					"store_groceries",
+					"Generichouse_00"
 				]
 			}
 		},

--- a/Mods/Core/Tiles/Tiles.json
+++ b/Mods/Core/Tiles/Tiles.json
@@ -2215,7 +2215,8 @@
 					"Generichouse",
 					"store_groceries",
 					"Generichouse_00",
-					"generichouse_corner"
+					"generichouse_corner",
+					"generichouse_cross"
 				]
 			}
 		},
@@ -2258,7 +2259,8 @@
 					"Generichouse_00",
 					"Generichouse",
 					"store_groceries",
-					"generichouse_corner"
+					"generichouse_corner",
+					"generichouse_cross"
 				]
 			}
 		},

--- a/Mods/Core/Tiles/Tiles.json
+++ b/Mods/Core/Tiles/Tiles.json
@@ -844,7 +844,8 @@
 				"maps": [
 					"store_electronic_clothing",
 					"Generichouse",
-					"store_groceries"
+					"store_groceries",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -865,7 +866,8 @@
 					"generichouse_cross",
 					"store_electronic_clothing",
 					"Generichouse",
-					"store_groceries"
+					"store_groceries",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -886,7 +888,8 @@
 					"generichouse_t",
 					"store_electronic_clothing",
 					"Generichouse",
-					"store_groceries"
+					"store_groceries",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -931,7 +934,8 @@
 					"generichouse_t",
 					"store_electronic_clothing",
 					"Generichouse",
-					"store_groceries"
+					"store_groceries",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -951,7 +955,8 @@
 				"maps": [
 					"generichouse_corner",
 					"store_electronic_clothing",
-					"Generichouse"
+					"Generichouse",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -972,7 +977,8 @@
 					"generichouse_corner",
 					"store_electronic_clothing",
 					"Generichouse",
-					"store_groceries"
+					"store_groceries",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -992,7 +998,8 @@
 				"maps": [
 					"generichouse_t",
 					"Generichouse",
-					"store_groceries"
+					"store_groceries",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -1034,7 +1041,8 @@
 			"core": {
 				"maps": [
 					"Generichouse",
-					"store_groceries"
+					"store_groceries",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -1055,7 +1063,8 @@
 					"generichouse_t",
 					"store_electronic_clothing",
 					"Generichouse",
-					"store_groceries"
+					"store_groceries",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -1075,7 +1084,8 @@
 				"maps": [
 					"generichouse_corner",
 					"Generichouse",
-					"store_groceries"
+					"store_groceries",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -2311,7 +2321,8 @@
 				"maps": [
 					"store_electronic_clothing",
 					"Generichouse",
-					"store_groceries"
+					"store_groceries",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -2331,7 +2342,8 @@
 				"maps": [
 					"store_electronic_clothing",
 					"Generichouse",
-					"store_groceries"
+					"store_groceries",
+					"Generichouse_00"
 				]
 			}
 		},
@@ -2351,7 +2363,8 @@
 				"maps": [
 					"store_electronic_clothing",
 					"Generichouse",
-					"store_groceries"
+					"store_groceries",
+					"Generichouse_00"
 				]
 			}
 		},

--- a/Mods/Core/Tiles/Tiles.json
+++ b/Mods/Core/Tiles/Tiles.json
@@ -353,7 +353,8 @@
 					"generichouse_t",
 					"Generichouse",
 					"Generichouse_00",
-					"store_groceries"
+					"store_groceries",
+					"generichouse_cross"
 				]
 			}
 		},
@@ -438,7 +439,8 @@
 				"maps": [
 					"Generichouse",
 					"Generichouse_00",
-					"generichouse_corner"
+					"generichouse_corner",
+					"generichouse_cross"
 				]
 			}
 		},
@@ -484,7 +486,8 @@
 					"generichouse_t",
 					"Generichouse",
 					"Generichouse_00",
-					"store_groceries"
+					"store_groceries",
+					"generichouse_cross"
 				]
 			}
 		},
@@ -2146,7 +2149,8 @@
 					"Generichouse_00",
 					"Generichouse",
 					"store_groceries",
-					"generichouse_corner"
+					"generichouse_corner",
+					"generichouse_cross"
 				]
 			}
 		},
@@ -2167,7 +2171,8 @@
 					"Generichouse",
 					"store_groceries",
 					"Generichouse_00",
-					"generichouse_corner"
+					"generichouse_corner",
+					"generichouse_cross"
 				]
 			}
 		},
@@ -2188,7 +2193,8 @@
 					"Generichouse",
 					"store_groceries",
 					"Generichouse_00",
-					"generichouse_corner"
+					"generichouse_corner",
+					"generichouse_cross"
 				]
 			}
 		},
@@ -2230,7 +2236,8 @@
 					"Generichouse",
 					"store_groceries",
 					"Generichouse_00",
-					"generichouse_corner"
+					"generichouse_corner",
+					"generichouse_cross"
 				]
 			}
 		},
@@ -2272,7 +2279,8 @@
 					"Generichouse_00",
 					"Generichouse",
 					"store_groceries",
-					"generichouse_corner"
+					"generichouse_corner",
+					"generichouse_cross"
 				]
 			}
 		},
@@ -2293,7 +2301,8 @@
 					"Generichouse_00",
 					"Generichouse",
 					"store_groceries",
-					"generichouse_corner"
+					"generichouse_corner",
+					"generichouse_cross"
 				]
 			}
 		},
@@ -2314,7 +2323,8 @@
 					"Generichouse",
 					"store_groceries",
 					"Generichouse_00",
-					"generichouse_corner"
+					"generichouse_corner",
+					"generichouse_cross"
 				]
 			}
 		},
@@ -2335,7 +2345,8 @@
 					"Generichouse",
 					"store_groceries",
 					"Generichouse_00",
-					"generichouse_corner"
+					"generichouse_corner",
+					"generichouse_cross"
 				]
 			}
 		},
@@ -2401,7 +2412,8 @@
 					"Generichouse",
 					"store_groceries",
 					"Generichouse_00",
-					"generichouse_corner"
+					"generichouse_corner",
+					"generichouse_cross"
 				]
 			}
 		},

--- a/Mods/Core/Tiles/Tiles.json
+++ b/Mods/Core/Tiles/Tiles.json
@@ -397,7 +397,8 @@
 					"generichouse_corner",
 					"generichouse_cross",
 					"Generichouse",
-					"Generichouse_00"
+					"Generichouse_00",
+					"generichouse_t"
 				]
 			}
 		},
@@ -440,7 +441,8 @@
 					"Generichouse",
 					"Generichouse_00",
 					"generichouse_corner",
-					"generichouse_cross"
+					"generichouse_cross",
+					"generichouse_t"
 				]
 			}
 		},
@@ -852,7 +854,8 @@
 					"store_groceries",
 					"Generichouse_00",
 					"generichouse_corner",
-					"generichouse_cross"
+					"generichouse_cross",
+					"generichouse_t"
 				]
 			}
 		},
@@ -875,7 +878,8 @@
 					"Generichouse",
 					"store_groceries",
 					"Generichouse_00",
-					"generichouse_corner"
+					"generichouse_corner",
+					"generichouse_t"
 				]
 			}
 		},
@@ -969,7 +973,8 @@
 					"store_electronic_clothing",
 					"Generichouse",
 					"Generichouse_00",
-					"generichouse_cross"
+					"generichouse_cross",
+					"generichouse_t"
 				]
 			}
 		},
@@ -992,7 +997,8 @@
 					"Generichouse",
 					"store_groceries",
 					"Generichouse_00",
-					"generichouse_cross"
+					"generichouse_cross",
+					"generichouse_t"
 				]
 			}
 		},
@@ -1060,7 +1066,8 @@
 					"store_groceries",
 					"Generichouse_00",
 					"generichouse_corner",
-					"generichouse_cross"
+					"generichouse_cross",
+					"generichouse_t"
 				]
 			}
 		},
@@ -1106,7 +1113,8 @@
 					"Generichouse",
 					"store_groceries",
 					"Generichouse_00",
-					"generichouse_cross"
+					"generichouse_cross",
+					"generichouse_t"
 				]
 			}
 		},
@@ -1129,7 +1137,8 @@
 					"Generichouse_00",
 					"Generichouse",
 					"store_groceries",
-					"generichouse_cross"
+					"generichouse_cross",
+					"generichouse_t"
 				]
 			}
 		},
@@ -1174,7 +1183,8 @@
 					"Generichouse",
 					"store_groceries",
 					"generichouse_corner",
-					"generichouse_cross"
+					"generichouse_cross",
+					"generichouse_t"
 				]
 			}
 		},
@@ -1195,7 +1205,8 @@
 					"Generichouse",
 					"store_groceries",
 					"generichouse_corner",
-					"generichouse_cross"
+					"generichouse_cross",
+					"generichouse_t"
 				]
 			}
 		},
@@ -2150,7 +2161,8 @@
 					"Generichouse",
 					"store_groceries",
 					"generichouse_corner",
-					"generichouse_cross"
+					"generichouse_cross",
+					"generichouse_t"
 				]
 			}
 		},
@@ -2172,7 +2184,8 @@
 					"store_groceries",
 					"Generichouse_00",
 					"generichouse_corner",
-					"generichouse_cross"
+					"generichouse_cross",
+					"generichouse_t"
 				]
 			}
 		},
@@ -2194,7 +2207,8 @@
 					"store_groceries",
 					"Generichouse_00",
 					"generichouse_corner",
-					"generichouse_cross"
+					"generichouse_cross",
+					"generichouse_t"
 				]
 			}
 		},
@@ -2216,7 +2230,8 @@
 					"store_groceries",
 					"Generichouse_00",
 					"generichouse_corner",
-					"generichouse_cross"
+					"generichouse_cross",
+					"generichouse_t"
 				]
 			}
 		},
@@ -2238,7 +2253,8 @@
 					"store_groceries",
 					"Generichouse_00",
 					"generichouse_corner",
-					"generichouse_cross"
+					"generichouse_cross",
+					"generichouse_t"
 				]
 			}
 		},
@@ -2260,7 +2276,8 @@
 					"Generichouse",
 					"store_groceries",
 					"generichouse_corner",
-					"generichouse_cross"
+					"generichouse_cross",
+					"generichouse_t"
 				]
 			}
 		},
@@ -2282,7 +2299,8 @@
 					"Generichouse",
 					"store_groceries",
 					"generichouse_corner",
-					"generichouse_cross"
+					"generichouse_cross",
+					"generichouse_t"
 				]
 			}
 		},
@@ -2304,7 +2322,8 @@
 					"Generichouse",
 					"store_groceries",
 					"generichouse_corner",
-					"generichouse_cross"
+					"generichouse_cross",
+					"generichouse_t"
 				]
 			}
 		},
@@ -2326,7 +2345,8 @@
 					"store_groceries",
 					"Generichouse_00",
 					"generichouse_corner",
-					"generichouse_cross"
+					"generichouse_cross",
+					"generichouse_t"
 				]
 			}
 		},
@@ -2348,7 +2368,8 @@
 					"store_groceries",
 					"Generichouse_00",
 					"generichouse_corner",
-					"generichouse_cross"
+					"generichouse_cross",
+					"generichouse_t"
 				]
 			}
 		},
@@ -2370,7 +2391,8 @@
 					"Generichouse",
 					"store_groceries",
 					"Generichouse_00",
-					"generichouse_corner"
+					"generichouse_corner",
+					"generichouse_t"
 				]
 			}
 		},
@@ -2392,7 +2414,8 @@
 					"Generichouse",
 					"store_groceries",
 					"Generichouse_00",
-					"generichouse_corner"
+					"generichouse_corner",
+					"generichouse_t"
 				]
 			}
 		},
@@ -2415,7 +2438,8 @@
 					"store_groceries",
 					"Generichouse_00",
 					"generichouse_corner",
-					"generichouse_cross"
+					"generichouse_cross",
+					"generichouse_t"
 				]
 			}
 		},

--- a/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
@@ -55,7 +55,6 @@ var current_image_display: String = ""
 
 
 # This signal will be emitted when the user presses the save button
-# This signal should alert Gamedata that the mob data array should be saved to disk
 signal data_changed()
 
 

--- a/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
@@ -641,6 +641,7 @@ func save_miniature_map_image():
 		# Create an ImageTexture from the Image
 		var image_texture = ImageTexture.create_from_image(image)
 		mapEditor.currentMap.sprite = image_texture
+		mapEditor.data_changed.emit()
 	else:
 		print("Failed to save image:", file_path)
 

--- a/Scenes/ContentManager/Mapeditor/Scripts/Map_Editor_Preview_Popup.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/Map_Editor_Preview_Popup.gd
@@ -54,12 +54,12 @@ func load_level_data(level: int) -> void:
 	# If any data exists on this level, we load it
 	if newLevelData != []:
 		for tile in map_preview_grid.get_children():
-			tile.tileData = newLevelData[i]  # Assuming set_tile_data method exists in tileScene
+			tile.update_display(newLevelData[i])  # Assuming set_tile_data method exists in tileScene
 			i += 1
 	else:
 		# No data is present on this level. apply the default value for each tile
 		for tile in map_preview_grid.get_children():
-			tile.set_default()  # Assuming set_default method exists in tileScene
+			tile.update_display()  # Calling this without parameters resets the tile to default
 
 
 # Function to generate the map preview

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditor.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditor.gd
@@ -92,7 +92,7 @@ func _on_rotate_map_button_up():
 
 # When the user presses the map preview button
 func _on_preview_map_button_up():
-	map_preview.mapData = tileGrid.mapEditor.currentMap.get_data()
+	map_preview.mapData = currentMap.get_data()
 	map_preview.show()
 
 

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditor.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditor.gd
@@ -15,6 +15,9 @@ extends Control
 
 
 signal zoom_level_changed(value: int)
+
+# This signal should alert the content_list that a refresh is needed
+signal data_changed()
 var tileSize: int = 128
 var mapHeight: int = 32
 var mapWidth: int = 32

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditortile.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditortile.gd
@@ -1,45 +1,8 @@
 extends Control
 
-#If a tile has no data, we save an empty object. Tiledata can have:
-# id, rotation, mob, furniture, itemgroup and areas
-const defaultTileData: Dictionary = {}
 const defaultTexture: String = "res://Scenes/ContentManager/Mapeditor/Images/emptyTile.png"
 const aboveTexture: String = "res://Scenes/ContentManager/Mapeditor/Images/tileAbove.png"
 const areaTexture: String = "res://Scenes/ContentManager/Mapeditor/Images/areatile.png"
-var tileData: Dictionary = defaultTileData.duplicate():
-	set(data):
-		if (tileData.has("id") and tileData.id == "null") or (tileData.has("id") and tileData.id == null):
-			return
-		tileData = data
-		if tileData.has("id") and not tileData.id == "" and not tileData.id == "null":
-			$TileSprite.texture = Gamedata.tiles.sprite_by_id(tileData.id)
-			set_rotation_amount(tileData.get("rotation", 0))
-			$ObjectSprite.hide()
-			$ObjectSprite.rotation_degrees = 0
-			$AreaSprite.hide()
-			$AreaSprite.rotation_degrees = 0
-			if tileData.has("mob"):
-				if tileData.mob.has("rotation"):
-					$ObjectSprite.rotation_degrees = tileData.mob.rotation
-				$ObjectSprite.texture = Gamedata.mobs.sprite_by_id(tileData.mob.id)
-				$ObjectSprite.show()
-			elif tileData.has("furniture"):
-				if tileData.furniture.has("rotation"):
-					$ObjectSprite.rotation_degrees = tileData.furniture.rotation
-				$ObjectSprite.texture = Gamedata.furnitures.sprite_by_id(tileData.furniture.id)
-				$ObjectSprite.show()
-			elif tileData.has("itemgroups"):
-				var random_itemgroup: String = tileData.itemgroups.pick_random()
-				$ObjectSprite.texture = Gamedata.itemgroups.sprite_by_id(random_itemgroup)
-				$ObjectSprite.show()
-			if tileData.has("areas"):
-				$AreaSprite.show()
-		else:
-			$TileSprite.texture = load(defaultTexture)
-			$ObjectSprite.texture = null
-			$ObjectSprite.hide()
-			$AreaSprite.hide()
-		set_tooltip()
 
 
 signal tile_clicked(clicked_tile: Control)
@@ -260,7 +223,7 @@ func remove_area_from_tile(area_id: String) -> void:
 
 
 # Sets the tooltip for this tile. The user can use this to see what's on this tile.
-func set_tooltip() -> void:
+func set_tooltip(tileData: Dictionary) -> void:
 	var tooltiptext = "Tile Overview:\n"
 	
 	# Display tile ID
@@ -342,3 +305,38 @@ func get_tileData() -> Dictionary:
 	if tileData.has("rotation") and tileData.rotation == 0:
 		tileData.erase("rotation")
 	return tileData
+
+
+# Updates the tile visuals based on the provided data
+# Tiledata can have:
+# id, rotation, mob, furniture, itemgroup and areas
+func update_display(tileData: Dictionary):
+	if tileData.has("id") and tileData["id"] != "" and tileData["id"] != "null":
+		$TileSprite.texture = Gamedata.tiles.sprite_by_id(tileData["id"])
+		$TileSprite.rotation_degrees = tileData.get("rotation", 0)
+		$ObjectSprite.hide()
+		$ObjectSprite.rotation_degrees = 0
+		$AreaSprite.hide()
+		$AreaSprite.rotation_degrees = 0
+		if tileData.has("mob"):
+			if tileData["mob"].has("rotation"):
+				$ObjectSprite.rotation_degrees = tileData["mob"]["rotation"]
+			$ObjectSprite.texture = Gamedata.mobs.sprite_by_id(tileData["mob"]["id"])
+			$ObjectSprite.show()
+		elif tileData.has("furniture"):
+			if tileData["furniture"].has("rotation"):
+				$ObjectSprite.rotation_degrees = tileData["furniture"]["rotation"]
+			$ObjectSprite.texture = Gamedata.furnitures.sprite_by_id(tileData["furniture"]["id"])
+			$ObjectSprite.show()
+		elif tileData.has("itemgroups"):
+			var random_itemgroup: String = tileData["itemgroups"].pick_random()
+			$ObjectSprite.texture = Gamedata.itemgroups.sprite_by_id(random_itemgroup)
+			$ObjectSprite.show()
+		if tileData.has("areas"):
+			$AreaSprite.show()
+	else:
+		$TileSprite.texture = load(defaultTexture)
+		$ObjectSprite.texture = null
+		$ObjectSprite.hide()
+		$AreaSprite.hide()
+	set_tooltip(tileData)

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditortile.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditortile.gd
@@ -254,6 +254,7 @@ func remove_area_from_tile(area_id: String) -> void:
 				$AreaSprite.hide()
 				break
 		if tileData.areas.is_empty():
+			tileData.erase("areas") # leave no empty array
 			$AreaSprite.hide()
 	set_tooltip()
 

--- a/Scenes/ContentManager/Mapeditor/mapeditor.tscn
+++ b/Scenes/ContentManager/Mapeditor/mapeditor.tscn
@@ -82,10 +82,12 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+current_tab = 0
 
 [node name="Edit Map" type="HSplitContainer" parent="TabContainer"]
 layout_mode = 2
 theme_override_icons/grabber = SubResource("GradientTexture2D_1xgu1")
+metadata/_tab_index = 0
 
 [node name="MapeditorContainer" type="VBoxContainer" parent="TabContainer/Edit Map"]
 layout_mode = 2
@@ -358,6 +360,7 @@ tileBrush = ExtResource("8_o4x7s")
 visible = false
 layout_mode = 2
 columns = 2
+metadata/_tab_index = 1
 
 [node name="NameLabel" type="Label" parent="TabContainer/Settings"]
 layout_mode = 2

--- a/Scenes/ContentManager/Scripts/contenteditor.gd
+++ b/Scenes/ContentManager/Scripts/contenteditor.gd
@@ -100,6 +100,7 @@ func instantiate_editor(type: Gamedata.ContentType, itemID: String, newEditor: P
 	match type:
 		Gamedata.ContentType.MAPS:
 			newContentEditor.currentMap = Gamedata.maps.by_id(itemID)
+			newContentEditor.data_changed.connect(list.load_data)
 		
 		Gamedata.ContentType.TACTICALMAPS:
 			newContentEditor.currentMap = Gamedata.tacticalmaps.by_id(itemID)

--- a/Scripts/CtrlInventoryStackedCustom.gd
+++ b/Scripts/CtrlInventoryStackedCustom.gd
@@ -368,13 +368,8 @@ func _on_row_mouse_entered(row_name: String):
 	if inventory_rows.has(row_name):
 		for control in inventory_rows[row_name]["controls"]:
 			control.highlight()
-		# Store the item for which the tooltip should be shown
 		var item = inventory_rows[row_name]["item"] as InventoryItem
 		if item:
-			# Now that you have the item, you can use it as needed.
-			# For example, start a timer for showing a tooltip.
-			#tooltip_timer.set_meta("item", item)  # Store the item in the timer's metadata
-			#tooltip_timer.start()
 			mouse_entered_item.emit(item)
 
 

--- a/Scripts/InventoryWindow.gd
+++ b/Scripts/InventoryWindow.gd
@@ -114,6 +114,8 @@ func _on_inventory_item_mouse_entered(item: InventoryItem):
 
 	description = _append_food_attributes(item, description)
 	description = _append_medical_attributes(item, description)
+	description = _append_melee_attributes(item, description)
+	description = _append_ranged_attributes(item, description)
 
 	tooltip_item_description.text = description
 	_set_tooltip_size(description)
@@ -160,6 +162,46 @@ func _append_medical_attributes(item: InventoryItem, description: String) -> Str
 					line += " " + "".join(values)
 					description += line + "\n"
 	return description
+
+# Add text to the tooltip to display the Melee attributes
+func _append_melee_attributes(item: InventoryItem, description: String) -> String:
+	var dmelee = DItem.Melee.new(item.get_property("Melee", {}))
+	if dmelee.damage > 0 or dmelee.reach > 0 or dmelee.used_skill:
+		description += "\n\nAttributes (Melee):\n"  # Add a section for melee attributes
+		if dmelee.damage > 0:
+			description += "- Damage: " + str(dmelee.damage) + "\n"
+		if dmelee.reach > 0:
+			description += "- Reach: " + str(dmelee.reach) + "\n"
+		if dmelee.used_skill:
+			description += "- Skill: " + str(dmelee.used_skill.get("skill_id", "Unknown")) + " (XP: " + str(dmelee.used_skill.get("xp", 0)) + ")\n"
+	return description
+
+# Add text to the tooltip to display the Ranged attributes
+func _append_ranged_attributes(item: InventoryItem, description: String) -> String:
+	var dranged = DItem.Ranged.new(item.get_property("Ranged", {}))
+	if dranged.firing_speed > 0 or dranged.firing_range > 0 or dranged.recoil > 0 or dranged.reload_speed > 0 or dranged.used_ammo != "" or dranged.used_skill:
+		description += "\n\nAttributes (Ranged):\n"  # Add a section for ranged attributes
+		if dranged.firing_speed > 0:
+			description += "- Firing Speed: " + str(dranged.firing_speed) + "\n"
+		if dranged.firing_range > 0:
+			description += "- Firing Range: " + str(dranged.firing_range) + "\n"
+		if dranged.recoil > 0:
+			description += "- Recoil: " + str(dranged.recoil) + "\n"
+		if dranged.reload_speed > 0:
+			description += "- Reload Speed: " + str(dranged.reload_speed) + "\n"
+		if dranged.spread > 0:
+			description += "- Spread: " + str(dranged.spread) + "\n"
+		if dranged.sway > 0:
+			description += "- Sway: " + str(dranged.sway) + "\n"
+		if dranged.used_ammo != "":
+			description += "- Ammo Type: " + dranged.used_ammo + "\n"
+		if dranged.used_magazine != "":
+			description += "- Magazine Type: " + dranged.used_magazine + "\n"
+		if dranged.used_skill:
+			description += "- Skill: " + str(dranged.used_skill.get("skill_id", "Unknown")) + " (XP: " + str(dranged.used_skill.get("xp", 0)) + ")\n"
+	return description
+
+
 
 
 func _on_inventory_item_mouse_exited():


### PR DESCRIPTION
Requires #403 
Fixes #402 

Tiledata was stored inside the tile instances, but this lead to various issues when changing a level or renaming areas. This pr refactors the script so that all mapdata.levels processing is done in the GridContainer script. This involved moving some function from mapeditortile into the gridcontainer script. 

I tested some functions of the mapeditor. I think everything works but if there are any more bugs I'll add them as new issues.