### PR TITLE
Spawn mob group

### DIFF
--- a/Mods/Core/Maps/urbanroad.json
+++ b/Mods/Core/Maps/urbanroad.json
@@ -85,44 +85,9 @@
 		{
 			"entities": [
 				{
-					"count": 4,
-					"id": "basic_zombie_1",
-					"type": "mob"
-				},
-				{
-					"count": 4,
-					"id": "basic_zombie_2",
-					"type": "mob"
-				},
-				{
-					"count": 3,
-					"id": "bloated_zombie",
-					"type": "mob"
-				},
-				{
-					"count": 2,
-					"id": "rushing_zombie",
-					"type": "mob"
-				},
-				{
-					"count": 2,
-					"id": "charred_zombie",
-					"type": "mob"
-				},
-				{
-					"count": 3,
-					"id": "heavy_zombie",
-					"type": "mob"
-				},
-				{
-					"count": 2,
-					"id": "skeleton_zombie",
-					"type": "mob"
-				},
-				{
-					"count": 3,
-					"id": "limping_zombie",
-					"type": "mob"
+					"count": 1,
+					"id": "basic_zombies",
+					"type": "mobgroup"
 				}
 			],
 			"id": "zombies",
@@ -131,7 +96,7 @@
 			"spawn_chance": 100,
 			"tiles": [
 				{
-					"count": 8000,
+					"count": 2000,
 					"id": "null"
 				}
 			]

--- a/Mods/Core/Mobgroups/Mobgroups.json
+++ b/Mods/Core/Mobgroups/Mobgroups.json
@@ -15,6 +15,9 @@
 		"name": "Basic zombies",
 		"references": {
 			"core": {
+				"maps": [
+					"urbanroad"
+				],
 				"quests": [
 					"starter_tutorial_00",
 					"quest_holy_crusade_01"

--- a/Mods/Core/Mobs/Mobs.json
+++ b/Mods/Core/Mobs/Mobs.json
@@ -394,7 +394,6 @@
 		"references": {
 			"core": {
 				"maps": [
-					"urbanroad",
 					"urbanroad_cross",
 					"urbanroad_corner",
 					"urbanroad_t",
@@ -467,7 +466,6 @@
 		"references": {
 			"core": {
 				"maps": [
-					"urbanroad",
 					"urbanroad_cross",
 					"urbanroad_corner",
 					"urbanroad_t",
@@ -541,7 +539,6 @@
 		"references": {
 			"core": {
 				"maps": [
-					"urbanroad",
 					"urbanroad_cross",
 					"store_groceries",
 					"office_building_00",
@@ -615,7 +612,6 @@
 		"references": {
 			"core": {
 				"maps": [
-					"urbanroad",
 					"urbanroad_cross",
 					"store_groceries",
 					"office_building_00",
@@ -696,7 +692,6 @@
 		"references": {
 			"core": {
 				"maps": [
-					"urbanroad",
 					"urbanroad_cross",
 					"store_groceries",
 					"office_building_00",
@@ -770,7 +765,6 @@
 		"references": {
 			"core": {
 				"maps": [
-					"urbanroad",
 					"urbanroad_cross",
 					"store_groceries",
 					"office_building_00",
@@ -844,7 +838,6 @@
 		"references": {
 			"core": {
 				"maps": [
-					"urbanroad",
 					"urbanroad_cross",
 					"store_groceries",
 					"office_building_00",
@@ -918,7 +911,6 @@
 		"references": {
 			"core": {
 				"maps": [
-					"urbanroad",
 					"urbanroad_cross",
 					"store_groceries",
 					"office_building_00",

--- a/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
@@ -266,6 +266,8 @@ func apply_paint_to_tile(tile: Control, brush: Control, tilerotate: int):
 		if brush:
 			if brush.entityType == "mob":
 				tileData.erase("mob")
+			elif brush.entityType == "mobgroup":
+				tileData.erase("mobgroup")
 			elif brush.entityType == "furniture":
 				tileData.erase("furniture")
 			elif brush.entityType == "itemgroup":
@@ -280,18 +282,27 @@ func apply_paint_to_tile(tile: Control, brush: Control, tilerotate: int):
 		var tilerotation = brushcomposer.get_tilerotation(tilerotate)
 		if brush.entityType == "mob":
 			tileData.erase("furniture")
+			tileData.erase("mobgroup")
 			tileData.erase("itemgroups")
 			tileData["mob"] = {"id": brush.entityID}
-			set_entity_rotation(tileData,"mob",tilerotation)
+			set_entity_rotation(tileData, "mob", tilerotation)
 		elif brush.entityType == "furniture":
 			tileData.erase("mob")
+			tileData.erase("mobgroup")
 			tileData.erase("itemgroups")
 			tileData["furniture"] = {"id": brush.entityID}
-			set_entity_rotation(tileData,"furniture",tilerotation)
+			set_entity_rotation(tileData, "furniture", tilerotation)
 			tileData["furniture"]["itemgroups"] = brushcomposer.get_itemgroup_entity_ids()
+		elif brush.entityType == "mobgroup":
+			tileData.erase("mob")
+			tileData.erase("furniture")
+			tileData.erase("itemgroups")
+			tileData["mobgroup"] = {"id": brush.entityID}
+			set_entity_rotation(tileData, "mobgroup", tilerotation)
 		elif brush.entityType == "itemgroup":
 			tileData.erase("mob")
 			tileData.erase("furniture")
+			tileData.erase("mobgroup")
 			tileData["itemgroups"] = brushcomposer.get_itemgroup_entity_ids()
 		else:
 			set_tile_id(tileData,brush.entityID)
@@ -716,6 +727,12 @@ func rotate_tile_data(tile_data: Dictionary):
 	if tile_data.has("id"):
 		var tile_rotation = int(tile_data.get("rotation", 0))
 		tile_data["rotation"] = (tile_rotation + 90) % 360
+	if tile_data.has("mob"):
+		var mob_rotation = int(tile_data["mob"].get("rotation", 0))
+		tile_data["mob"]["rotation"] = (mob_rotation + 90) % 360
+	if tile_data.has("mobgroup"):
+		var mobgroup_rotation = int(tile_data["mobgroup"].get("rotation", 0))
+		tile_data["mobgroup"]["rotation"] = (mobgroup_rotation + 90) % 360
 	# Rotate furniture if present, initializing rotation to 0 if not set
 	if tile_data.has("furniture"):
 		var furniture_rotation = int(tile_data["furniture"].get("rotation", 0))
@@ -1268,7 +1285,7 @@ func set_entity_rotation(tileData: Dictionary, key: String, rotationDegrees: int
 # If no furniture is present, it applies the itemgroup to the tile and updates the ObjectSprite with a random sprite.
 # If the tileData has the "mob" property, it returns without making any changes.
 func set_tile_itemgroups(tileData: Dictionary, itemgroups: Array) -> void:
-	if tileData.has("mob"):
+	if tileData.has("mob") or tileData.has("mobgroup"):
 		return
 	
 	# If the tile doesn't have furniture

--- a/Scenes/ContentManager/Mapeditor/Scripts/TilebrushList.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/TilebrushList.gd
@@ -21,27 +21,36 @@ func _ready():
 	
 # this function will read all files in Gamedata.data.mobs.data and creates tilebrushes for each tile in the list. It will make separate lists for each category that the mobs belong to.
 func loadMobs():
+	# Combine mobs and mobgroups into a single list
 	var mobList: Dictionary = Gamedata.mobs.get_all()
+	var mobgroupList: Dictionary = Gamedata.mobgroups.get_all()
 	var newMobsList: Control = scrolling_Flow_Container.instantiate()
 	newMobsList.header = "Mobs"
 	newMobsList.collapse_button_pressed.connect(_on_collapse_button_pressed)
 	add_child(newMobsList)
 	newMobsList.is_collapsed = load_collapse_state("Mobs")
-	for dmob: DMob in mobList.values():
-		# Get the texture from dmob
-		var texture: Resource = dmob.sprite
-		# Create a TextureRect node
-		var brushInstance = tileBrush.instantiate()
-		# Assign the texture to the TextureRect
-		brushInstance.set_tile_texture(texture)
-		# Since the map editor needs to knw what tile ID is used,
-		# We store the tile id in a variable in the brush
-		brushInstance.entityID = dmob.id
-		brushInstance.tilebrush_clicked.connect(tilebrush_clicked)
-		brushInstance.entityType = "mob"
-		# Add the TextureRect as a child to the TilesList
-		newMobsList.add_content_item(brushInstance)
-		instanced_brushes.append(brushInstance)
+
+	# Add all mobs
+	for dmob: RefCounted in mobList.values():
+		create_brush_instance(dmob, "mob", newMobsList)
+
+	# Add all mobgroups
+	for dmobgroup: RefCounted in mobgroupList.values():
+		create_brush_instance(dmobgroup, "mobgroup", newMobsList)
+
+
+# Function to create a brush instance and configure it
+func create_brush_instance(entity: RefCounted, entity_type: String, newMobsList: Control):
+	var texture: Resource = entity.sprite
+	var brushInstance = tileBrush.instantiate()
+	brushInstance.set_tile_texture(texture)
+	brushInstance.entityID = entity.id
+	brushInstance.entityType = entity_type
+	brushInstance.tilebrush_clicked.connect(tilebrush_clicked)
+	if entity_type == "mobgroup":
+		brushInstance.show_label()  # Specific behavior for mobgroups
+	newMobsList.add_content_item(brushInstance)
+	instanced_brushes.append(brushInstance)
 
 
 func loadFurniture():

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd
@@ -392,6 +392,10 @@ func add_brushes_from_area(entity_list: Array, entity_type: String = "entity"):
 				properties["texture"] = Gamedata.furnitures.sprite_by_id(entity["id"])
 			"itemgroup":
 				properties["texture"] = Gamedata.itemgroups.sprite_by_id(entity["id"])
+			"mobgroup":  # Add support for mobgroup
+				properties["texture"] = Gamedata.mobgroups.sprite_by_id(entity["id"])  # Ensure mobgroup textures exist
+			_:
+				continue  # Skip unsupported entity types
 
 		add_tilebrush_to_container_with_properties(properties)
 

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditortile.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditortile.gd
@@ -82,6 +82,16 @@ func set_tooltip(tileData: Dictionary) -> void:
 			tooltiptext += "Mob Rotation: 0 degrees\n"
 	else:
 		tooltiptext += "Mob: None\n"
+		
+	# Display mobgroup information
+	if tileData.has("mobgroup"):
+		tooltiptext += "Mob Group ID: " + str(tileData.mobgroup.id) + "\n"
+		if tileData.mobgroup.has("rotation"):
+			tooltiptext += "Mob Group Rotation: " + str(tileData.mobgroup.rotation) + " degrees\n"
+		else:
+			tooltiptext += "Mob Group Rotation: 0 degrees\n"
+	else:
+		tooltiptext += "Mob Group: None\n"
 	
 	# Display furniture information
 	if tileData.has("furniture"):
@@ -145,6 +155,11 @@ func update_display(tileData: Dictionary = {}, selected_area_name: String = "Non
 		$AreaSprite.rotation_degrees = 0
 
 		# Check for mob and furniture, and update accordingly
+		if tileData.has("mobgroup"):
+			if tileData["mobgroup"].has("rotation"):
+				$ObjectSprite.rotation_degrees = tileData["mobgroup"]["rotation"]
+			$ObjectSprite.texture = Gamedata.mobgroups.sprite_by_id(tileData["mobgroup"]["id"])
+			$ObjectSprite.show()
 		if tileData.has("mob"):
 			if tileData["mob"].has("rotation"):
 				$ObjectSprite.rotation_degrees = tileData["mob"]["rotation"]
@@ -187,7 +202,7 @@ func set_tile_id(id: String) -> void:
 # If the itemgroups array is empty, it hides the ObjectSprite and removes the itemgroups property from the tile.
 # If the tileData contains a mob or furniture, the function returns early without making any changes.
 func set_tile_itemgroups(tileData: Dictionary) -> void:
-	if tileData.has("mob") or tileData.has("furniture"):
+	if tileData.has("mob") or tileData.has("furniture") or tileData.has("mobgroup"):
 		return
 	
 	var itemgroups: Array = tileData.get("itemgroups", [])

--- a/Scenes/ContentManager/Mapeditor/Scripts/tilebrush.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/tilebrush.gd
@@ -7,9 +7,11 @@ extends Control
 signal tilebrush_clicked(clicked_tile: Control)
 var entityID: String = ""
 var selected: bool = false
-# Can be "tile", "mob", "furniture", "itemgroup"
+# Can be "tile", "mob", "furniture", "itemgroup", "mobgroup"
 var entityType: String = "tile"
 @export var tile_sprite: TextureRect
+@export var label: Label = null
+
 
 const TILEMARGIN: int = 10
 
@@ -39,3 +41,10 @@ func set_selected(is_selected: bool) -> void:
 func set_minimum_size(newsize: Vector2) -> void:
 	custom_minimum_size = Vector2(newsize.x + TILEMARGIN, newsize.y + TILEMARGIN)
 	tile_sprite.custom_minimum_size = newsize
+
+
+func show_label():
+	label.show()
+	
+func hide_label():
+	label.hide()

--- a/Scenes/ContentManager/Mapeditor/tilebrush.tscn
+++ b/Scenes/ContentManager/Mapeditor/tilebrush.tscn
@@ -1,9 +1,11 @@
-[gd_scene load_steps=3 format=3 uid="uid://cccnrdolr1bfo"]
+[gd_scene load_steps=4 format=3 uid="uid://cccnrdolr1bfo"]
 
 [ext_resource type="Script" path="res://Scenes/ContentManager/Mapeditor/Scripts/tilebrush.gd" id="1_x2ml4"]
 [ext_resource type="Texture2D" uid="uid://d0ec7u2d3yqqp" path="res://Mods/Core/Tiles/asphalt_middle_horizontal.png" id="2_0qm6c"]
 
-[node name="TileBrush" type="Control" node_paths=PackedStringArray("tile_sprite")]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_art0c"]
+
+[node name="TileBrush" type="Control" node_paths=PackedStringArray("tile_sprite", "label")]
 custom_minimum_size = Vector2(64, 64)
 layout_mode = 3
 anchors_preset = 15
@@ -13,6 +15,7 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_x2ml4")
 tile_sprite = NodePath("TileSprite")
+label = NodePath("Label")
 
 [node name="TileSprite" type="TextureRect" parent="."]
 custom_minimum_size = Vector2(64, 64)
@@ -22,5 +25,21 @@ offset_bottom = 40.0
 texture = ExtResource("2_0qm6c")
 expand_mode = 2
 stretch_mode = 4
+
+[node name="Label" type="Label" parent="."]
+visible = false
+layout_mode = 1
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -20.0
+offset_right = 4.0
+offset_bottom = 24.0
+grow_horizontal = 2
+theme_override_colors/font_color = Color(0.742012, 0.102377, 4.81307e-07, 1)
+theme_override_font_sizes/font_size = 16
+theme_override_styles/normal = SubResource("StyleBoxFlat_art0c")
+text = "G"
+horizontal_alignment = 1
 
 [connection signal="gui_input" from="TileSprite" to="." method="_on_texture_rect_gui_input"]

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -149,6 +149,14 @@ func process_level_data() -> Dictionary:
 								# We spawn it slightly above the block and let it fall. Might want to 
 								# fiddle with the Y coordinate for optimization
 								processed_leveldata.mobs.append({"json": tileJSON.mob, "pos": Vector3(w, y + 1.5, h)})
+							if tileJSON.has("mobgroup"):
+								# Fetch the mobgroup ID and use it to get a random mob ID
+								var mobgroup_id: String = tileJSON.mobgroup.id
+								var random_mob_id: String = Gamedata.mobgroups.by_id(mobgroup_id).get_random_mob_id()
+								if random_mob_id != "":
+									tileJSON.mobgroup.id = random_mob_id
+									# Append the mob with its position and rotation from the mobgroup data
+									processed_leveldata.mobs.append({"json": tileJSON.mobgroup, "pos": Vector3(w, y + 1.5, h)})
 							if tileJSON.has("furniture"):
 								# We spawn it slightly above the block. Might want to 
 								# fiddle with the Y coordinate for optimization

--- a/Scripts/Gamedata/DMap.gd
+++ b/Scripts/Gamedata/DMap.gd
@@ -270,6 +270,9 @@ func add_entities_in_area_to_set(myarea: Dictionary, entity_set: Dictionary):
 				"mob":
 					if not entity_set["mobs"].has(entity["id"]):
 						entity_set["mobs"].append(entity["id"])
+				"mobgroup":
+					if not entity_set["mobgroups"].has(entity["id"]):
+						entity_set["mobgroups"].append(entity["id"])
 				"furniture":
 					if not entity_set["furniture"].has(entity["id"]):
 						entity_set["furniture"].append(entity["id"])
@@ -289,8 +292,8 @@ func add_entities_to_set(level: Array, entity_set: Dictionary):
 	for entity in level:
 		if entity.has("mob") and not entity_set["mobs"].has(entity["mob"]["id"]):
 			entity_set["mobs"].append(entity["mob"]["id"])
-		if entity.has("mobgroup") and not entity_set["mobgroups"].has(entity["mobgroup"]):  # Add mobgroup
-			entity_set["mobgroups"].append(entity["mobgroup"])
+		if entity.has("mobgroup") and not entity_set["mobgroups"].has(entity["mobgroup"]["id"]):  # Add mobgroup
+			entity_set["mobgroups"].append(entity["mobgroup"]["id"])
 		if entity.has("furniture"):
 			if not entity_set["furniture"].has(entity["furniture"]["id"]):
 				entity_set["furniture"].append(entity["furniture"]["id"])
@@ -345,7 +348,7 @@ func remove_entity_from_levels(entity_type: String, entity_id: String) -> void:
 						entity.erase("mob")  # Removing the mob object from the entity
 				"mobgroup":
 					# Check if the entity has 'mobgroup' and matches the given ID
-					if entity.has("mobgroup") and entity["mobgroup"] == entity_id:
+					if entity.has("mobgroup") and entity["mobgroup"].get("id", "") == entity_id:
 						entity.erase("mobgroup")  # Remove mobgroup from the entity
 				"itemgroup":
 					# Check if the entity has 'furniture' and 'itemgroups', then remove the itemgroup

--- a/Scripts/Gamedata/DMap.gd
+++ b/Scripts/Gamedata/DMap.gd
@@ -44,6 +44,7 @@ class maptile:
 	# Furniture, Mob and Itemgroups are mutually exclusive. Only one can exist at a time
 	var furniture: String = ""
 	var mob: String = ""
+	var mobgroup: String = ""  # Add mobgroup support
 	var itemgroups: Array = []
 
 
@@ -176,6 +177,10 @@ func data_changed(oldmap: DMap):
 			for entity_id in new_entities[entity_type]:
 				var dmob: DMob = Gamedata.mobs.by_id(entity_id)
 				dmob.add_reference("core","maps",id)
+		elif entity_type == "mobgroups":  # Handle mobgroup references
+			for entity_id in new_entities[entity_type]:
+				var mobgroup: DMobgroup = Gamedata.mobgroups.by_id(entity_id)
+				mobgroup.add_reference("core", "maps", id)
 		elif entity_type == "itemgroups":
 			for entity_id in new_entities[entity_type]:
 				var ditemgroup: DItemgroup = Gamedata.itemgroups.by_id(entity_id)
@@ -203,6 +208,11 @@ func data_changed(oldmap: DMap):
 				if not new_entities[entity_type].has(entity_id):
 					var mob: DMob = Gamedata.mobs.by_id(entity_id)
 					mob.remove_reference("core","maps",id)
+		elif entity_type == "mobgroups":  # Remove mobgroup references
+			for entity_id in old_entities[entity_type]:
+				if not new_entities[entity_type].has(entity_id):
+					var mobgroup: DMobgroup = Gamedata.mobgroups.by_id(entity_id)
+					mobgroup.remove_reference("core", "maps", id)
 
 
 	# Save changes to the data files if there were any updates
@@ -220,12 +230,14 @@ func data_changed(oldmap: DMap):
 func collect_unique_entities(oldmap: DMap) -> Dictionary:
 	var new_entities = {
 		"mobs": [],
+		"mobgroups": [],  # Add mobgroup
 		"furniture": [],
 		"itemgroups": [],
 		"tiles": []
 	}
 	var old_entities = {
 		"mobs": [],
+		"mobgroups": [],  # Add mobgroup
 		"furniture": [],
 		"itemgroups": [],
 		"tiles": []
@@ -277,6 +289,8 @@ func add_entities_to_set(level: Array, entity_set: Dictionary):
 	for entity in level:
 		if entity.has("mob") and not entity_set["mobs"].has(entity["mob"]["id"]):
 			entity_set["mobs"].append(entity["mob"]["id"])
+		if entity.has("mobgroup") and not entity_set["mobgroups"].has(entity["mobgroup"]):  # Add mobgroup
+			entity_set["mobgroups"].append(entity["mobgroup"])
 		if entity.has("furniture"):
 			if not entity_set["furniture"].has(entity["furniture"]["id"]):
 				entity_set["furniture"].append(entity["furniture"]["id"])
@@ -329,6 +343,10 @@ func remove_entity_from_levels(entity_type: String, entity_id: String) -> void:
 					# Check if the entity has 'mob' and the 'id' within it matches
 					if entity.has("mob") and entity["mob"].get("id", "") == entity_id:
 						entity.erase("mob")  # Removing the mob object from the entity
+				"mobgroup":
+					# Check if the entity has 'mobgroup' and matches the given ID
+					if entity.has("mobgroup") and entity["mobgroup"] == entity_id:
+						entity.erase("mobgroup")  # Remove mobgroup from the entity
 				"itemgroup":
 					# Check if the entity has 'furniture' and 'itemgroups', then remove the itemgroup
 					if entity.has("furniture") and entity["furniture"].has("itemgroups"):
@@ -355,7 +373,7 @@ func erase_entity_from_areas(entity_type: String, entity_id: String) -> void:
 					myarea["tiles"] = myarea["tiles"].filter(func(tile):
 						return tile["id"] != entity_id
 					)
-			"furniture", "mob", "itemgroup":
+			"furniture", "mob", "mobgroup", "itemgroup":
 				if myarea.has("entities"):
 					myarea["entities"] = myarea["entities"].filter(func(entity):
 						return not (entity["type"] == entity_type and entity["id"] == entity_id)

--- a/Scripts/Gamedata/DMobgroup.gd
+++ b/Scripts/Gamedata/DMobgroup.gd
@@ -154,3 +154,26 @@ func execute_callable_on_references_of_type(module: String, type: String, callab
 		# If the type exists, execute the callable on each ID found under this type
 		for ref_id in references[module][type]:
 			callable.call(ref_id)
+
+
+# Function to return a randomly selected mob ID based on the weights in the "mobs" property
+func get_random_mob_id() -> String:
+	# If no mobs are present, return an empty string
+	if mobs.is_empty():
+		return ""
+
+	# Calculate the total weight
+	var total_weight: int = 0
+	for weight in mobs.values():
+		total_weight += weight
+
+	# Generate a random number within the total weight
+	var random_pick: int = randi() % total_weight
+
+	# Iterate through the mobs and select the mob based on the random pick
+	for mob_id in mobs.keys():
+		random_pick -= mobs[mob_id]
+		if random_pick < 0:
+			return mob_id  # Return the selected mob ID
+
+	return ""  # Fallback in case of an error, should not be reached

--- a/Scripts/Gamedata/DQuest.gd
+++ b/Scripts/Gamedata/DQuest.gd
@@ -33,6 +33,12 @@ extends RefCounted
 #				"type": "kill"
 #			},
 #			{
+#				"amount": 3,
+#				"mobgroup": "bandits",  # Example mobgroup kill step
+#				"tip": "You can find them in the northern forest",
+#				"type": "kill"
+#			},
+#			{
 #				"map_id": "city_square",
 #				"tip": "Circuit boards can often be scavenged from scrap piles or robotic enemies.",
 #				"type": "enter",
@@ -83,6 +89,9 @@ func delete():
 	var stepmobs: Array =  steps.filter(func(step): return step.has("mob"))
 	for killstep in stepmobs:
 		Gamedata.mobs.remove_reference(killstep.mob, "core", "quests", id)
+	var stepmobgroups: Array = steps.filter(func(step): return step.has("mobgroup"))
+	for killstep in stepmobgroups:
+		Gamedata.mobgroups.remove_reference(killstep.mobgroup, "core", "quests", id)
 	var steprewards: Array = rewards.filter(func(reward): return reward.has("item_id"))
 	for reward in steprewards: # Remove the reference to this quest from the reward item
 		Gamedata.items.remove_reference(reward.item_id, "core", "quests", id)
@@ -156,6 +165,15 @@ func remove_steps_by_mob(mob_id: String) -> void:
 		return not (step.has("mob") and step.mob == mob_id)
 	)
 	save_to_disk()
+
+
+# Removes all steps where the mobgroup property matches the given mobgroup_id
+func remove_steps_by_mobgroup(mobgroup_id: String) -> void:
+	steps = steps.filter(func(step): 
+		return not (step.has("mobgroup") and step.mobgroup == mobgroup_id)
+	)
+	save_to_disk()
+
 
 # Removes all steps where the item property matches the given item_id
 func remove_steps_by_item(item_id: String) -> void:

--- a/Scripts/Gamedata/DQuests.gd
+++ b/Scripts/Gamedata/DQuests.gd
@@ -92,6 +92,11 @@ func sprite_by_file(spritefile: String) -> Texture:
 func remove_mob_from_quest(quest_id: String, mob_id: String) -> void:
 	by_id(quest_id).remove_steps_by_mob(mob_id)
 
+
+# Removes all steps where the mobgroup property matches the given mob_id
+func remove_mobgroup_from_quest(quest_id: String, mobgroup_id: String) -> void:
+	by_id(quest_id).remove_steps_by_mobgroup(mobgroup_id)
+
 # Removes all steps and rewards where the item property matches the given item_id
 func remove_item_from_quest(quest_id: String, item_id: String) -> void:
 	by_id(quest_id).remove_steps_by_item(item_id)

--- a/Scripts/Helper/map_manager.gd
+++ b/Scripts/Helper/map_manager.gd
@@ -82,6 +82,8 @@ func _process_entities_data(area_data: Dictionary, result: Dictionary) -> void:
 					result["furniture"] = {"id": selected_entity["id"], "rotation": rotation}
 				"mob":
 					result["mob"] = {"id": selected_entity["id"], "rotation": rotation}
+				"mobgroup":
+					result["mobgroup"] = {"id": selected_entity["id"], "rotation": rotation}
 				"itemgroup":
 					result["itemgroups"] = [selected_entity["id"]]
 
@@ -124,7 +126,7 @@ func apply_area_to_tile(tile: Dictionary, selected_areas: Array, mapData: Dictio
 				var area_data = get_area_data_by_id(area["id"], mapData)
 				var processed_data = process_area_data(area_data, original_tile_id)
 				# Check if any of ["mob", "furniture", "itemgroups"] are in tile.keys()
-				var entities_to_check = ["mob", "furniture", "itemgroups"]
+				var entities_to_check = ["mob", "furniture", "mobgroup", "itemgroups"]
 				var new_has_entities = entities_to_check.any(func(entity): return processed_data.has(entity))
 				
 				if new_has_entities:
@@ -175,17 +177,28 @@ func get_area_data_based_on_spawn_chance(mapData: Dictionary) -> Array:
 # If no areas exist in the mapdata, no changes are made
 # Example area data:
 #"areas": [
-#     {
-#        "id": "tree_layer",
-#        "rotate_random": true,
-#        "spawn_chance": 100,
-#        "entities": [
-#            {"id": "Tree_00", "type": "furniture", "count": 11},
-#            {"id": "PineTree_00", "type": "furniture", "count": 11},
-#            {"id": "WillowTree_00", "type": "furniture", "count": 11}
-#        ],
-#        "tiles": [{"id": "null", "count": 100}]
-#    },
+#	{
+#		"id": "tree_layer",
+#		"rotate_random": true,
+#		"spawn_chance": 100,
+#		"entities": [
+#			{"id": "Tree_00", "type": "furniture", "count": 11},
+#			{"id": "PineTree_00", "type": "furniture", "count": 11},
+#			{"id": "WillowTree_00", "type": "furniture", "count": 11}
+#		],
+#		"tiles": [{"id": "null", "count": 100}]
+#	},
+#	{
+#		"id": "forest_mobs",
+#		"rotate_random": true,
+#		"spawn_chance": 50,
+#		"entities": [
+#			{"id": "bandits", "type": "mobgroup", "count": 20},
+#			{"id": "wolves", "type": "mobgroup", "count": 10},
+#			{"id": "deer", "type": "mobgroup", "count": 15}
+#		],
+#		"tiles": [{"id": "forest_grass", "count": 100}]
+#	}
 #    {
 #        "id": "ground_layer",
 #        "rotate_random": true,
@@ -333,7 +346,7 @@ func apply_area_clusters_to_tiles(level: Array, area_id: String, mapData: Dictio
 			var processed_data = process_area_data(area_data, original_tile_id, picked_tile)
 
 			# Remove existing entities if new entities are present in processed data
-			var entities_to_check = ["mob", "furniture", "itemgroups"]
+			var entities_to_check = ["mob", "furniture", "mobgroup", "itemgroups"]
 			var new_has_entities = entities_to_check.any(func(entity): return processed_data.has(entity))
 
 			if new_has_entities:


### PR DESCRIPTION
Now mob groups can be used to spawn mobs. This is a basic implementation with some areas still available for improvement. There are two options for spawning:
- You can paint a group directly onto the map. This will guarantee that one of the mobs from the group spawns at that location (unless that tile is overwritten by an area, for example if a tree happens to spawn on the spot of your mob)
- You can add the mob group to an area and it will spawn mobs according to the weights. So how to control the weights? Observe this image:

![image](https://github.com/user-attachments/assets/4eeb400a-3cd5-4894-9f52-1682da99fd61)

Here is an area that will have a 1 in 2000 chance to spawn one of the mobs from the group for each tile in the area. If you lower the 2000 to 100, each tile in the area will have a 1 in 100 chance to spawn one of the mobs from the group. Which mob will spawn? That will be determined by the weight specified in the group.

You can also combine mob spawn and mob group spawn. This way you cold skew the weights by adding one mob to the area with a higher weight in addition to the mob group.

This pr will also cause the map_guide in quests to be unable to find zombies on the urbanroad since they no longer spawn there directly. The map_guide needs to be adjusted so that it will also consider mobs spawned in a mob group.