### PR TITLE
Fix despawn containers

### DIFF
--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -356,7 +356,7 @@ func terminate_mob_instances(mapMobs):
 func free_item_instances(mapitems):
 	for item in mapitems:
 		if _is_object_in_range(item.containerpos):
-			item.queue_free.call_deferred()
+			item.destroy.call_deferred()
 
 # Returns an array of furniture data that will be saved for this chunk
 # Furniture that has it's x and z position in the boundary of the chunk's position and size

--- a/Scripts/Gamedata/DMobgroup.gd
+++ b/Scripts/Gamedata/DMobgroup.gd
@@ -124,7 +124,7 @@ func delete():
 
 # Retrieves all maps associated with the mob group, including maps from its mobs.
 func get_maps() -> Array:
-	var unique_maps: Array = []
+	var unique_maps: Array = Helper.json_helper.get_nested_data(references, "core.maps")
 
 	# Collect maps from each mob in the group
 	for mob_id in mobs.keys():

--- a/Scripts/container.gd
+++ b/Scripts/container.gd
@@ -313,3 +313,25 @@ func set_random_inventory_item_texture():
 	
 	# Set the sprite_3d texture to the item's sprite
 	sprite_3d.texture = Gamedata.items.sprite_by_id(item_id)
+
+
+# Properly destroys the container and its associated resources
+func destroy():
+	Helper.signal_broker.container_exited_proximity.emit(self)
+	# Disconnect signals to avoid issues during cleanup
+	if inventory:
+		inventory.item_removed.disconnect(_on_item_removed)
+		inventory.item_added.disconnect(_on_item_added)
+
+	# Free the inventory resource
+	if inventory:
+		inventory.queue_free()
+		inventory = null
+
+	# Free the sprite resource
+	if sprite_3d:
+		sprite_3d.queue_free()
+		sprite_3d = null
+
+	# Free the node itself
+	queue_free()


### PR DESCRIPTION
Fixes #478 

The stack trace shows that the inventory node gets the "unparented" notification and respond to that. This likely happens during destruction, when the chunk gets unloaded. The "destroy" function works but wasn't complete without: 
`Helper.signal_broker.container_exited_proximity.emit(self)`

After that I am unable to reproduce the error.