### PR TITLE
Add time progression and a clock

### DIFF
--- a/Scripts/Helper.gd
+++ b/Scripts/Helper.gd
@@ -20,8 +20,10 @@ const task_manager_Class = preload("res://Scripts/Helper/task_manager.gd")
 const map_manager_Class = preload("res://Scripts/Helper/map_manager.gd")
 const overmap_manager_Class = preload("res://Scripts/Helper/overmap_manager.gd")
 const quest_helper_Class = preload("res://Scripts/Helper/quest_helper.gd")
+const time_helper_Class = preload("res://Scripts/Helper/time_helper.gd")
 
 var json_helper: RefCounted = null
+var time_helper: RefCounted = null
 var save_helper: Node = null
 var signal_broker: Node = null
 var task_manager: Node = null
@@ -46,6 +48,7 @@ func initialize_helpers():
 	map_manager = map_manager_Class.new()
 	overmap_manager = overmap_manager_Class.new()
 	quest_helper = quest_helper_Class.new()
+	time_helper = time_helper_Class.new()
 
 
 func _process(_delta: float) -> void:

--- a/Scripts/Helper.gd
+++ b/Scripts/Helper.gd
@@ -23,7 +23,7 @@ const quest_helper_Class = preload("res://Scripts/Helper/quest_helper.gd")
 const time_helper_Class = preload("res://Scripts/Helper/time_helper.gd")
 
 var json_helper: RefCounted = null
-var time_helper: RefCounted = null
+var time_helper: Node = null
 var save_helper: Node = null
 var signal_broker: Node = null
 var task_manager: Node = null
@@ -36,6 +36,7 @@ func _ready():
 	initialize_helpers()
 	add_child(save_helper)
 	add_child(quest_helper)
+	add_child(time_helper)
 	add_child(overmap_manager)
 	signal_broker.game_ended.connect(_on_game_ended)
 

--- a/Scripts/Helper/time_helper.gd
+++ b/Scripts/Helper/time_helper.gd
@@ -1,0 +1,65 @@
+class_name TimeHelper
+extends RefCounted
+
+# Internal state
+var _elapsed_time: float = 0.0  # Total elapsed time for the current game session (in seconds)
+var _is_tracking_time: bool = false  # Flag to track if we are actively counting time
+var _last_tick_time: int = 0  # The last recorded tick time (in milliseconds)
+
+func _ready():
+	# Connect signals for game state changes
+	Helper.signal_broker.game_started.connect(_on_game_started)
+	Helper.signal_broker.game_loaded.connect(_on_game_loaded)
+	Helper.signal_broker.game_ended.connect(_on_game_ended)
+
+func _process(delta: float):
+	if _is_tracking_time:
+		# Update elapsed time based on ticks for precision
+		var current_ticks = Time.get_ticks_msec()
+		_elapsed_time += (current_ticks - _last_tick_time) / 1000.0  # Convert ms to seconds
+		_last_tick_time = current_ticks
+
+# --- Signal Handlers ---
+# Called when a new game starts. Resets time tracking and begins counting from zero.
+func _on_game_started():
+	_elapsed_time = 0.0  # Reset elapsed time for a new game
+	_start_tracking_time()
+
+# Called when a game is loaded. Resumes time tracking from the saved time.
+func _on_game_loaded(saved_time: float):
+	_elapsed_time = saved_time  # Resume from the saved time
+	_start_tracking_time()
+
+# Called when the game ends. Stops time tracking.
+func _on_game_ended():
+	_stop_tracking_time()
+
+# --- Private Helpers ---
+
+# Starts time tracking by recording the current tick time.
+func _start_tracking_time():
+	_last_tick_time = Time.get_ticks_msec()
+	_is_tracking_time = true
+
+# Stops time tracking by clearing the tracking flag.
+func _stop_tracking_time():
+	_is_tracking_time = false
+
+# --- Public API ---
+
+# Returns the total elapsed time in seconds for the current session.
+func get_elapsed_time() -> float:
+	return _elapsed_time
+
+
+# Sets the elapsed time for saving/loading purposes.
+# Resets the reference for accurate tracking.
+func set_elapsed_time(new_time: float):
+	_elapsed_time = new_time
+	if _is_tracking_time:
+		_last_tick_time = Time.get_ticks_msec()
+
+
+# Returns the time difference between a given past time and the current time.
+func get_time_difference(past_time: float) -> float:
+	return max(0.0, _elapsed_time - past_time)

