### PR TITLE
Add test environment

### DIFF
--- a/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
@@ -1290,3 +1290,12 @@ func set_tile_itemgroups(tileData: Dictionary, itemgroups: Array) -> void:
 		tileData.furniture.itemgroups = itemgroups
 	else: # The furniture is not a container so we erase the itemgroups
 		tileData.furniture.erase("itemgroups")
+
+
+func _on_save_and_test_button_button_up() -> void:
+	save_map_json_file()
+	# Save the current map ID to the test_map_name
+	Helper.test_map_name = mapEditor.currentMap.id
+	
+	# Switch to the test environment scene
+	get_tree().change_scene_to_file("res://test_environment.tscn")

--- a/Scenes/ContentManager/Mapeditor/mapeditor.tscn
+++ b/Scenes/ContentManager/Mapeditor/mapeditor.tscn
@@ -130,7 +130,8 @@ text = "Save"
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.15
-tooltip_text = "Saves your changes to the map to disk."
+tooltip_text = "Saves your changes to the map to disk and loads your map
+into the test environment. You will leave the content editor!"
 text = "Save & test"
 
 [node name="CreatePreviewImageButton" type="CheckBox" parent="TabContainer/Edit Map/MapeditorContainer/Toolbar"]

--- a/Scenes/ContentManager/Mapeditor/mapeditor.tscn
+++ b/Scenes/ContentManager/Mapeditor/mapeditor.tscn
@@ -126,6 +126,13 @@ size_flags_stretch_ratio = 0.15
 tooltip_text = "Saves your changes to the map to disk."
 text = "Save"
 
