### PR TITLE
Day-night cycle 1.0

### DIFF
--- a/Scripts/Helper/time_helper.gd
+++ b/Scripts/Helper/time_helper.gd
@@ -139,3 +139,15 @@ func get_current_in_game_minutes() -> int:
 
 	# Return the current in-game minute of the day
 	return current_minutes_of_day
+	
+
+# Returns a number representing the current hour. For example:
+# Midnight will return 0.0
+# Noon will return 12.0
+# 10:14 will return 10.1
+func get_time_in_hr() -> float:
+	# Get the current in-game minutes
+	var current_minutes_of_day = get_current_in_game_minutes()
+	
+	# Map the current in-game minutes (0 to 1440) to animation frames (0 to 24)
+	return float(current_minutes_of_day) / in_game_day_minutes * 24.0

--- a/day_night.gd
+++ b/day_night.gd
@@ -1,0 +1,10 @@
+extends CanvasModulate
+@onready var ani_player = $AnimationPlayer
+@onready var timer = $Timer
+
+func _process(delta) -> void:
+	var time_passed = timer.wait_time - timer.time_left
+	var animation_frame = remap(time_passed, 0, timer.wait_time, 0, 24)
+	print(animation_frame)
+	ani_player.play("daynight")
+	ani_player.seek(animation_frame)

--- a/day_night.gd
+++ b/day_night.gd
@@ -2,9 +2,21 @@ extends CanvasModulate
 @onready var ani_player = $AnimationPlayer
 @onready var timer = $Timer
 
-func _process(delta) -> void:
-	var time_passed = timer.wait_time - timer.time_left
-	var animation_frame = remap(time_passed, 0, timer.wait_time, 0, 24)
-	print(animation_frame)
-	ani_player.play("daynight")
-	ani_player.seek(animation_frame)
+# This script belongs to `day_night.tscn`
+# It will animate the daylight color based on the current time of day
+# The color is then read by `front_light.gd` that manipulates the lights' color.
+
+
+func _ready():
+	Helper.time_helper.minute_passed.connect(_on_minute_passed)
+
+func _on_minute_passed(current_time: String):
+	# Map the current in-game minutes (0 to 1440) to animation frames (0 to 24)
+	var animation_frame = Helper.time_helper.get_time_in_hr()
+	
+	# Seek the animation to the calculated frame. 
+	# The animation has a speed of 0 so it doesn't actually play.
+	# This is because when we set the animation frame it might skip to another point and
+	# you can see the light flicker because of it.
+	ani_player.play("daynight", -1, 0.0)
+	ani_player.seek(animation_frame, true, true)

--- a/day_night.tscn
+++ b/day_night.tscn
@@ -2,22 +2,6 @@
 
 [ext_resource type="Script" path="res://day_night.gd" id="1_iw4nk"]
 
-[sub_resource type="Animation" id="Animation_72a8g"]
-resource_name = "daynight"
-length = 24.0
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath(".:color")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 1, 2, 3, 4, 5, 5.76667, 6.5, 7.5, 10, 12, 15.5, 18, 20.9667, 24),
-"transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
-"update": 0,
-"values": [Color(1.03481e-06, 0, 0.495731, 1), Color(1.82897e-06, 3.85046e-07, 0.635201, 1), Color(1.84774e-06, 3.57628e-07, 0.635201, 1), Color(2.11775e-06, 5.77569e-07, 0.681749, 1), Color(4.23551e-06, 4.23551e-06, 0.941456, 1), Color(0.106641, 0.338589, 0.999996, 1), Color(0.44497, 0.506755, 0.85487, 1), Color(0.843137, 0.47451, 0, 1), Color(0.784314, 0.580392, 0, 1), Color(0.890196, 0.772549, 0, 1), Color(1, 0.745098, 0.329412, 1), Color(0.874738, 0.493752, 1.03962e-05, 1), Color(0.677192, 0.377156, 4.04298e-06, 1), Color(0, 0, 0.941176, 1), Color(0, 0, 0.494118, 1)]
-}
-
 [sub_resource type="Animation" id="Animation_g822v"]
 length = 0.001
 tracks/0/type = "value"
@@ -31,6 +15,22 @@ tracks/0/keys = {
 "transitions": PackedFloat32Array(1),
 "update": 0,
 "values": [Color(1, 1, 1, 1)]
+}
+
+[sub_resource type="Animation" id="Animation_72a8g"]
+resource_name = "daynight"
+length = 24.0
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:color")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 1, 2, 3, 4, 5, 5.76667, 6.5, 7.5, 9, 14, 19, 20, 20.9667, 24),
+"transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+"update": 0,
+"values": [Color(1.03481e-06, 0, 0.495731, 1), Color(1.82897e-06, 3.85046e-07, 0.635201, 1), Color(1.84774e-06, 3.57628e-07, 0.635201, 1), Color(2.11775e-06, 5.77569e-07, 0.681749, 1), Color(4.23551e-06, 4.23551e-06, 0.941456, 1), Color(0.106641, 0.338589, 0.999996, 1), Color(0.44497, 0.506755, 0.85487, 1), Color(0.843137, 0.47451, 0, 1), Color(0.784314, 0.580392, 0, 1), Color(0.890196, 0.772549, 0, 1), Color(1, 0.745098, 0.329412, 1), Color(0.874738, 0.493752, 1.03962e-05, 1), Color(0.677192, 0.377156, 4.04298e-06, 1), Color(0, 0, 0.941176, 1), Color(0, 0, 0.494118, 1)]
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_m3ech"]