--- a/Scripts/Helper/time_helper.gd
+++ b/Scripts/Helper/time_helper.gd
@@ -1,10 +1,26 @@
 class_name TimeHelper
-extends RefCounted
+extends Node # Needs to be node in order to have the `_process` function
+
+# This script is loaded into the helper.gd autoload singleton
+# It can be accessed through Helper.time_helper
+# This is a helper script that manages time, supporting many game mechanics.
 
 # Internal state
 var _elapsed_time: float = 0.0  # Total elapsed time for the current game session (in seconds)
 var _is_tracking_time: bool = false  # Flag to track if we are actively counting time
 var _last_tick_time: int = 0  # The last recorded tick time (in milliseconds)
+
+# Time constants
+const daytime: int = 20  # Daytime in minutes
+const nighttime: int = 15  # Nighttime in minutes
+const day_duration: int = daytime + nighttime  # Total duration of a day in real-life minutes
+const in_game_day_minutes: int = 24 * 60  # In-game minutes in a full day (1440)
+
+# Signal to notify when an in-game minute has passed
+signal minute_passed(current_time: String)
+# Internal state to track the last emitted in-game minute
+var _last_emitted_minute: int = -1
+
 
 func _ready():
 	# Connect signals for game state changes
@@ -12,12 +28,22 @@ func _ready():
 	Helper.signal_broker.game_loaded.connect(_on_game_loaded)
 	Helper.signal_broker.game_ended.connect(_on_game_ended)
 
-func _process(delta: float):
+func _process(_delta: float):
 	if _is_tracking_time:
 		# Update elapsed time based on ticks for precision
 		var current_ticks = Time.get_ticks_msec()
 		_elapsed_time += (current_ticks - _last_tick_time) / 1000.0  # Convert ms to seconds
 		_last_tick_time = current_ticks
+
+		# Get the current in-game minute
+		var current_in_game_minutes = get_current_in_game_minutes()
+
+		# Emit signal if a new in-game minute has passed
+		if current_in_game_minutes != _last_emitted_minute:
+			_last_emitted_minute = current_in_game_minutes
+			var current_time: String = get_current_time()  # Optionally still provide the formatted string
+			minute_passed.emit(current_time)
+
 
 # --- Signal Handlers ---
 # Called when a new game starts. Resets time tracking and begins counting from zero.
@@ -63,3 +89,56 @@ func set_elapsed_time(new_time: float):
 # Returns the time difference between a given past time and the current time.
 func get_time_difference(past_time: float) -> float:
 	return max(0.0, _elapsed_time - past_time)
