### PR TITLE
Add Mob groups to quest

### DIFF
--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="ItemProtoset" load_steps=2 format=3]
+[gd_resource type="Resource" script_class="ItemProtoset" load_steps=2 format=3 uid="uid://bxubu34gjes1y"]
 
 [ext_resource type="Script" path="res://addons/gloot/core/item_protoset.gd" id="1_o35lu"]
 

--- a/Mods/Core/Mobgroups/Mobgroups.json
+++ b/Mods/Core/Mobgroups/Mobgroups.json
@@ -1,0 +1,11 @@
+[
+	{
+		"description": "A group of basic zombies, representing a minor threat to the player",
+		"id": "basic_zombies",
+		"mobs": {
+			"basic_zombie_1": 100
+		},
+		"name": "Basic zombies",
+		"spriteid": "zombie_64_64.png"
+	}
+]

--- a/Mods/Core/Mobgroups/Mobgroups.json
+++ b/Mods/Core/Mobgroups/Mobgroups.json
@@ -13,6 +13,13 @@
 			"skeleton_zombie": 10
 		},
 		"name": "Basic zombies",
+		"references": {
+			"core": {
+				"quests": [
+					"starter_tutorial_00"
+				]
+			}
+		},
 		"spriteid": "zombie_64_64.png"
 	}
 ]

--- a/Mods/Core/Mobgroups/Mobgroups.json
+++ b/Mods/Core/Mobgroups/Mobgroups.json
@@ -3,7 +3,14 @@
 		"description": "A group of basic zombies, representing a minor threat to the player",
 		"id": "basic_zombies",
 		"mobs": {
-			"basic_zombie_1": 100
+			"basic_zombie_1": 100,
+			"basic_zombie_2": 100,
+			"bloated_zombie": 50,
+			"charred_zombie": 10,
+			"heavy_zombie": 50,
+			"limping_zombie": 25,
+			"rushing_zombie": 25,
+			"skeleton_zombie": 10
 		},
 		"name": "Basic zombies",
 		"spriteid": "zombie_64_64.png"

--- a/Mods/Core/Mobs/Mobs.json
+++ b/Mods/Core/Mobs/Mobs.json
@@ -392,7 +392,7 @@
 					"basic_zombies"
 				],
 				"quests": [
-					"starter_tutorial_00"
+					"quest_holy_crusade_01"
 				]
 			}
 		},

--- a/Mods/Core/Mobs/Mobs.json
+++ b/Mods/Core/Mobs/Mobs.json
@@ -388,6 +388,9 @@
 					"generichouse_corner",
 					"store_electronic_clothing"
 				],
+				"mobgroups": [
+					"basic_zombies"
+				],
 				"quests": [
 					"starter_tutorial_00",
 					"store_electronic_clothing",

--- a/Mods/Core/Mobs/Mobs.json
+++ b/Mods/Core/Mobs/Mobs.json
@@ -392,10 +392,7 @@
 					"basic_zombies"
 				],
 				"quests": [
-					"starter_tutorial_00",
-					"store_electronic_clothing",
-					"store_groceries",
-					"quest_holy_crusade_01"
+					"starter_tutorial_00"
 				]
 			}
 		},
@@ -466,6 +463,9 @@
 					"generichouse_corner",
 					"store_electronic_clothing",
 					"store_groceries"
+				],
+				"mobgroups": [
+					"basic_zombies"
 				]
 			}
 		},
@@ -536,6 +536,9 @@
 					"generichouse_t",
 					"generichouse_corner",
 					"store_electronic_clothing"
+				],
+				"mobgroups": [
+					"basic_zombies"
 				],
 				"quests": [
 					"quest_holy_crusade_01"
@@ -609,6 +612,9 @@
 					"generichouse_t",
 					"generichouse_corner",
 					"store_electronic_clothing"
+				],
+				"mobgroups": [
+					"basic_zombies"
 				],
 				"quests": [
 					"quest_holy_crusade_01"
@@ -689,6 +695,9 @@
 					"generichouse_t",
 					"generichouse_corner",
 					"store_electronic_clothing"
+				],
+				"mobgroups": [
+					"basic_zombies"
 				]
 			}
 		},
@@ -759,6 +768,9 @@
 					"generichouse_t",
 					"generichouse_corner",
 					"store_electronic_clothing"
+				],
+				"mobgroups": [
+					"basic_zombies"
 				],
 				"quests": [
 					"quest_holy_crusade_01"
@@ -833,6 +845,9 @@
 					"generichouse_corner",
 					"store_electronic_clothing"
 				],
+				"mobgroups": [
+					"basic_zombies"
+				],
 				"quests": [
 					"quest_holy_crusade_01"
 				]
@@ -905,6 +920,9 @@
 					"generichouse_t",
 					"generichouse_corner",
 					"store_electronic_clothing"
+				],
+				"mobgroups": [
+					"basic_zombies"
 				]
 			}
 		},

