### PR TITLE
Tile details are now shown while hovering the mouse cursor instead of having to click on the tile.

### DIFF
--- a/Scenes/Overmap/OvermapTile.tscn
+++ b/Scenes/Overmap/OvermapTile.tscn
@@ -40,3 +40,4 @@ horizontal_alignment = 1
 vertical_alignment = 1
 
 [connection signal="gui_input" from="TextureRect" to="." method="_on_texture_rect_gui_input"]
+[connection signal="mouse_entered" from="TextureRect" to="." method="_on_texture_rect_mouse_entered"]

--- a/Scenes/Overmap/Scripts/OvermapTile.gd
+++ b/Scenes/Overmap/Scripts/OvermapTile.gd
@@ -19,12 +19,15 @@ var map_cell:
 signal tile_clicked(clicked_tile: Control)
 
 # Handle mouse input to emit the tile_clicked signal
+func _on_texture_rect_mouse_entered():
+	tile_clicked.emit(self)
+
 func _on_texture_rect_gui_input(event: InputEvent) -> void:
 	if event is InputEventMouseButton:
 		match event.button_index:
 			MOUSE_BUTTON_LEFT:
 				if event.pressed:
-					tile_clicked.emit(self)
+					pass
 
 # Set the texture for the TextureRect
 func set_texture(res: Resource) -> void:


### PR DESCRIPTION
Fixes #458.

Before you had to click on the tile in an overmap to get the tile details, now you can simply hover and it'll automatically show the tile details to the player.

I didn't remove the old input signal, since it can now be used for something else.

Note: this is only applied to in-game map (I tested it there, not in content editor).