+
+
+# Returns the number of in-game days since the start
+func get_days_since_start() -> int:
+	return int(_elapsed_time / (day_duration * 60))  # Convert minutes to seconds
+
+
+# Returns a string representing the current time in-game in 24h format
+func get_current_time() -> String:
+	# Reuse the current in-game minutes calculation
+	var current_minutes_of_day: int = get_current_in_game_minutes()
+
+	# Convert total in-game minutes into hours and minutes
+	var hours: int = current_minutes_of_day / 60  # Convert to hours
+	var minutes: int = current_minutes_of_day % 60  # Remaining minutes
+
+	# Format as a 24-hour time string (e.g., "14:35")
+	return "%02d:%02d" % [hours, minutes]
+
+
+# Returns the percentage of the in-game day that has progressed
+func get_day_progress_percentage() -> float:
+	# Reuse the current in-game minutes calculation
+	var current_minutes_of_day: int = get_current_in_game_minutes()
+
+	# Calculate the percentage of the day completed
+	# Divide the current minutes of the day by the total in-game minutes per day
+	return (current_minutes_of_day / float(in_game_day_minutes)) * 100.0
+
+
+# Returns the current in-game minute as an integer value (0 to 1440),
+# representing the number of minutes passed since the start of the in-game day.
+func get_current_in_game_minutes() -> int:
+	# Scale real-life elapsed time to in-game time.
+	# _elapsed_time is the total real-life time in seconds, divided by day_duration to scale to in-game days.
+	# Multiplying by in_game_day_minutes converts the scaled time to in-game minutes.
+	# Example: Real-life elapsed time (_elapsed_time): 1050 seconds (17.5 minutes in real time)
+	# _elapsed_time / day_duration: 1050 / (35 * 60) = 0.5 (Half an in-game day has passed).
+	# scaled_elapsed_time = 0.5 * 1440 = 720 (720 in-game minutes have passed).
+	var scaled_elapsed_time = (_elapsed_time / day_duration) * in_game_day_minutes
+
+	# Convert the scaled time into a whole number of in-game minutes.
+	# This represents the total number of in-game minutes passed since the game started.
+	# Example: total_in_game_minutes = int(720) = 720.
+	var total_in_game_minutes: int = int(scaled_elapsed_time)
+
+	# Use modulo operation to wrap the total minutes into a single in-game day.
+	# This ensures the result is always between 0 and 1439 (1440 total minutes in a day).
+	# Example: current_minutes_of_day = 720 % 1440 = 720.
+	var current_minutes_of_day: int = total_in_game_minutes % in_game_day_minutes
+
+	# Return the current in-game minute of the day.
+	return current_minutes_of_day

--- a/Scripts/Helper/time_helper.gd
+++ b/Scripts/Helper/time_helper.gd
@@ -58,8 +58,8 @@ func _on_game_started():
 
 
 # Called when a game is loaded. Resumes time tracking from the saved time.
-func _on_game_loaded(saved_time: float):
-	_elapsed_time = saved_time  # Resume from the saved time
+func _on_game_loaded():
+	#_elapsed_time = saved_time  # Resume from the saved time
 	_start_tracking_time()
 
 # Called when the game ends. Stops time tracking.

--- a/Scripts/Helper/time_helper.gd
+++ b/Scripts/Helper/time_helper.gd
@@ -48,8 +48,14 @@ func _process(_delta: float):
 # --- Signal Handlers ---
 # Called when a new game starts. Resets time tracking and begins counting from zero.
 func _on_game_started():
-	_elapsed_time = 0.0  # Reset elapsed time for a new game
+	# Start the game with 8 in-game hours already passed
+	# Calculate the real-life time equivalent to 8 in-game hours
+	var in_game_hours = 8
+	var in_game_minutes = in_game_hours * 60  # 8 hours * 60 minutes
+	_elapsed_time = (in_game_minutes / float(in_game_day_minutes)) * day_duration * 60  # Convert to real-life seconds
+	
 	_start_tracking_time()
+
 
 # Called when a game is loaded. Resumes time tracking from the saved time.
 func _on_game_loaded(saved_time: float):
@@ -96,49 +102,40 @@ func get_days_since_start() -> int:
 	return int(_elapsed_time / (day_duration * 60))  # Convert minutes to seconds
 
 
-# Returns a string representing the current time in-game in 24h format
+# The current time string, representing the time of day
 func get_current_time() -> String:
-	# Reuse the current in-game minutes calculation
-	var current_minutes_of_day: int = get_current_in_game_minutes()
+	# Use get_current_in_game_minutes to get the current in-game minutes
+	var current_minutes_of_day = get_current_in_game_minutes()
 
-	# Convert total in-game minutes into hours and minutes
-	var hours: int = current_minutes_of_day / 60  # Convert to hours
-	var minutes: int = current_minutes_of_day % 60  # Remaining minutes
+	# Calculate hours and minutes
+	var hours: int = current_minutes_of_day / 60
+	var minutes: int = current_minutes_of_day % 60
 
-	# Format as a 24-hour time string (e.g., "14:35")
 	return "%02d:%02d" % [hours, minutes]
 
 
