### PR TITLE
Add overmap grid visualization to menu

### DIFF
--- a/Scenes/ContentManager/OtherTools/Scripts/overmap_grid_visualization.gd
+++ b/Scenes/ContentManager/OtherTools/Scripts/overmap_grid_visualization.gd
@@ -38,3 +38,7 @@ func generate_grid():
 			else:
 				# If no tile exists at the current position, set texture to null
 				tile_instance.set_texture(null)
+
+
+func _on_back_button_button_up() -> void:
+	get_tree().change_scene_to_file("res://Scenes/ContentManager/othertools.tscn")

--- a/Scenes/ContentManager/OtherTools/overmap_grid_visualization.tscn
+++ b/Scenes/ContentManager/OtherTools/overmap_grid_visualization.tscn
@@ -25,10 +25,16 @@ grow_vertical = 2
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
 layout_mode = 2
 
+[node name="BackButton" type="Button" parent="VBoxContainer/HBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 24
+text = "Back"
+
 [node name="GenerateButton" type="Button" parent="VBoxContainer/HBoxContainer"]
 custom_minimum_size = Vector2(0, 60)
 layout_mode = 2
 size_flags_horizontal = 3
+theme_override_font_sizes/font_size = 24
 text = "Generate"
 
 [node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer"]
@@ -40,4 +46,5 @@ layout_mode = 2
 size_flags_horizontal = 0
 columns = 20
 
+[connection signal="button_up" from="VBoxContainer/HBoxContainer/BackButton" to="." method="_on_back_button_button_up"]
 [connection signal="button_up" from="VBoxContainer/HBoxContainer/GenerateButton" to="." method="_on_generate_button_button_up"]

--- a/Scenes/ContentManager/Scripts/contentmanager.gd
+++ b/Scenes/ContentManager/Scripts/contentmanager.gd
@@ -11,3 +11,7 @@ func _on_content_editor_button_button_up():
 
 func _on_mod_manager_button_button_up():
 	get_tree().change_scene_to_file("res://Scenes/ContentManager/modmanager.tscn")
+
+
+func _on_other_tools_button_button_up() -> void:
+	get_tree().change_scene_to_file("res://Scenes/ContentManager/othertools.tscn")

--- a/Scenes/ContentManager/Scripts/othertools.gd
+++ b/Scenes/ContentManager/Scripts/othertools.gd
@@ -1,0 +1,9 @@
+extends Control
+
+
+func _on_back_button_button_up() -> void:
+	get_tree().change_scene_to_file("res://Scenes/ContentManager/contentmanager.tscn")
+
+
+func _on_overmap_visualisation_button_button_up() -> void:
+	get_tree().change_scene_to_file("res://Scenes/ContentManager/OtherTools/overmap_grid_visualization.tscn")

--- a/Scenes/ContentManager/contentmanager.tscn
+++ b/Scenes/ContentManager/contentmanager.tscn
@@ -35,6 +35,11 @@ layout_mode = 2
 theme_override_font_sizes/font_size = 36
 text = "Content editor"
 
+[node name="OtherToolsButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 36
+text = "Other Tools"
+
 [node name="BackButton" type="Button" parent="VBoxContainer"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 36
@@ -42,4 +47,5 @@ text = "Back"
 
 [connection signal="button_up" from="VBoxContainer/ModManagerButton" to="." method="_on_mod_manager_button_button_up"]
 [connection signal="button_up" from="VBoxContainer/ContentEditorButton" to="." method="_on_content_editor_button_button_up"]
+[connection signal="button_up" from="VBoxContainer/OtherToolsButton" to="." method="_on_other_tools_button_button_up"]
 [connection signal="button_up" from="VBoxContainer/BackButton" to="." method="_on_back_button_button_up"]

--- a/Scenes/ContentManager/othertools.tscn
+++ b/Scenes/ContentManager/othertools.tscn
@@ -1,0 +1,39 @@
+[gd_scene load_steps=2 format=3 uid="uid://d2jn8nd57qmfk"]
+
+[ext_resource type="Script" path="res://Scenes/ContentManager/Scripts/othertools.gd" id="1_wv57c"]
+
+[node name="othertools" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_wv57c")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -60.5
+offset_top = -33.0
+offset_right = 60.5
+offset_bottom = 33.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="OvermapVisualisationButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 36
+text = "Overmap visualizer"
+
+[node name="BackButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 36
+text = "Back"
+
+[connection signal="button_up" from="VBoxContainer/OvermapVisualisationButton" to="." method="_on_overmap_visualisation_button_button_up"]
+[connection signal="button_up" from="VBoxContainer/BackButton" to="." method="_on_back_button_button_up"]


### PR DESCRIPTION
The overmap grid visualization was a separate scene not connected trough the menus. I added it to "other tools" in the "content manager".

I was trying to figure out why it's so slow in generating the grid, but I haven't been able to solve it. The grid data only takes a second, but visualizing it to 10000 tiles is taking about a minute. We would need to do something similar to what the overmap window does, chunking the parts and visualizing a few at a time.