### PR TITLE
Spawn tacticalmaps outside radius from start position

### DIFF
--- a/Mods/Core/Maps/Generichouse_00.json
+++ b/Mods/Core/Maps/Generichouse_00.json
@@ -471,7 +471,8 @@
 	"categories": [
 		"House",
 		"City",
-		"Suburban"
+		"Suburban",
+		"Urban"
 	],
 	"connections": {
 		"east": "road",

--- a/Mods/Core/Maps/neighborhood_school.json
+++ b/Mods/Core/Maps/neighborhood_school.json
@@ -524,7 +524,8 @@
 	"categories": [
 		"House",
 		"City",
-		"Suburban"
+		"Suburban",
+		"Urban"
 	],
 	"connections": {
 		"east": "ground",

--- a/Mods/Core/Maps/radio_tower.json
+++ b/Mods/Core/Maps/radio_tower.json
@@ -193,7 +193,7 @@
 	],
 	"categories": [
 		"Infrastructure",
-		"Road"
+		"Urban"
 	],
 	"connections": {
 		"east": "ground",

--- a/Mods/Core/Maps/two_story_house.json
+++ b/Mods/Core/Maps/two_story_house.json
@@ -451,7 +451,8 @@
 	"categories": [
 		"Infrastructure",
 		"House",
-		"Suburban"
+		"Suburban",
+		"Urban"
 	],
 	"connections": {
 		"east": "road",


### PR DESCRIPTION
Makes sure that tacticalmaps spawn outside a radius of 15 from (0,0). This was needed since I put all the robots on it and it was dangerously closed to the player spawn.

We might expand on this and specify a radius per tacticalmap. The overmapareas are still unrestricted, so the player could spawn next to a city.

Also added the "urban" category to some maps. This prevents them from being replaced during the road generation between cities.