### PR TITLE
Unload chunk after test

### DIFF
--- a/test_environment.gd
+++ b/test_environment.gd
@@ -1,6 +1,7 @@
 extends Node3D
 
 @export var canvas_layer: CanvasLayer = null
+@export var chunk: Chunk = null
 
 
 
@@ -17,6 +18,7 @@ func _process(_delta):
 
 # The user pressed the return button, we go to the contenteditor
 func _on_return_button_button_up() -> void:
+	chunk.unload_chunk()
 	Helper.test_map_name = "" # Reset this before returning otherwise the main game will be in trouble
 	get_tree().change_scene_to_file("res://Scenes/ContentManager/contenteditor.tscn")
 

--- a/test_environment.tscn
+++ b/test_environment.tscn
@@ -45,9 +45,10 @@ points = PackedVector3Array(0, 0, 0.325, -1, -1, 0.325, -1, 1, 0.325, 0, 0, -0.3
 height = 1.0
 radius = 1.5
 
-[node name="TestEnvironment" type="Node3D" node_paths=PackedStringArray("canvas_layer")]
+[node name="TestEnvironment" type="Node3D" node_paths=PackedStringArray("canvas_layer", "chunk")]
 script = ExtResource("1_vhsh0")
 canvas_layer = NodePath("CanvasLayer")
+chunk = NodePath("Chunk")
 
 [node name="Chunk" type="Node3D" parent="." node_paths=PackedStringArray("level_manager")]
 script = ExtResource("1_hp7uo")


### PR DESCRIPTION
Fixes #480 

Calls chunk.unload_chunk before returning to the content editor.