### PR TITLE
Fixed a bug where pressing "return to main menu" multiple times leads to a crash in game over scene.

### DIFF
--- a/Scripts/GameOver.gd
+++ b/Scripts/GameOver.gd
@@ -1,9 +1,12 @@
 extends Control
 
 
+var is_button_pressed: bool = false
 # This script belongs to the Gameover window that shows in-game when the player is defeated
 
 # When the player presses the 'return to main menu' button
 func _on_return_button_button_up():
-	Helper.signal_broker.game_terminated.emit()
-	Helper.exit_game()
+	if is_button_pressed == false:
+		is_button_pressed = true
+		Helper.signal_broker.game_terminated.emit()
+		Helper.exit_game()


### PR DESCRIPTION
Fixes #439. 

Initially, when the player was dead, you could press "return to main menu" multiple times which led to a crash (Cannot call method 'queue_free' on a null value.). Now It is fixed using a simple boolean variable. Tested multiple times within the game, no issues whatsoever.

Note: the button can still be pressed multiple times, however it won't lead to the crash.