### PR TITLE
Transfer inventory item on doubleclick

### DIFF
--- a/Scripts/CtrlInventoryStackedCustom.gd
+++ b/Scripts/CtrlInventoryStackedCustom.gd
@@ -56,6 +56,7 @@ signal unload_item(items: Array[InventoryItem])
 # UI signals emitted when the cursor hovers over a row in the list
 signal mouse_entered_item(item: InventoryItem)
 signal mouse_exited_item
+signal grid_cell_doubleclicked(item: InventoryItem)
 
 
 func initialize_list():
@@ -614,6 +615,10 @@ func _on_grid_cell_gui_input(event, gridCell: Control):
 			mouse_press_position = event.position  # Store the position of mouse press
 			match event.button_index:
 				MOUSE_BUTTON_LEFT:
+					# Detect double-click
+					if event.double_click:
+						_on_grid_cell_double_clicked(gridCell)
+						return
 					# Do not handle click here if items are selected, wait for release
 					if get_selected_inventory_items().size() == 0:
 						# One item selected, handle the click immediately
@@ -766,3 +771,15 @@ func get_items() -> Array:
 # Transfers an item from this inventory to the destination inventory
 func transfer_autosplitmerge(item: InventoryItem, destination: InventoryStacked) -> bool:
 	return myInventory.transfer_autosplitmerge(item, destination)
+
+
+# Function to handle item transfer on double-click
+func _on_grid_cell_double_clicked(gridCell: Control) -> void:
+	# Get the row name of the double-clicked grid cell
+	var row_name = _get_row_name(gridCell)
+	
+	# Ensure the row corresponds to an inventory item
+	if inventory_rows.has(row_name):
+		var item = inventory_rows[row_name]["item"] as InventoryItem
+		if item:
+			grid_cell_doubleclicked.emit(item)

--- a/Scripts/InventoryWindow.gd
+++ b/Scripts/InventoryWindow.gd
@@ -55,6 +55,7 @@ func initialize_inventory_control(control: Control, inv: InventoryStacked):
 	control.initialize_list()
 	control.mouse_entered_item.connect(_on_inventory_item_mouse_entered)
 	control.mouse_exited_item.connect(_on_inventory_item_mouse_exited)
+	control.grid_cell_doubleclicked.connect(_on_grid_cell_double_clicked) 
 
 # If any items are present in the player equipment, load them
 func equip_loaded_items():
@@ -384,3 +385,24 @@ func transfer_autosplitmerge_list(items: Array, src: Control, dest: Control) -> 
 
 	Helper.signal_broker.inventory_operation_finished.emit()
 	return success
+
+
+# Function to handle double-clicking a grid cell in the inventory grid
+func _on_grid_cell_double_clicked(item: InventoryItem):
+	var source_inventory = item.get_inventory()
+	var destination_inventory: InventoryStacked
+
+	# Determine the destination inventory based on the source inventory
+	if source_inventory == inventory:
+		# Check if the current proximity inventory is the default set in the ItemManager
+		var proximityinventory: InventoryStacked = proximity_inventory_control.get_inventory()
+		if proximityinventory == ItemManager.proximityInventory:
+			print_debug("Attempt to transfer to default proximity inventory aborted.")
+			return  # Exit the function early if the condition is met
+		destination_inventory = proximityinventory
+	else:
+		destination_inventory = inventory
+
+	# Attempt to transfer the item
+	if not destination_inventory or not source_inventory.transfer_autosplitmerge(item, destination_inventory):
+		print("Failed to transfer item!")


### PR DESCRIPTION
Fixes #457 

I implemented it as suggested. I do wonder if this is the right place to check for doubleclick:
```
# When the user clicks on one of the cells in the grid
func _on_grid_cell_gui_input(event, gridCell: Control):
	if event is InputEventMouseButton:
		if event.pressed:  # Check if the mouse button was pressed down
			mouse_press_position = event.position  # Store the position of mouse press
			match event.button_index:
				MOUSE_BUTTON_LEFT:
					# Detect double-click
					if event.double_click:
						_on_grid_cell_double_clicked(gridCell)
						return
```

But I tested it and it works. You can also drag items and the other functionality works as before. If you doubleclick an inventory item in the player inventory and there is no nearby container, nothing happens.