-# Returns the percentage of the in-game day that has progressed
+# Returns a percentage between 0 and 100, indicating how much of the day has progressed.
 func get_day_progress_percentage() -> float:
-	# Reuse the current in-game minutes calculation
-	var current_minutes_of_day: int = get_current_in_game_minutes()
+	# Use get_current_in_game_minutes to get the current in-game minutes
+	var current_minutes_of_day = get_current_in_game_minutes()
 
-	# Calculate the percentage of the day completed
-	# Divide the current minutes of the day by the total in-game minutes per day
+	# Calculate percentage of the day completed
 	return (current_minutes_of_day / float(in_game_day_minutes)) * 100.0
 
 
-# Returns the current in-game minute as an integer value (0 to 1440),
-# representing the number of minutes passed since the start of the in-game day.
+# Returns the current number of in-game minutes in an in-game day, a value between 0 and 1440
 func get_current_in_game_minutes() -> int:
-	# Scale real-life elapsed time to in-game time.
-	# _elapsed_time is the total real-life time in seconds, divided by day_duration to scale to in-game days.
-	# Multiplying by in_game_day_minutes converts the scaled time to in-game minutes.
-	# Example: Real-life elapsed time (_elapsed_time): 1050 seconds (17.5 minutes in real time)
-	# _elapsed_time / day_duration: 1050 / (35 * 60) = 0.5 (Half an in-game day has passed).
-	# scaled_elapsed_time = 0.5 * 1440 = 720 (720 in-game minutes have passed).
-	var scaled_elapsed_time = (_elapsed_time / day_duration) * in_game_day_minutes
+	# Convert day_duration to seconds to match _elapsed_time
+	var day_duration_seconds = day_duration * 60.0
 
-	# Convert the scaled time into a whole number of in-game minutes.
-	# This represents the total number of in-game minutes passed since the game started.
-	# Example: total_in_game_minutes = int(720) = 720.
+	# Scale real-life elapsed time to in-game time
+	var scaled_elapsed_time = (_elapsed_time / day_duration_seconds) * in_game_day_minutes
+
+	# Convert the scaled time into a whole number of in-game minutes
 	var total_in_game_minutes: int = int(scaled_elapsed_time)
 
-	# Use modulo operation to wrap the total minutes into a single in-game day.
-	# This ensures the result is always between 0 and 1439 (1440 total minutes in a day).
-	# Example: current_minutes_of_day = 720 % 1440 = 720.
+	# Wrap the total minutes into a single in-game day
 	var current_minutes_of_day: int = total_in_game_minutes % in_game_day_minutes
 
-	# Return the current in-game minute of the day.
+	# Return the current in-game minute of the day
 	return current_minutes_of_day

--- a/Scripts/hud.gd
+++ b/Scripts/hud.gd
@@ -1,6 +1,8 @@
 extends CanvasLayer
 
 @export var stamina_HUD: NodePath
+@export var clock_label: Label = null
+
 
 @export var ammo_HUD_left: NodePath
 @export var ammo_HUD_right: NodePath
@@ -47,6 +49,8 @@ func _ready():
 	var buildmenu = get_node(building_menu)
 	buildmenu.visibility_changed.connect(\
 	Helper.signal_broker.on_build_menu_visibility_changed.bind(buildmenu))
+	Helper.time_helper.minute_passed.connect(_on_minute_passed)
+
 
 func update_progress_bar():
 	var progressBarNode = get_node(progress_bar_filling)
@@ -131,3 +135,7 @@ func _on_item_detector_add_to_proximity_inventory(container):
 # The parameter container the inventory that has left proximity
 func _on_item_detector_remove_from_proximity_inventory(container):
 	inventoryWindow._on_item_detector_remove_from_proximity_inventory(container)
+
+
+func _on_minute_passed(current_time: String):
+	clock_label.text = current_time  # Update the clock label