--- a/Mods/Core/Quests/Quests.json
+++ b/Mods/Core/Quests/Quests.json
@@ -142,7 +142,7 @@
 			{
 				"amount": 30,
 				"map_guide": "none",
-				"mob": "basic_zombie_1",
+				"mobgroup": "basic_zombies",
 				"type": "kill"
 			},
 			{

--- a/Mods/Core/Quests/Quests.json
+++ b/Mods/Core/Quests/Quests.json
@@ -31,7 +31,7 @@
 			{
 				"amount": 2,
 				"map_guide": "revealed",
-				"mob": "basic_zombie_1",
+				"mobgroup": "basic_zombies",
 				"tip": "The map will show you where to find them and update the target if there's no zombie there.",
 				"type": "kill"
 			},
@@ -142,7 +142,7 @@
 			{
 				"amount": 30,
 				"map_guide": "none",
-				"mobgroup": "basic_zombies",
+				"mob": "basic_zombie_1",
 				"type": "kill"
 			},
 			{

--- a/Scenes/ContentManager/Custom_Editors/MobgroupsEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/MobgroupsEditor.tscn
@@ -93,7 +93,7 @@ size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.1
 focus_next = NodePath("../DescriptionTextEdit")
 focus_previous = NodePath("../MobGroupImageDisplay")
-placeholder_text = "Perception"
+placeholder_text = "Basic zombies"
 
 [node name="DescriptionLabel" type="Label" parent="VBoxContainer/FormGrid"]
 layout_mode = 2
@@ -105,7 +105,7 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 size_flags_stretch_ratio = 0.9
 focus_previous = NodePath("../NameTextEdit")
-placeholder_text = "Your ability to observe the environment"
+placeholder_text = "A group of basic zombies, representing a minor threat to the player"
 wrap_mode = 1
 
 [node name="ItemsLabel" type="Label" parent="VBoxContainer/FormGrid"]
@@ -114,6 +114,8 @@ text = "Mobs"
 
 [node name="PanelContainer" type="PanelContainer" parent="VBoxContainer/FormGrid"]
 layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
 mouse_filter = 1
 theme_override_styles/panel = SubResource("StyleBoxFlat_3w4h5")
 
@@ -127,13 +129,14 @@ custom_minimum_size = Vector2(600, 200)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
-tooltip_text = "Drag items to this list from the left menu of the content editor. Once the list has been made, you can assign it to a container, for example in the furniture editor."
-columns = 6
+tooltip_text = "Drag mobs to this list from the left menu of the content editor. Once the list
+has been made, you can assign this group to a quest, in the quest editor."
+columns = 4
 
 [node name="Sprite_selector" parent="." instance=ExtResource("3_hpi3t")]
 visible = false
 
 [connection signal="button_up" from="VBoxContainer/HBoxContainer/CloseButton" to="." method="_on_close_button_button_up"]
 [connection signal="button_up" from="VBoxContainer/HBoxContainer/SaveButton" to="." method="_on_save_button_button_up"]
-[connection signal="gui_input" from="VBoxContainer/FormGrid/MobGroupImageDisplay" to="." method="_on_stat_image_display_gui_input"]
+[connection signal="gui_input" from="VBoxContainer/FormGrid/MobGroupImageDisplay" to="." method="_on_mob_group_image_display_gui_input"]
 [connection signal="sprite_selected_ok" from="Sprite_selector" to="." method="_on_sprite_selector_sprite_selected_ok"]

--- a/Scenes/ContentManager/Custom_Editors/MobgroupsEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/MobgroupsEditor.tscn
@@ -1,0 +1,139 @@
+[gd_scene load_steps=5 format=3 uid="uid://bw14nfwdnu41d"]
+
+[ext_resource type="Script" path="res://Scenes/ContentManager/Custom_Editors/Scripts/MobgroupsEditor.gd" id="1_vrae5"]
+[ext_resource type="Texture2D" uid="uid://c8ragmxitca47" path="res://Scenes/ContentManager/Mapeditor/Images/emptyTile.png" id="2_sxhq2"]
+[ext_resource type="PackedScene" uid="uid://d1h1rpwt8f807" path="res://Scenes/ContentManager/Custom_Widgets/Sprite_Selector_Popup.tscn" id="3_hpi3t"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_3w4h5"]
+content_margin_left = 8.0
+content_margin_top = 8.0
+content_margin_right = 8.0
+content_margin_bottom = 8.0
+
+[node name="MobgroupsEditor" type="Control" node_paths=PackedStringArray("mobgroupImageDisplay", "IDTextLabel", "PathTextLabel", "NameTextEdit", "DescriptionTextEdit", "mobgroupSelector", "mob_list")]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_vrae5")
+mobgroupImageDisplay = NodePath("VBoxContainer/FormGrid/MobGroupImageDisplay")
+IDTextLabel = NodePath("VBoxContainer/FormGrid/IDTextLabel")
+PathTextLabel = NodePath("VBoxContainer/FormGrid/PathTextLabel")
+NameTextEdit = NodePath("VBoxContainer/FormGrid/NameTextEdit")
+DescriptionTextEdit = NodePath("VBoxContainer/FormGrid/DescriptionTextEdit")
+mobgroupSelector = NodePath("Sprite_selector")
+mob_list = NodePath("VBoxContainer/FormGrid/PanelContainer/ScrollContainer/MobList")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="CloseButton" type="Button" parent="VBoxContainer/HBoxContainer"]
+layout_mode = 2
+text = "Close"
+
+[node name="SaveButton" type="Button" parent="VBoxContainer/HBoxContainer"]
+layout_mode = 2
+text = "Save"
+
+[node name="FormGrid" type="GridContainer" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+columns = 2
+
+[node name="ImageLabel" type="Label" parent="VBoxContainer/FormGrid"]
+layout_mode = 2
+text = "Sprite:"
+
+[node name="MobGroupImageDisplay" type="TextureRect" parent="VBoxContainer/FormGrid"]
+custom_minimum_size = Vector2(128, 128)
+layout_mode = 2
+size_flags_horizontal = 0
+size_flags_stretch_ratio = 0.4
+texture = ExtResource("2_sxhq2")
+expand_mode = 3
+
+[node name="PathLabel" type="Label" parent="VBoxContainer/FormGrid"]
+layout_mode = 2
+text = "Sprite name"
+
+[node name="PathTextLabel" type="Label" parent="VBoxContainer/FormGrid"]
+custom_minimum_size = Vector2(0, 30)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.1
+
+[node name="IDLabel" type="Label" parent="VBoxContainer/FormGrid"]
+layout_mode = 2
+text = "ID:"
+
+[node name="IDTextLabel" type="Label" parent="VBoxContainer/FormGrid"]
+custom_minimum_size = Vector2(0, 30)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.1
+
+[node name="NameLabel" type="Label" parent="VBoxContainer/FormGrid"]
+layout_mode = 2
+text = "Name"
+
+[node name="NameTextEdit" type="TextEdit" parent="VBoxContainer/FormGrid"]
+custom_minimum_size = Vector2(0, 30)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.1
+focus_next = NodePath("../DescriptionTextEdit")
+focus_previous = NodePath("../MobGroupImageDisplay")
+placeholder_text = "Perception"
+
+[node name="DescriptionLabel" type="Label" parent="VBoxContainer/FormGrid"]
+layout_mode = 2
+text = "Description"
+
+[node name="DescriptionTextEdit" type="TextEdit" parent="VBoxContainer/FormGrid"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+size_flags_stretch_ratio = 0.9
+focus_previous = NodePath("../NameTextEdit")
+placeholder_text = "Your ability to observe the environment"
+wrap_mode = 1
+
+[node name="ItemsLabel" type="Label" parent="VBoxContainer/FormGrid"]
+layout_mode = 2
+text = "Mobs"
+
+[node name="PanelContainer" type="PanelContainer" parent="VBoxContainer/FormGrid"]
+layout_mode = 2
+mouse_filter = 1
+theme_override_styles/panel = SubResource("StyleBoxFlat_3w4h5")
+
+[node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer/FormGrid/PanelContainer"]
+custom_minimum_size = Vector2(600, 200)
+layout_mode = 2
+horizontal_scroll_mode = 0
+
+[node name="MobList" type="GridContainer" parent="VBoxContainer/FormGrid/PanelContainer/ScrollContainer"]
+custom_minimum_size = Vector2(600, 200)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+tooltip_text = "Drag items to this list from the left menu of the content editor. Once the list has been made, you can assign it to a container, for example in the furniture editor."
+columns = 6
+
+[node name="Sprite_selector" parent="." instance=ExtResource("3_hpi3t")]
+visible = false
+
+[connection signal="button_up" from="VBoxContainer/HBoxContainer/CloseButton" to="." method="_on_close_button_button_up"]
+[connection signal="button_up" from="VBoxContainer/HBoxContainer/SaveButton" to="." method="_on_save_button_button_up"]
+[connection signal="gui_input" from="VBoxContainer/FormGrid/MobGroupImageDisplay" to="." method="_on_stat_image_display_gui_input"]
+[connection signal="sprite_selected_ok" from="Sprite_selector" to="." method="_on_sprite_selector_sprite_selected_ok"]

--- a/Scenes/ContentManager/Custom_Editors/Scripts/MobgroupsEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/MobgroupsEditor.gd
@@ -65,7 +65,7 @@ func _on_save_button_button_up() -> void:
 	dmobgroup.name = NameTextEdit.text
 	dmobgroup.description = DescriptionTextEdit.text
 	dmobgroup.sprite = mobgroupImageDisplay.texture
-	dmobgroup.save_to_disk()
+	dmobgroup.changed(olddata)
 	data_changed.emit()
 	olddata = DMobgroup.new(dmobgroup.get_data().duplicate(true))
 
@@ -185,3 +185,8 @@ func save_mob_list_to_dmobgroup():
 		new_mobs[mob_id] = weight
 	
 	dmobgroup.mobs = new_mobs
+
+
+func _on_mob_group_image_display_gui_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton and event.pressed:
+		mobgroupSelector.show()

--- a/Scenes/ContentManager/Custom_Editors/Scripts/MobgroupsEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/MobgroupsEditor.gd
@@ -1,0 +1,187 @@
+extends Control
+
+# This scene is intended to be used inside the content editor
+# It is supposed to edit exactly one Mobgroup
+# It expects to save the data to a JSON file
+# To load data, provide the name of the mobgroup data file and an ID
+
+@export var mobgroupImageDisplay: TextureRect = null
+@export var IDTextLabel: Label = null
+@export var PathTextLabel: Label = null
+@export var NameTextEdit: TextEdit = null
+@export var DescriptionTextEdit: TextEdit = null
+@export var mobgroupSelector: Popup = null
+@export var mob_list: GridContainer = null
+
+
+# This signal will be emitted when the user presses the save button
+# This signal should alert Gamedata that the mobgroup data array should be saved to disk
+signal data_changed()
+
+var olddata: DMobgroup # Remember what the value of the data was before editing
+
+# The data that represents this mobgroup
+# The data is selected from the Gamedata.mobgroups
+# based on the ID that the user has selected in the content editor
+var dmobgroup: DMobgroup = null:
+	set(value):
+		dmobgroup = value
+		load_mobgroup_data()
+		mobgroupSelector.sprites_collection = Gamedata.mobgroups.sprites
+		olddata = DMobgroup.new(dmobgroup.get_data().duplicate(true))
+
+
+
+# Forward drag-and-drop functionality to the attributesGridContainer
+func _ready() -> void:
+	mob_list.set_drag_forwarding(Callable(), _can_drop_mob_data, _drop_mob_data)
+
+
+# This function updates the form based on the DMobgroup that has been loaded
+func load_mobgroup_data() -> void:
+	if mobgroupImageDisplay != null and dmobgroup.spriteid != "":
+		mobgroupImageDisplay.texture = dmobgroup.sprite
+		PathTextLabel.text = dmobgroup.spriteid
+	if IDTextLabel != null:
+		IDTextLabel.text = str(dmobgroup.id)
+	if NameTextEdit != null:
+		NameTextEdit.text = dmobgroup.name
+	if DescriptionTextEdit != null:
+		DescriptionTextEdit.text = dmobgroup.description
+	update_mob_list()
+
+# The editor is closed, destroy the instance
+# TODO: Check for unsaved changes
+func _on_close_button_button_up() -> void:
+	queue_free()
+
+# This function takes all data from the form elements and stores them in the DMobgroup instance
+# Since dmobgroup is a reference to an item in Gamedata.mobgroups
+# the central array for mobgroup data is updated with the changes as well
+# The function will signal to Gamedata that the data has changed and needs to be saved
+func _on_save_button_button_up() -> void:
+	save_mob_list_to_dmobgroup()
+	dmobgroup.spriteid = PathTextLabel.text
+	dmobgroup.name = NameTextEdit.text
+	dmobgroup.description = DescriptionTextEdit.text
+	dmobgroup.sprite = mobgroupImageDisplay.texture
+	dmobgroup.save_to_disk()
+	data_changed.emit()
+	olddata = DMobgroup.new(dmobgroup.get_data().duplicate(true))
+
+
+# When the mobgroupImageDisplay is clicked, the user will be prompted to select an image from 
+# "res://Mods/Core/Mobs/". The texture of the mobgroupImageDisplay will change to the selected image
+func _on_mobgroup_image_display_gui_input(event) -> void:
+	if event is InputEventMouseButton and event.pressed:
+		mobgroupSelector.show()
+
+func _on_sprite_selector_sprite_selected_ok(clicked_sprite) -> void:
+	var mobgroupTexture: Resource = clicked_sprite.get_texture()
+	mobgroupImageDisplay.texture = mobgroupTexture
+	PathTextLabel.text = mobgroupTexture.resource_path.get_file()
+
+
+# Refreshes the mob_list based on the dmobgroup data
+func update_mob_list():
+	# Clear all existing children in mob_list
+	while mob_list.get_child_count() > 0:
+		var child = mob_list.get_child(0)
+		mob_list.remove_child(child)
+		child.queue_free()
+	
+	add_header_row_to_mob_list()
+	
+	# Populate mob_list with data from dmobgroup.mobs
+	for mob_id in dmobgroup.mobs.keys():
+		var weight = dmobgroup.mobs[mob_id]
+		add_mob_entry(mob_id, weight)
+
+
+# Adds a new mob and its controls to the mob_list
+func add_mob_entry(mob_id: String, weight: int):
+	var mob_icon = TextureRect.new()
+	var mob_sprite = Gamedata.mobs.sprite_by_id(mob_id)
+	mob_icon.texture = mob_sprite
+	mob_icon.custom_minimum_size = Vector2(16, 16)
+
+	var mob_label = Label.new()
+	mob_label.text = mob_id
+
+	var weight_spinbox = SpinBox.new()
+	weight_spinbox.min_value = 1
+	weight_spinbox.max_value = 100
+	weight_spinbox.value = weight
+	weight_spinbox.step = 1
+	weight_spinbox.tooltip_text = "Assign the weight for this mob (1 to 100)."
+
+	var delete_button = Button.new()
+	delete_button.text = "X"
+	delete_button.button_up.connect(_on_delete_mob_button_pressed.bind(mob_id))
+
+	# Add components to GridContainer
+	mob_list.add_child(mob_icon)
+	mob_list.add_child(mob_label)
+	mob_list.add_child(weight_spinbox)
+	mob_list.add_child(delete_button)
+
+
+# Deletes the mob entry from mob_list
+func _on_delete_mob_button_pressed(mob_id: String):
+	var num_columns = mob_list.columns
+	var children_to_remove = []
+	
+	for i in range(mob_list.get_child_count()):
+		var child = mob_list.get_child(i)
+		if child is Label and child.text == mob_id:
+			var start_index = i - (i % num_columns)
+			for j in range(num_columns):
+				children_to_remove.append(mob_list.get_child(start_index + j))
+			break
+	
+	for child in children_to_remove:
+		mob_list.remove_child(child)
+		child.queue_free()
+	
+	# Remove mob from dmobgroup.mobs
+	dmobgroup.mobs.erase(mob_id)
+
+
+# Adds a header row to mob_list
+func add_header_row_to_mob_list():
+	var headers = ["Sprite", "Mob ID", "Weight", "Delete"]
+	for header_text in headers:
+		var header_label = Label.new()
+		header_label.text = header_text
+		header_label.set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER)
+		mob_list.add_child(header_label)
+
+
+# Checks if the dropped mob can be added to mob_list
+func _can_drop_mob_data(_newpos, data) -> bool:
+	if not data or not data.has("id"):
+		return false
+	var mob_id = data["id"]
+	return Gamedata.mobs.has_id(mob_id) and not dmobgroup.mobs.has(mob_id)
+
+
+# Handles mob data being dropped
+func _drop_mob_data(newpos, data) -> void:
+	if _can_drop_mob_data(newpos, data):
+		var mob_id = data["id"]
+		dmobgroup.mobs[mob_id] = 1  # Default weight is 1
+		add_mob_entry(mob_id, 1)
+
+
+# Save the mob data from mob_list into dmobgroup
+func save_mob_list_to_dmobgroup():
+	var new_mobs = {}
+	var num_columns = mob_list.columns
+	var num_children = mob_list.get_child_count()
+	
+	for i in range(4, num_children, num_columns):  # Skip header
+		var mob_id = mob_list.get_child(i + 1).text
+		var weight = mob_list.get_child(i + 2).get_value()
+		new_mobs[mob_id] = weight
+	
+	dmobgroup.mobs = new_mobs

--- a/Scenes/ContentManager/Custom_Editors/Scripts/QuestEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/QuestEditor.gd
@@ -103,10 +103,16 @@ func _on_save_button_button_up() -> void:
 			step["tip"] = (hbox.get_child(3) as TextEdit).text
 		elif step_type_label.text == "Kill:":
 			step["type"] = "kill"
-			step["mob"] = (hbox.get_child(1)).get_text()
+			var mob_or_group = (hbox.get_child(1)).get_text()
+			if Gamedata.mobs.has_id(mob_or_group):
+				step["mob"] = mob_or_group
+			elif Gamedata.mobgroups.has_id(mob_or_group):
+				step["mobgroup"] = mob_or_group
+			else:
+				print_debug("Invalid mob or mobgroup ID: " + mob_or_group)
 			step["amount"] = (hbox.get_child(2) as SpinBox).value
-			var reveal_option_button: OptionButton = hbox.get_child(3)
-			step["map_guide"] = reveal_option_button.get_item_text(reveal_option_button.selected)
+			var map_guide_option_button: OptionButton = hbox.get_child(3)
+			step["map_guide"] = map_guide_option_button.get_item_text(map_guide_option_button.selected)
 			step["tip"] = (hbox.get_child(4) as TextEdit).text
 		
 		# Remove "tip" key if it is empty
@@ -278,11 +284,11 @@ func add_kill_step(step: Dictionary) -> HBoxContainer:
 	label_instance.text = "Kill:"
 	hbox.add_child(label_instance)
 
-	# Add the dropable text edit for the mob ID
+	# Add the dropable text edit for the mob or mobgroup ID
 	var dropable_textedit_instance: HBoxContainer = dropabletextedit.instantiate()
-	dropable_textedit_instance.set_text(step["mob"])
+	dropable_textedit_instance.set_text(step.get("mob", step.get("mobgroup", "")))
 	dropable_textedit_instance.set_meta("step_type", "kill")
-	dropable_textedit_instance.myplaceholdertext = "Drop a mob from the left menu"
+	dropable_textedit_instance.myplaceholdertext = "Drop a mob or mobgroup from the left menu"
 	set_drop_functions(dropable_textedit_instance)
 	hbox.add_child(dropable_textedit_instance)
 
@@ -386,7 +392,7 @@ func entity_drop(dropped_data: Dictionary, texteditcontrol: HBoxContainer) -> vo
 			"craft", "collect":
 				valid_data = Gamedata.items.has_id(dropped_data["id"])
 			"kill":
-				valid_data = Gamedata.mobs.has_id(dropped_data["id"])
+				valid_data = Gamedata.mobs.has_id(dropped_data["id"]) or Gamedata.mobgroups.has_id(dropped_data["id"])
 			"enter":
 				valid_data = Gamedata.maps.has_id(dropped_data["id"])
 		
@@ -405,7 +411,7 @@ func can_entity_drop(dropped_data: Dictionary, texteditcontrol: HBoxContainer) -
 		"craft", "collect":
 			valid_data = Gamedata.items.has_id(dropped_data["id"])
 		"kill":
-			valid_data = Gamedata.mobs.has_id(dropped_data["id"])
+			valid_data = Gamedata.mobs.has_id(dropped_data["id"]) or Gamedata.mobgroups.has_id(dropped_data["id"])
 		"enter":
 			valid_data = Gamedata.maps.has_id(dropped_data["id"])
 	

--- a/Scenes/ContentManager/Scripts/contenteditor.gd
+++ b/Scenes/ContentManager/Scripts/contenteditor.gd
@@ -14,6 +14,7 @@ extends Control
 @export var questsEditor: PackedScene = null
 @export var playerattributesEditor: PackedScene = null
 @export var overmapareaEditor: PackedScene = null
+@export var mobgroupsEditor: PackedScene = null
 @export var content: VBoxContainer = null
 @export var tabContainer: TabContainer = null
 @export var type_selector_menu_button: MenuButton = null
@@ -34,6 +35,7 @@ func _ready():
 	load_content_list(Gamedata.ContentType.SKILLS, "Skills")
 	load_content_list(Gamedata.ContentType.QUESTS, "Quests")
 	load_content_list(Gamedata.ContentType.OVERMAPAREAS, "Overmap areas")
+	load_content_list(Gamedata.ContentType.MOBGROUPS, "Mob groups")
 	# Populate the type_selector_menu_button with items
 	populate_type_selector_menu_button()
 
@@ -77,7 +79,8 @@ func _on_content_item_activated(type: Gamedata.ContentType, itemID: String, list
 		Gamedata.ContentType.STATS: statsEditor,
 		Gamedata.ContentType.SKILLS: skillsEditor,
 		Gamedata.ContentType.QUESTS: questsEditor,
-		Gamedata.ContentType.OVERMAPAREAS: overmapareaEditor
+		Gamedata.ContentType.OVERMAPAREAS: overmapareaEditor,
+		Gamedata.ContentType.MOBGROUPS: mobgroupsEditor
 	}
 
 	instantiate_editor(type, itemID, editors[type], list)
@@ -155,6 +158,10 @@ func instantiate_editor(type: Gamedata.ContentType, itemID: String, newEditor: P
 			newContentEditor.dovermaparea = Gamedata.overmapareas.by_id(itemID)
 			newContentEditor.data_changed.connect(list.load_data)
 		
+		Gamedata.ContentType.MOBGROUPS:
+			newContentEditor.dmobgroup = Gamedata.mobgroups.by_id(itemID)
+			newContentEditor.data_changed.connect(list.load_data)
+		
 		_:
 			print("Unknown content type:", type)
 
@@ -172,7 +179,7 @@ func populate_type_selector_menu_button():
 	var headers = [
 		"Maps", "Tactical Maps", "Items", "Terrain Tiles", "Mobs", 
 		"Furniture", "Item Groups", "Player Attributes", "Wearable Slots", 
-		"Stats", "Skills", "Quests", "Overmap areas"
+		"Stats", "Skills", "Quests", "Overmap areas", "Mob groups"
 	]
 	
 	for i in headers.size():

--- a/Scenes/ContentManager/contenteditor.tscn
+++ b/Scenes/ContentManager/contenteditor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=3 uid="uid://480xqusluqrk"]
+[gd_scene load_steps=17 format=3 uid="uid://480xqusluqrk"]
 
 [ext_resource type="Script" path="res://Scenes/ContentManager/Scripts/contenteditor.gd" id="1_65sl4"]
 [ext_resource type="PackedScene" uid="uid://bhh0v7x4fjsgi" path="res://Scenes/ContentManager/content_list.tscn" id="2_4f21i"]
@@ -15,6 +15,7 @@
 [ext_resource type="PackedScene" uid="uid://b7k2j4d6wx4yy" path="res://Scenes/ContentManager/Custom_Editors/QuestEditor.tscn" id="13_gv2y0"]
 [ext_resource type="PackedScene" uid="uid://b07i30w3ey3aa" path="res://Scenes/ContentManager/Custom_Editors/PlayerAttributeEditor.tscn" id="14_uu117"]
 [ext_resource type="PackedScene" uid="uid://b3ggaal1e2obk" path="res://Scenes/ContentManager/Custom_Editors/OvermapAreaEditor.tscn" id="15_qbq5b"]
+[ext_resource type="PackedScene" uid="uid://bw14nfwdnu41d" path="res://Scenes/ContentManager/Custom_Editors/MobgroupsEditor.tscn" id="16_lrbdj"]
 
 [node name="contenteditor" type="Control" node_paths=PackedStringArray("content", "tabContainer", "type_selector_menu_button")]
 layout_mode = 3
@@ -38,6 +39,7 @@ skillsEditor = ExtResource("12_orpls")
 questsEditor = ExtResource("13_gv2y0")
 playerattributesEditor = ExtResource("14_uu117")
 overmapareaEditor = ExtResource("15_qbq5b")
+mobgroupsEditor = ExtResource("16_lrbdj")
 content = NodePath("HSplitContainer/ContentLists/TabContainer2/Content/ContentList")
 tabContainer = NodePath("HSplitContainer/TabContainer")
 type_selector_menu_button = NodePath("HSplitContainer/ContentLists/TabContainer2/Content/Toolbar/TypeSelectorMenuButton")

--- a/Scripts/Gamedata/DMobgroup.gd
+++ b/Scripts/Gamedata/DMobgroup.gd
@@ -112,10 +112,17 @@ func delete():
 	for mob in mobs.keys():
 		Gamedata.mobs.remove_reference(mob, "core", "mobgroups", id)
 
-# Retrieves the list of maps referenced by the mob group
+# Retrieves all maps associated with the mob group, including maps from its mobs.
 func get_maps() -> Array:
-	var mapsdata: Array = Helper.json_helper.get_nested_data(references, "core.maps")
-	return mapsdata if mapsdata else []
+	var unique_maps: Array = Helper.json_helper.get_nested_data(references, "core.maps") or []
+
+	# Collect maps from each mob in the group
+	for mob_id in mobs.keys():
+		var mob = Gamedata.mobs.by_id(mob_id)
+		if mob:
+			unique_maps = Helper.json_helper.merge_unique(unique_maps, mob.get_maps())
+	return unique_maps
+
 
 # Function to return an array of all mob IDs in the "mobs" property
 func get_mob_ids() -> Array[String]:
@@ -123,6 +130,7 @@ func get_mob_ids() -> Array[String]:
 	for mob_id in mobs.keys():
 		mob_ids.append(mob_id)
 	return mob_ids
+
 
 # Function to check if a specific mob ID exists in the "mobs" property
 func has_mob(mob_id: String) -> bool:

--- a/Scripts/Gamedata/DMobgroup.gd
+++ b/Scripts/Gamedata/DMobgroup.gd
@@ -114,7 +114,7 @@ func delete():
 
 # Retrieves all maps associated with the mob group, including maps from its mobs.
 func get_maps() -> Array:
-	var unique_maps: Array = Helper.json_helper.get_nested_data(references, "core.maps") or []
+	var unique_maps: Array = []
 
 	# Collect maps from each mob in the group
 	for mob_id in mobs.keys():

--- a/Scripts/Gamedata/DMobgroup.gd
+++ b/Scripts/Gamedata/DMobgroup.gd
@@ -1,0 +1,120 @@
+class_name DMobgroup
+extends RefCounted
+
+
+# There's a D in front of the class name to indicate this class only handles mob data, nothing more
+# This script is intended to be used inside the GameData autoload singleton
+# This script handles the data for one mobgroup. You can access it through Gamedata.mobgroups
+
+
+# Represents a mob group and its properties.
+# This script is used for handling mob group data within the GameData autoload singleton.
+# Example mob group JSON:
+# {
+# 	"id": "basic_zombies",
+# 	"name": "Basic zombies",
+# 	"description": "The default, basic zombies posing a low threat to the player",
+# 	"spriteid": "scrapwalker64.png",
+# 	"references": {
+# 		"core": {
+# 			"maps": [
+# 				"Generichouse",
+# 				"store_electronic_clothing"
+# 			]
+# 		}
+# 	},
+# 	"mobs": {
+# 		"basic_zombie_1": 100,
+# 		"basic_zombie_2": 100,
+# 		"limping_zombie": 25,
+# 		"fast_zombie": 10,
+# 		"heavy_zombie": 25
+# 	}
+# }
+
+# Properties defined in the JSON structure
+var id: String
+var name: String
+var description: String
+var spriteid: String
+var sprite: Texture
+var references: Dictionary = {}
+var mobs: Dictionary = {}  # Holds the list of mobs and their weights
+
+# Constructor to initialize mob group properties from a dictionary
+func _init(data: Dictionary):
+	id = data.get("id", "")
+	name = data.get("name", "")
+	description = data.get("description", "")
+	spriteid = data.get("spriteid", "")
+	references = data.get("references", {})
+	mobs = data.get("mobs", {})
+
+# Returns all properties of the mob group as a dictionary
+func get_data() -> Dictionary:
+	return {
+		"id": id,
+		"name": name,
+		"description": description,
+		"spriteid": spriteid,
+		"references": references,
+		"mobs": mobs
+	}
+
+# Removes the specified reference from the mob group's references
+func remove_reference(module: String, type: String, refid: String):
+	var changes_made = Gamedata.dremove_reference(references, module, type, refid)
+	if changes_made:
+		Gamedata.mobgroups.save_mobgroups_to_disk()
+
+# Adds a new reference to the mob group's references
+func add_reference(module: String, type: String, refid: String):
+	var changes_made = Gamedata.dadd_reference(references, module, type, refid)
+	if changes_made:
+		Gamedata.mobgroups.save_mobgroups_to_disk()
+
+# Handles changes to the mob group, such as updating references
+func changed(olddata: DMobgroup):
+	update_mob_references(olddata)
+	Gamedata.mobgroups.save_mobgroups_to_disk()
+
+# Updates references to mobs within the mob group
+func update_mob_references(olddata: DMobgroup):
+	var old_mobs = olddata.mobs.keys()
+	var new_mobs = mobs.keys()
+
+	# Remove old references not present in the new data
+	for old_mob in old_mobs:
+		if not new_mobs.has(old_mob):
+			Gamedata.mobs.remove_reference(old_mob, "core", "mobgroups", id)
+
+	# Add new references
+	for new_mob in new_mobs:
+		Gamedata.mobs.add_reference(new_mob, "core", "mobgroups", id)
+
+# Deletes the mob group, removing all its references
+func delete():
+	# Remove references to maps
+	var mapsdata: Array = Helper.json_helper.get_nested_data(references, "core.maps")
+	if mapsdata:
+		Gamedata.maps.remove_entity_from_selected_maps("mobgroup", id, mapsdata)
+
+	# Remove references to mobs
+	for mob in mobs.keys():
+		Gamedata.mobs.remove_reference(mob, "core", "mobgroups", id)
+
+# Retrieves the list of maps referenced by the mob group
+func get_maps() -> Array:
+	var mapsdata: Array = Helper.json_helper.get_nested_data(references, "core.maps")
+	return mapsdata if mapsdata else []
+
+# Function to return an array of all mob IDs in the "mobs" property
+func get_mob_ids() -> Array[String]:
+	var mob_ids: Array[String] = []
+	for mob_id in mobs.keys():
+		mob_ids.append(mob_id)
+	return mob_ids
+
+# Function to check if a specific mob ID exists in the "mobs" property
+func has_mob(mob_id: String) -> bool:
+	return mobs.has(mob_id)

--- a/Scripts/Gamedata/DMobgroup.gd
+++ b/Scripts/Gamedata/DMobgroup.gd
@@ -50,16 +50,25 @@ func _init(data: Dictionary):
 	references = data.get("references", {})
 	mobs = data.get("mobs", {})
 
+
 # Returns all properties of the mob group as a dictionary
 func get_data() -> Dictionary:
-	return {
+	var data: Dictionary = {
 		"id": id,
 		"name": name,
 		"description": description,
 		"spriteid": spriteid,
-		"references": references,
 		"mobs": mobs
 	}
+	if not references.is_empty():
+		data["references"] = references
+	return data
+
+
+# Method to save any changes to the stat back to disk
+func save_to_disk():
+	Gamedata.stats.save_stats_to_disk()
+
 
 # Removes the specified reference from the mob group's references
 func remove_reference(module: String, type: String, refid: String):

--- a/Scripts/Gamedata/DMobgroups.gd
+++ b/Scripts/Gamedata/DMobgroups.gd
@@ -1,0 +1,97 @@
+class_name DMobgroups
+extends RefCounted
+
+# There's a D in front of the class name to indicate this class only handles mob group data, nothing more
+# This script is intended to be used inside the GameData autoload singleton
+# This script handles the list of mob groups. You can access it through Gamedata.mobgroups
+
+var dataPath: String = "./Mods/Core/Mobgroups/Mobgroups.json"
+var spritePath: String = "./Mods/Core/Mobs/"
+var mobgroupdict: Dictionary = {}
+var sprites: Dictionary = {}
+
+func _init():
+	load_sprites()
+	load_mobgroups_from_disk()
+
+# Load all mob group data from disk into memory
+func load_mobgroups_from_disk() -> void:
+	var mobgrouplist: Array = Helper.json_helper.load_json_array_file(dataPath)
+	for mymobgroup in mobgrouplist:
+		var mobgroup: DMobgroup = DMobgroup.new(mymobgroup)
+		if mobgroup.spriteid:
+			mobgroup.sprite = sprites[mobgroup.spriteid]
+		mobgroupdict[mobgroup.id] = mobgroup
+
+# Loads sprites and assigns them to the proper dictionary
+func load_sprites() -> void:
+	var png_files: Array = Helper.json_helper.file_names_in_dir(spritePath, ["png"])
+	for png_file in png_files:
+		# Load the .png file as a texture
+		var texture := load(spritePath + png_file)
+		# Add the material to the dictionary
+		sprites[png_file] = texture
+
+func on_data_changed():
+	save_mobgroups_to_disk()
+
+# Saves all mob groups to disk
+func save_mobgroups_to_disk() -> void:
+	var save_data: Array = []
+	for mobgroup in mobgroupdict.values():
+		save_data.append(mobgroup.get_data())
+	Helper.json_helper.write_json_file(dataPath, JSON.stringify(save_data, "\t"))
+
+func get_all() -> Dictionary:
+	return mobgroupdict
+
+func duplicate_to_disk(mobgroupid: String, newmobgroupid: String) -> void:
+	var mobgroupdata: Dictionary = by_id(mobgroupid).get_data().duplicate(true)
+	# A duplicated mob group is brand new and can't already be referenced by something
+	# So we delete the references from the duplicated data if it is present
+	mobgroupdata.erase("references")
+	mobgroupdata.id = newmobgroupid
+	var newmobgroup: DMobgroup = DMobgroup.new(mobgroupdata)
+	mobgroupdict[newmobgroupid] = newmobgroup
+	save_mobgroups_to_disk()
+
+func add_new(newid: String) -> void:
+	var newmobgroup: DMobgroup = DMobgroup.new({"id": newid})
+	mobgroupdict[newmobgroup.id] = newmobgroup
+	save_mobgroups_to_disk()
+
+func delete_by_id(mobgroupid: String) -> void:
+	mobgroupdict[mobgroupid].delete()
+	mobgroupdict.erase(mobgroupid)
+	save_mobgroups_to_disk()
+
+func by_id(mobgroupid: String) -> DMobgroup:
+	return mobgroupdict[mobgroupid]
+
+func has_id(mobgroupid: String) -> bool:
+	return mobgroupdict.has(mobgroupid)
+
+# Returns the sprite of the mob group
+# mobgroupid: The id of the mob group to return the sprite of
+func sprite_by_id(mobgroupid: String) -> Texture:
+	return mobgroupdict[mobgroupid].sprite
+
+# Returns the sprite of the mob group
+# spritefile: The file of the sprite to return the sprite of
+func sprite_by_file(spritefile: String) -> Texture:
+	return sprites[spritefile]
+
+# Removes the reference from the selected mob group
+func remove_reference(mobgroupid: String, module: String, type: String, refid: String):
+	var mymobgroup: DMobgroup = mobgroupdict[mobgroupid]
+	mymobgroup.remove_reference(module, type, refid)
+
+# Adds a reference to the references list
+# For example, add "grass_field" to references.Core.maps
+# mobgroupid: The id of the mob group to add the reference to
+# module: the mod that the entity belongs to, for example "Core"
+# type: The type of entity, for example "maps"
+# refid: The id of the entity to reference, for example "grass_field"
+func add_reference(mobgroupid: String, module: String, type: String, refid: String):
+	var mymobgroup: DMobgroup = mobgroupdict[mobgroupid]
+	mymobgroup.add_reference(module, type, refid)

--- a/Scripts/Gamedata/DQuest.gd
+++ b/Scripts/Gamedata/DQuest.gd
@@ -92,18 +92,18 @@ func delete():
 func changed(olddata: DQuest):
 	var quest_id: String = id
 
-	# Get items and mobs from the old steps
+	# Get items, mobs, mobgroups, and maps from the old steps
 	var old_quest_items: Array = olddata.steps.filter(func(step): return step.has("item"))
 	var old_quest_mobs: Array = olddata.steps.filter(func(step): return step.has("mob"))
+	var old_quest_mobgroups: Array = olddata.steps.filter(func(step): return step.has("mobgroup"))
 	var old_quest_maps: Array = olddata.steps.filter(func(step): return step.has("map_id"))
-	# Get rewards from the old data
 	var old_quest_rewards: Array = olddata.rewards.filter(func(reward): return reward.has("item_id"))
 
-	# Get items and mobs from the new steps
+	# Get items, mobs, mobgroups, and maps from the new steps
 	var new_quest_items: Array = steps.filter(func(step): return step.has("item"))
 	var new_quest_mobs: Array = steps.filter(func(step): return step.has("mob"))
+	var new_quest_mobgroups: Array = steps.filter(func(step): return step.has("mobgroup"))
 	var new_quest_maps: Array = steps.filter(func(step): return step.has("map_id"))
-	# Get rewards from the new data
 	var new_quest_rewards: Array = rewards.filter(func(reward): return reward.has("item_id"))
 
 	# Remove references for old items and rewards that are not in the new data
@@ -124,6 +124,11 @@ func changed(olddata: DQuest):
 		if old_mob not in new_quest_mobs:
 			Gamedata.mobs.remove_reference(old_mob.mob, "core", "quests", quest_id)
 
+	# Remove references for old mobgroups that are not in the new data
+	for old_mobgroup in old_quest_mobgroups:
+		if old_mobgroup not in new_quest_mobgroups:
+			Gamedata.mobgroups.remove_reference(old_mobgroup.mobgroup, "core", "quests", quest_id)
+
 	# Add references for new items and rewards
 	for new_item in new_quest_items:
 		Gamedata.items.add_reference(new_item.item, "core", "quests", quest_id)
@@ -138,7 +143,12 @@ func changed(olddata: DQuest):
 	for new_mob in new_quest_mobs:
 		Gamedata.mobs.add_reference(new_mob.mob, "core", "quests", quest_id)
 
+	# Add references for new mobgroups
+	for new_mobgroup in new_quest_mobgroups:
+		Gamedata.mobgroups.add_reference(new_mobgroup.mobgroup, "core", "quests", quest_id)
+
 	save_to_disk()
+
 
 # Removes all steps where the mob property matches the given mob_id
 func remove_steps_by_mob(mob_id: String) -> void:

--- a/Scripts/QuestTrackerUI.gd
+++ b/Scripts/QuestTrackerUI.gd
@@ -15,17 +15,17 @@ func update_quest_ui(quest_name: String):
 	# Update the quest name label
 	var dquest: DQuest = Gamedata.quests.by_id(quest_name)
 	quest_name_label.text = dquest.name
-	
+
 	# Get the current step
 	var current_step = QuestManager.get_current_step(quest_name)
 	if current_step == null or current_step.is_empty():
 		hide_ui_elements()
 		return
-	
+
 	# Retrieve step requirement details
 	var step_type = current_step.get("step_type", "Unknown")
 	var step_requirement = ""
-	
+
 	match step_type:
 		QuestManager.INCREMENTAL_STEP:
 			var stepmeta: Dictionary = current_step.get("meta_data", {}).get("stepjson", {})
@@ -37,12 +37,19 @@ func update_quest_ui(quest_name: String):
 				var item_name = Gamedata.items.by_id(item_id).name if item_id != "" else "Unknown Item"
 				step_requirement = "Collect " + str(current_amount) + "/" + str(target_amount) + " " + item_name
 			elif stepmeta.get("type", "") == "kill":
-				var mob_id = stepmeta.get("mob", "")
-				var mob_name = Gamedata.mobs.by_id(mob_id).name if mob_id != "" else "Unknown Mob"
-				step_requirement = "Kill " + str(current_amount) + "/" + str(target_amount) + " " + mob_name
+				if stepmeta.has("mob"):
+					var mob_id = stepmeta["mob"]
+					var mob_name = Gamedata.mobs.by_id(mob_id).name if mob_id != "" else "Unknown Mob"
+					step_requirement = "Kill " + str(current_amount) + "/" + str(target_amount) + " " + mob_name
+				elif stepmeta.has("mobgroup"):
+					var mobgroup_id = stepmeta["mobgroup"]
+					var mobgroup_name = Gamedata.mobgroups.by_id(mobgroup_id).name if mobgroup_id != "" else "Unknown Mob Group"
+					step_requirement = "Kill " + str(current_amount) + "/" + str(target_amount) + " from " + mobgroup_name
+				else:
+					step_requirement = "Kill target not specified."
 			else:
 				step_requirement = "Progress: " + str(current_amount) + "/" + str(target_amount)
-				
+
 		QuestManager.ITEMS_STEP:
 			var items_required = current_step.get("required_items", {})
 			step_requirement = "Items needed: " + str(items_required)
@@ -50,9 +57,10 @@ func update_quest_ui(quest_name: String):
 			step_requirement = current_step.details
 		_:
 			step_requirement = "Objective unknown."
-	
+
 	# Update the quest step label
 	quest_target_label.text = step_requirement
+
 
 
 # Example call to update the UI with a specific quest

--- a/Scripts/QuestWindow.gd
+++ b/Scripts/QuestWindow.gd
@@ -276,11 +276,23 @@ func _handle_collect_step(step: Dictionary) -> String:
 # Function to handle the "kill" step type
 func _handle_kill_step(step: Dictionary) -> String:
 	var step_details_text = ""
-	# Retrieve mob data using the item name (ID) from the step
-	var dmob: DMob = Gamedata.mobs.by_id(step.item_name)
-	# Construct the step details text with the required and killed mob counts
-	step_details_text += "Kill " + str(step.required) + " "
-	step_details_text += dmob.name + " (Killed: " 
+	var step_meta = step.meta_data.get("stepjson", {})
+	
+	if step_meta.has("mob"):
+		# Handle single mob case
+		var dmob: DMob = Gamedata.mobs.by_id(step_meta["mob"])
+		step_details_text += "Kill " + str(step.required) + " "
+		step_details_text += dmob.name + " (Killed: "
+	elif step_meta.has("mobgroup"):
+		# Handle mob group case
+		var dmobgroup: DMobgroup = Gamedata.mobgroups.by_id(step_meta["mobgroup"])
+		step_details_text += "Kill " + str(step.required) + " "
+		step_details_text += dmobgroup.name + " (Killed: "
+	else:
+		# Handle missing data
+		step_details_text += "Kill target not specified (Killed: "
+
+	# Append the collected count and close the text
 	step_details_text += str(step.collected) + ")"
 	return step_details_text
 

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -16,6 +16,7 @@ var stats: DStats
 var skills: DSkills
 var quests: DQuests
 var overmapareas: DOvermapareas
+var mobgroups: DMobgroups
 
 # Only hides the visual instance when it's above the player. Casts no shadow
 static var hide_above_player_shader := preload("res://Shaders/HideAbovePlayer.gdshader")
@@ -42,8 +43,9 @@ enum ContentType {
 	WEARABLESLOTS,      #8
 	STATS,              #9
 	SKILLS,             #10
-	QUESTS,              #11
-	OVERMAPAREAS        #12
+	QUESTS,             #11
+	OVERMAPAREAS,       #12
+	MOBGROUPS        	#13
 }
 
 # Rotation mappings for how directions change based on tile rotation
@@ -81,6 +83,7 @@ func _ready():
 	skills = DSkills.new()
 	quests = DQuests.new()
 	overmapareas = DOvermapareas.new()
+	mobgroups = DMobgroups.new()
 
 	# Populate the gamedata_map with the instantiated objects
 	gamedata_map = {
@@ -96,7 +99,8 @@ func _ready():
 		ContentType.STATS: stats,
 		ContentType.SKILLS: skills,
 		ContentType.QUESTS: quests,
-		ContentType.OVERMAPAREAS: overmapareas
+		ContentType.OVERMAPAREAS: overmapareas,
+		ContentType.MOBGROUPS: mobgroups
 	}
 
 	load_sprites()


### PR DESCRIPTION
Adds mob groups to the game as a separate data entity. It's very simple, just a list of mobs. The mob group can be used in quests in the "kill" step. Instead of adding one mob, you add the mob group. Then, any member of the mob group will count towards the quest target.

Here I killed some random zombies and it counts towards one counter:
![image](https://github.com/user-attachments/assets/a8930109-776e-4db6-8074-f84e95edb536)

When the "map_guide" is set to something other then "none", all maps from all mobs in the group are considered and the closest will be targeted on the overmap.

The mob group can't be used in maps yet but I did add a weight field to the mob group so it will be easier to implement. 

I only changed the "beginnings" quest using the mob groups. The "last crusade" quest may also be improved in the same way.