--- a/day_night.tscn
+++ b/day_night.tscn
@@ -1,0 +1,52 @@
+[gd_scene load_steps=5 format=3 uid="uid://bisxe8aexlshr"]
+
+[ext_resource type="Script" path="res://day_night.gd" id="1_iw4nk"]
+
+[sub_resource type="Animation" id="Animation_72a8g"]
+resource_name = "daynight"
+length = 24.0
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:color")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 1, 2, 3, 4, 5, 5.76667, 6.5, 7.5, 10, 12, 15.5, 18, 20.9667, 24),
+"transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+"update": 0,
+"values": [Color(1.03481e-06, 0, 0.495731, 1), Color(1.82897e-06, 3.85046e-07, 0.635201, 1), Color(1.84774e-06, 3.57628e-07, 0.635201, 1), Color(2.11775e-06, 5.77569e-07, 0.681749, 1), Color(4.23551e-06, 4.23551e-06, 0.941456, 1), Color(0.106641, 0.338589, 0.999996, 1), Color(0.44497, 0.506755, 0.85487, 1), Color(0.843137, 0.47451, 0, 1), Color(0.784314, 0.580392, 0, 1), Color(0.890196, 0.772549, 0, 1), Color(1, 0.745098, 0.329412, 1), Color(0.874738, 0.493752, 1.03962e-05, 1), Color(0.677192, 0.377156, 4.04298e-06, 1), Color(0, 0, 0.941176, 1), Color(0, 0, 0.494118, 1)]
+}
+
+[sub_resource type="Animation" id="Animation_g822v"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:color")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(1, 1, 1, 1)]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_m3ech"]
+_data = {
+"RESET": SubResource("Animation_g822v"),
+"daynight": SubResource("Animation_72a8g")
+}
+
+[node name="day_night" type="CanvasModulate"]
+script = ExtResource("1_iw4nk")
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+"": SubResource("AnimationLibrary_m3ech")
+}
+
+[node name="Timer" type="Timer" parent="."]
+wait_time = 50.0
+autostart = true

--- a/front_light.gd
+++ b/front_light.gd
@@ -1,10 +1,7 @@
 extends SpotLight3D
 
-
-# Called when the node enters the scene tree for the first time.
-func _ready():
-	pass # Replace with function body.
-
+# This script is used in the main player light that allows him to see
+# Here we manipulate the brightness to simulate the time of day.
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):

--- a/front_light.gd
+++ b/front_light.gd
@@ -1,0 +1,11 @@
+extends SpotLight3D
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	%FrontLight.light_color = $day_night.color

--- a/level_generation.tscn
+++ b/level_generation.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=31 format=3 uid="uid://drl78uuphij1l"]
+[gd_scene load_steps=33 format=3 uid="uid://drl78uuphij1l"]
 
 [ext_resource type="Script" path="res://LevelGenerator.gd" id="1_i8qa4"]
 [ext_resource type="Script" path="res://LevelManager.gd" id="2_gm6x7"]
+[ext_resource type="PackedScene" uid="uid://bisxe8aexlshr" path="res://day_night.tscn" id="3_0lu7f"]
 [ext_resource type="Script" path="res://Scripts/ConstructionGhost.gd" id="5_iwiv4"]
 [ext_resource type="Script" path="res://Scripts/BuildManager.gd" id="6_y7rk5"]
 [ext_resource type="Texture2D" uid="uid://d33h00t0fl7x" path="res://Defaults/Player/VestDude01.png" id="7_jr4x1"]
@@ -19,6 +20,7 @@
 [ext_resource type="PackedScene" uid="uid://c6txt3py4smbb" path="res://front_light.tscn" id="15_coxfn"]
 [ext_resource type="Script" path="res://Scripts/ItemDetector.gd" id="15_r1xed"]
 [ext_resource type="Script" path="res://Scripts/Components/ComponentInteract.gd" id="16_v28fk"]
+[ext_resource type="Script" path="res://front_light.gd" id="16_xq4yf"]
 [ext_resource type="PackedScene" uid="uid://clhj525tmme3k" path="res://hud.tscn" id="17_qnmns"]
 [ext_resource type="AudioStream" uid="uid://b1q36r8e5wmen" path="res://Sounds/Music/Just in Reach of Sirens.mp3" id="18_ddslh"]
 
@@ -204,6 +206,10 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.179206, 0)
 shape = SubResource("ConvexPolygonShape3D_drnhn")
 
 [node name="FrontLight" parent="TacticalMap/Entities/Player/Sprite3D2" instance=ExtResource("15_coxfn")]
+unique_name_in_owner = true
+script = ExtResource("16_xq4yf")
+
+[node name="day_night" parent="TacticalMap/Entities/Player/Sprite3D2/FrontLight" instance=ExtResource("3_0lu7f")]
 
 [node name="Shooting" type="Node3D" parent="TacticalMap/Entities/Player" node_paths=PackedStringArray("left_hand_item", "right_hand_item")]
 script = ExtResource("11_6i2sa")


### PR DESCRIPTION
This is the first implementation of the function and may be subject to change or be deleted.

As of now, it has two issues (one major, the other insignificant)
1. The time system snipercup implemented has to be connected to time_passed in day_night.gd, so that the cycle automatically changes depending on the time of the day.

2. Adjust colors and maybe add even more color keys to AnimationPlayer, so that there is more variety of colors.