--- a/hud.tscn
+++ b/hud.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="Script" path="res://Scripts/hud.gd" id="1_s3xoj"]
 [ext_resource type="Script" path="res://Scripts/NonHUDclick.gd" id="2_kpbhl"]
 [ext_resource type="Texture2D" uid="uid://7hppy1l45loq" path="res://Textures/bar_progress.png" id="3_83uwt"]
-[ext_resource type="Resource" uid="uid://bxubu34gjes1y" path="res://ItemProtosets.tres" id="3_jmlkb"]
+[ext_resource type="Resource" uid="uid://dyabwmavhftem" path="res://ItemProtosets.tres" id="3_jmlkb"]
 [ext_resource type="Texture2D" uid="uid://dcgwgmsmi7mjn" path="res://Textures/bar_border.png" id="3_y43f5"]
 [ext_resource type="PackedScene" uid="uid://b6ooia1084wfx" path="res://Scenes/UI/AttributesWindow.tscn" id="6_6e87o"]
 [ext_resource type="PackedScene" uid="uid://drjw0yaxf8x1p" path="res://Scenes/UI/QuestTrackerUI.tscn" id="7_bbed4"]
@@ -21,9 +21,10 @@
 default_font = ExtResource("1_pxloi")
 default_font_size = 0
 
-[node name="HUD" type="CanvasLayer" node_paths=PackedStringArray("inventoryWindow", "characterWindow", "questWindow", "overmap")]
+[node name="HUD" type="CanvasLayer" node_paths=PackedStringArray("clock_label", "inventoryWindow", "characterWindow", "questWindow", "overmap")]
 script = ExtResource("1_s3xoj")
 stamina_HUD = NodePath("StaminaLevel")
+clock_label = NodePath("ClockLabel")
 ammo_HUD_left = NodePath("AmmoVisuals/LeftAmmo")
 ammo_HUD_right = NodePath("AmmoVisuals/RightAmmo")
 healthy_color = Color(0, 0.635294, 0, 1)
@@ -73,6 +74,17 @@ script = ExtResource("2_kpbhl")
 [node name="AttributesWindow" parent="." instance=ExtResource("6_6e87o")]
 
 [node name="QuestTracker" parent="." instance=ExtResource("7_bbed4")]
+
+[node name="ClockLabel" type="Label" parent="."]
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -20.5
+offset_right = 20.5
+offset_bottom = 23.0
+grow_horizontal = 2
+theme_override_font_sizes/font_size = 24
+text = "00:00"
 
 [node name="BloodLevel" type="Label" parent="."]
 anchors_preset = 2
@@ -207,6 +219,7 @@ loadingscreen = NodePath("../LoadingScreen")
 visible = false
 
 [node name="LoadingScreen" parent="." instance=ExtResource("20_kxcpa")]
+visible = false
 
 [connection signal="timeout" from="ProgressBar/ProgressBarTimer" to="." method="_on_progress_bar_timer_timeout"]
 [connection signal="mouse_entered" from="OutsideOfHUD" to="OutsideOfHUD" method="_on_mouse_entered"]

--- a/hud.tscn
+++ b/hud.tscn
@@ -219,7 +219,6 @@ loadingscreen = NodePath("../LoadingScreen")
 visible = false
 
 [node name="LoadingScreen" parent="." instance=ExtResource("20_kxcpa")]
-visible = false
 
 [connection signal="timeout" from="ProgressBar/ProgressBarTimer" to="." method="_on_progress_bar_timer_timeout"]
 [connection signal="mouse_entered" from="OutsideOfHUD" to="OutsideOfHUD" method="_on_mouse_entered"]


### PR DESCRIPTION
Adds `Helper.time_helper` that will manage time related functions. Also adds a clock to the UI so the player knows what time it is.

The script has definitions for a day cycle but the day/night cycle is not yet implemented. A full day takes an arbitrary 35 minutes. 

The game starts at 08:00 for now and 8 hours have indeed passed when starting the game. This is relevant in case we have more time related mechanics like food rot. 

The script has some convenient functions that we can use later when implementing more time mechanics. In due time I want this script to handle events as well.

The elapsed time is saved to your game and loaded when a save is loaded.