+[node name="SaveAndTestButton" type="Button" parent="TabContainer/Edit Map/MapeditorContainer/Toolbar"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.15
+tooltip_text = "Saves your changes to the map to disk."
+text = "Save & test"
+
 [node name="CreatePreviewImageButton" type="CheckBox" parent="TabContainer/Edit Map/MapeditorContainer/Toolbar"]
 layout_mode = 2
 tooltip_text = "Creates a miniature image of the map in the /mods/core/maps folder. The file name will be the ID of the map + png. "
@@ -468,6 +475,7 @@ visible = false
 [connection signal="zoom_level_changed" from="." to="TabContainer/Edit Map/MapeditorContainer/HBoxContainer/MapScrollWindow/PanWindow/GridContainer/TileGrid" method="_on_zoom_level_changed"]
 [connection signal="button_up" from="TabContainer/Edit Map/MapeditorContainer/Toolbar/CloseButton" to="." method="_on_close_button_button_up"]
 [connection signal="button_up" from="TabContainer/Edit Map/MapeditorContainer/Toolbar/SaveButton" to="TabContainer/Edit Map/MapeditorContainer/HBoxContainer/MapScrollWindow/PanWindow/GridContainer/TileGrid" method="save_map_json_file"]
+[connection signal="button_up" from="TabContainer/Edit Map/MapeditorContainer/Toolbar/SaveAndTestButton" to="TabContainer/Edit Map/MapeditorContainer/HBoxContainer/MapScrollWindow/PanWindow/GridContainer/TileGrid" method="_on_save_and_test_button_button_up"]
 [connection signal="button_up" from="TabContainer/Edit Map/MapeditorContainer/Toolbar/CreatePreviewImageButton" to="TabContainer/Edit Map/MapeditorContainer/HBoxContainer/MapScrollWindow/PanWindow/GridContainer/TileGrid" method="_on_create_preview_image_button_button_up"]
 [connection signal="button_up" from="TabContainer/Edit Map/MapeditorContainer/Toolbar/RotateMap" to="." method="_on_rotate_map_button_up"]
 [connection signal="button_up" from="TabContainer/Edit Map/MapeditorContainer/Toolbar/PreviewMap" to="." method="_on_preview_map_button_up"]

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -16,7 +16,7 @@ extends Node3D
 
 # Reference to the level manager. Some nodes that could be moved to other chunks 
 # should be parented to this (like moveable furniture and mobs)
-var level_manager : Node3D
+@export var level_manager : Node3D
 var level_generator : Node3D
 var furniture_static_spawner: FurnitureStaticSpawner
 var furniture_physics_spawner: FurniturePhysicsSpawner
@@ -96,6 +96,8 @@ func reset_state():
 
 
 func initialize_chunk_data():
+	if Helper.test_map_name: # If we have a map explicitly set for test purposes, override it
+		chunk_data["id"] = Helper.test_map_name
 	if is_new_chunk(): # This chunk is created for the first time
 		#This contains the data of one map, loaded from maps.data, for example generichouse.json
 		var mapsegmentData: Dictionary = Gamedata.maps.by_id(chunk_data.id).get_data().duplicate(true)

--- a/Scripts/Helper.gd
+++ b/Scripts/Helper.gd
@@ -3,6 +3,7 @@ extends Node3D
 # Contains the navigationmap for each chunk, used to give mobs the proper navigationmap
 # When crossing chunk boundary
 var chunk_navigation_maps: Dictionary = {}
+var test_map_name: String # Used for testing in the test_environment
 
 # Overmap data
 var position_coord: Vector2 = Vector2(0, 0)

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -37,7 +37,7 @@ var knockback_distance_remaining: float = 0.0
 
 @export var sprite : Sprite3D
 @export var collision_detector : Area3D # Used for detecting collision with furniture
-
+@export var testing: bool = false # Used to test in the test_environment
 @export var interact_range : float = 10
 
 #@export var progress_bar : NodePath
@@ -63,7 +63,8 @@ func _ready():
 	Helper.save_helper.load_player_state(self)
 	Helper.save_helper.load_quest_state()
 	_connect_signals()
-	Helper.signal_broker.player_spawned.emit(self)
+	if not testing:
+		Helper.signal_broker.player_spawned.emit(self)
 
 
 # Connect necessary signals for interaction and updates

--- a/test_environment.gd
+++ b/test_environment.gd
@@ -1,0 +1,26 @@
+extends Node3D
+
+@export var canvas_layer: CanvasLayer = null
+
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(_delta):
+	if Input.is_action_just_pressed("escape"):
+		canvas_layer.show()
+
+
+# The user pressed the return button, we go to the contenteditor
+func _on_return_button_button_up() -> void:
+	Helper.test_map_name = "" # Reset this before returning otherwise the main game will be in trouble
+	get_tree().change_scene_to_file("res://Scenes/ContentManager/contenteditor.tscn")
+
+
+# The user presses the resume button, hide the window
+func _on_resume_button_button_up() -> void:
+	canvas_layer.hide()

--- a/test_environment.tscn
+++ b/test_environment.tscn
@@ -1,0 +1,234 @@
+[gd_scene load_steps=26 format=3 uid="uid://by4k08jqt2qal"]
+
+[ext_resource type="Script" path="res://Scripts/Chunk.gd" id="1_hp7uo"]
+[ext_resource type="Script" path="res://test_environment.gd" id="1_vhsh0"]
+[ext_resource type="Script" path="res://Scripts/player.gd" id="2_djsnx"]
+[ext_resource type="Script" path="res://Scripts/Camera.gd" id="3_m8tfq"]
+[ext_resource type="PackedScene" uid="uid://bwlxjl00td75p" path="res://spot_light_3d.tscn" id="4_4b0kv"]
+[ext_resource type="PackedScene" uid="uid://r0oar0ocyo6v" path="res://spot_light_3d_2.tscn" id="5_7f1m0"]
+[ext_resource type="Texture2D" uid="uid://d33h00t0fl7x" path="res://Defaults/Player/VestDude01.png" id="6_bmb7i"]
+[ext_resource type="Texture2D" uid="uid://piolgplta87y" path="res://Defaults/Player/weapon_left.png" id="7_lus3f"]
+[ext_resource type="Script" path="res://Scripts/EquippedItem.gd" id="8_uyqga"]
+[ext_resource type="PackedScene" uid="uid://kf2d2vvgh7l0" path="res://Defaults/Projectiles/DefaultBullet.tscn" id="9_3ns7a"]
+[ext_resource type="AudioStream" uid="uid://gdwwxc0yvg5g" path="res://Sounds/Weapons/Shooting/pistol_shot.wav" id="10_naftw"]
+[ext_resource type="Texture2D" uid="uid://delyq5g2t13cx" path="res://Defaults/Player/weapon_right.png" id="11_30vkt"]
+[ext_resource type="PackedScene" uid="uid://c6txt3py4smbb" path="res://front_light.tscn" id="12_few2t"]
+[ext_resource type="Script" path="res://Scripts/PlayerShooting.gd" id="13_mey1o"]
+[ext_resource type="AudioStream" uid="uid://cfmgnsm10aj4i" path="res://Sounds/Weapons/Reloading/pistol_reload_sound.mp3" id="14_qra48"]
+[ext_resource type="Script" path="res://Scripts/ItemDetector.gd" id="15_vfagn"]
+[ext_resource type="Script" path="res://Scripts/Components/ComponentInteract.gd" id="16_2adj1"]
+[ext_resource type="Script" path="res://LevelManager.gd" id="17_akyhy"]
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_oq8au"]
+albedo_color = Color(0, 1, 0, 1)
+
+[sub_resource type="BoxMesh" id="BoxMesh_63elu"]
+size = Vector3(0.3, 1, 0.55)
+
+[sub_resource type="ConvexPolygonShape3D" id="ConvexPolygonShape3D_0rk2n"]
+points = PackedVector3Array(0.15, 0.15, 0.275, -0.15, 0.15, 0.275, 0.15, -0.5, 0.275, 0.15, 0.15, -0.275, -0.15, 0.15, -0.275, -0.15, -0.5, 0.275, 0.15, -0.5, -0.275, -0.15, -0.5, -0.275)
+
+[sub_resource type="AudioStreamRandomizer" id="AudioStreamRandomizer_mjfg7"]
+playback_mode = 1
+random_pitch = 1.2
+streams_count = 1
+stream_0/stream = ExtResource("10_naftw")
+
+[sub_resource type="AudioStreamRandomizer" id="AudioStreamRandomizer_ikrwj"]
+playback_mode = 1
+random_pitch = 1.2
+
+[sub_resource type="ConvexPolygonShape3D" id="ConvexPolygonShape3D_qtql3"]
+points = PackedVector3Array(0, 0, 0.325, -1, -1, 0.325, -1, 1, 0.325, 0, 0, -0.325, -1, -1, -0.325, -1, 1, -0.325)
+
+[sub_resource type="CylinderShape3D" id="CylinderShape3D_yag6m"]
+height = 1.0
+radius = 1.5
+
+[node name="TestEnvironment" type="Node3D" node_paths=PackedStringArray("canvas_layer")]
+script = ExtResource("1_vhsh0")
+canvas_layer = NodePath("CanvasLayer")
+
+[node name="Chunk" type="Node3D" parent="." node_paths=PackedStringArray("level_manager")]
+script = ExtResource("1_hp7uo")
+level_manager = NodePath("../LevelManager")
+
+[node name="Player" type="CharacterBody3D" parent="." node_paths=PackedStringArray("sprite", "collision_detector") groups=["Players"]]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 15)
+collision_mask = 22
+floor_constant_speed = true
+floor_max_angle = 0.872665
+script = ExtResource("2_djsnx")
+sprite = NodePath("Sprite3D2")
+collision_detector = NodePath("Sprite3D2/CollisionDetector")
+testing = true
+
+[node name="Camera3D" type="Camera3D" parent="Player" groups=["Camera"]]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 19, 0)
+current = true
+size = 50.0
+script = ExtResource("3_m8tfq")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Player"]
+visible = false
+material_override = SubResource("StandardMaterial3D_oq8au")
+mesh = SubResource("BoxMesh_63elu")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Player"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.100794, 0)
+shape = SubResource("ConvexPolygonShape3D_0rk2n")
+
+[node name="OmniLight3D" type="OmniLight3D" parent="Player"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.17078, 0)
+visible = false
+shadow_enabled = true
+omni_range = 18.071
+omni_attenuation = 0.0371628
+
+[node name="SpotLight3D" parent="Player" instance=ExtResource("4_4b0kv")]
+
+[node name="SpotLight3D2" parent="Player" instance=ExtResource("5_7f1m0")]
+
+[node name="Sprite3D2" type="Sprite3D" parent="Player"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.277026, 0)
+pixel_size = 0.003
+render_priority = 15
+texture = ExtResource("6_bmb7i")
+
+[node name="EquippedRight" type="Sprite3D" parent="Player/Sprite3D2" node_paths=PackedStringArray("attack_cooldown_timer", "melee_attack_area", "melee_collision_shape", "player", "playerSprite", "shoot_audio_player", "reload_audio_player")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.190849, -0.123334, 0)
+pixel_size = 0.002
+render_priority = 15
+texture = ExtResource("7_lus3f")
+script = ExtResource("8_uyqga")
+bullet_speed = 25.0
+bullet_damage = 25.0
+bullet_scene = ExtResource("9_3ns7a")
+attack_cooldown_timer = NodePath("../../Shooting/Right_attack_cooldown")
+melee_attack_area = NodePath("../MeleeRange")
+melee_collision_shape = NodePath("../MeleeRange/MeleeCollisionShape3D")
+player = NodePath("../..")
+playerSprite = NodePath("..")
+hud = NodePath("../../../../../HUD")
+shoot_audio_player = NodePath("../../Shooting/ShootAudio")
+shoot_audio_randomizer = SubResource("AudioStreamRandomizer_mjfg7")
+reload_audio_player = NodePath("../../Shooting/ReloadAudio")
+
+[node name="EquippedLeft" type="Sprite3D" parent="Player/Sprite3D2" node_paths=PackedStringArray("attack_cooldown_timer", "melee_attack_area", "melee_collision_shape", "player", "playerSprite", "shoot_audio_player", "reload_audio_player")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.194626, 0.116675, 0)
+pixel_size = 0.002
+render_priority = 15
+texture = ExtResource("11_30vkt")
+script = ExtResource("8_uyqga")
+bullet_speed = 25.0
+bullet_damage = 25.0
+bullet_scene = ExtResource("9_3ns7a")
+attack_cooldown_timer = NodePath("../../Shooting/Left_attack_cooldown")
+melee_attack_area = NodePath("../MeleeRange")
+melee_collision_shape = NodePath("../MeleeRange/MeleeCollisionShape3D")
+player = NodePath("../..")
+playerSprite = NodePath("..")
+hud = NodePath("../../../../../HUD")
+equipped_left = true
+shoot_audio_player = NodePath("../../Shooting/ShootAudio")
+shoot_audio_randomizer = SubResource("AudioStreamRandomizer_ikrwj")
+reload_audio_player = NodePath("../../Shooting/ReloadAudio")
+
+[node name="MeleeRange" type="Area3D" parent="Player/Sprite3D2"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, -0.277026)
+collision_mask = 14
+
+[node name="MeleeCollisionShape3D" type="CollisionShape3D" parent="Player/Sprite3D2/MeleeRange"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.277026, 0)
+shape = SubResource("ConvexPolygonShape3D_qtql3")
+
+[node name="CollisionDetector" type="Area3D" parent="Player/Sprite3D2"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, -0.00202602)
+collision_mask = 8
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Player/Sprite3D2/CollisionDetector"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.179206, 0)
+shape = SubResource("ConvexPolygonShape3D_0rk2n")
+
+[node name="FrontLight" parent="Player/Sprite3D2" instance=ExtResource("12_few2t")]
+
+[node name="Shooting" type="Node3D" parent="Player" node_paths=PackedStringArray("left_hand_item", "right_hand_item")]
+script = ExtResource("13_mey1o")
+left_hand_item = NodePath("../Sprite3D2/EquippedLeft")
+right_hand_item = NodePath("../Sprite3D2/EquippedRight")
+player = NodePath("..")
+hud = NodePath("../../../../HUD")
+
+[node name="Left_attack_cooldown" type="Timer" parent="Player/Shooting"]
+one_shot = true
+
+[node name="Right_attack_cooldown" type="Timer" parent="Player/Shooting"]
+one_shot = true
+
+[node name="ShootAudio" type="AudioStreamPlayer3D" parent="Player/Shooting"]
+stream = ExtResource("10_naftw")
+bus = &"Sounds"
+
+[node name="ReloadAudio" type="AudioStreamPlayer3D" parent="Player/Shooting"]
+stream = ExtResource("14_qra48")
+bus = &"Sounds"
+
+[node name="ItemDetector" type="Area3D" parent="Player" node_paths=PackedStringArray("playernode")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1.1205, 0)
+collision_layer = 64
+collision_mask = 64
+script = ExtResource("15_vfagn")
+playernode = NodePath("..")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Player/ItemDetector"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.792087, 0)
+shape = SubResource("CylinderShape3D_yag6m")
+
+[node name="ComponentInteract" type="Node3D" parent="Player"]
+script = ExtResource("16_2adj1")
+
+[node name="LevelManager" type="Node3D" parent="."]
+script = ExtResource("17_akyhy")
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+visible = false
+
+[node name="ColorRect" type="ColorRect" parent="CanvasLayer"]
+anchors_preset = -1
+anchor_left = 0.37
+anchor_top = 0.315
+anchor_right = 0.635
+anchor_bottom = 0.65
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.129412, 0.14902, 0.180392, 1)
+
+[node name="VBoxContainer" type="VBoxContainer" parent="CanvasLayer"]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -94.5
+offset_top = -42.5
+offset_right = 94.5
+offset_bottom = 42.5
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="ResumeButton" type="Button" parent="CanvasLayer/VBoxContainer"]
+layout_mode = 2
+text = "Resume"
+
+[node name="ReturnButton" type="Button" parent="CanvasLayer/VBoxContainer"]
+layout_mode = 2
+text = "Return to content editor"
+
+[connection signal="timeout" from="Player/Shooting/Left_attack_cooldown" to="Player/Sprite3D2/EquippedLeft" method="_on_left_attack_cooldown_timeout"]
+[connection signal="timeout" from="Player/Shooting/Right_attack_cooldown" to="Player/Sprite3D2/EquippedRight" method="_on_right_attack_cooldown_timeout"]
+[connection signal="area_entered" from="Player/ItemDetector" to="Player/ItemDetector" method="_on_area_entered"]
+[connection signal="area_exited" from="Player/ItemDetector" to="Player/ItemDetector" method="_on_area_exited"]
+[connection signal="body_shape_entered" from="Player/ItemDetector" to="Player/ItemDetector" method="_on_body_shape_entered"]
+[connection signal="body_shape_exited" from="Player/ItemDetector" to="Player/ItemDetector" method="_on_body_shape_exited"]
+[connection signal="button_up" from="CanvasLayer/VBoxContainer/ResumeButton" to="." method="_on_resume_button_button_up"]
+[connection signal="button_up" from="CanvasLayer/VBoxContainer/ReturnButton" to="." method="_on_return_button_button_up"]


### PR DESCRIPTION
As requested by Khaligufzel, a way to quickly test a map in-game. 

Adds a `save & test` button to the map editor that will send you to the test environment and load the map you were editing. This testenvironment has the bare minimum. Some lights, the chunk representing the map and player movement. There is no inventory, overmap or any UI except for a menu to return to the content editor. You will have to open the map again to continue editing.

It may be improved in some ways:
- Being able to test it without saving the map beforehand
- Returning to the contenteditor with the map opened again so you can continue editing.
- Add the inventory window to the testing environment so you can check containers.