### PR TITLE
Remove map reference functions, remove map from overmaparea

### DIFF
--- a/Mods/Core/Maps/references.json
+++ b/Mods/Core/Maps/references.json
@@ -1,4 +1,14 @@
 {
+	"Generichouse": {
+		"overmapareas": [
+			"city"
+		]
+	},
+	"Generichouse_00": {
+		"overmapareas": [
+			"city"
+		]
+	},
 	"RockyHill_NE": {
 		"tacticalmaps": [
 			"RockyHill_00"
@@ -22,9 +32,107 @@
 			"RockyHill_00"
 		]
 	},
+	"abandoned_building": {
+		"overmapareas": [
+			"city"
+		]
+	},
+	"city_square": {
+		"overmapareas": [
+			"city"
+		]
+	},
+	"field_grass_basic_00": {
+		"overmapareas": [
+			"city"
+		]
+	},
+	"field_grass_flowers_00": {
+		"overmapareas": [
+			"city"
+		]
+	},
+	"field_grass_hill_00": {
+		"overmapareas": [
+			"city"
+		]
+	},
+	"field_grass_hole_00": {
+		"overmapareas": [
+			"city"
+		]
+	},
+	"generichouse_corner": {
+		"overmapareas": [
+			"city"
+		]
+	},
+	"generichouse_cross": {
+		"overmapareas": [
+			"city"
+		]
+	},
+	"generichouse_end": {
+		"overmapareas": [
+			"city"
+		]
+	},
+	"generichouse_t": {
+		"overmapareas": [
+			"city"
+		]
+	},
+	"neighborhood_school": {
+		"overmapareas": [
+			"city"
+		]
+	},
+	"office_building_00": {
+		"overmapareas": [
+			"city"
+		]
+	},
+	"parking_garage": {
+		"overmapareas": [
+			"city"
+		]
+	},
 	"police_station": {
+		"overmapareas": [
+			"city"
+		],
 		"quests": [
 			"starter_tutorial_00"
+		]
+	},
+	"radio_tower": {
+		"overmapareas": [
+			"city"
+		]
+	},
+	"skyscraper": {
+		"overmapareas": [
+			"city"
+		]
+	},
+	"store_electronic_clothing": {
+		"overmapareas": [
+			"city"
+		]
+	},
+	"store_groceries": {
+		"overmapareas": [
+			"city"
+		]
+	},
+	"subway_station": {
+		"overmapareas": [
+			"city"
+		]
+	},
+	"two_story_house": {
+		"overmapareas": [
+			"city"
 		]
 	}
 }

--- a/Mods/Core/Tiles/Tiles.json
+++ b/Mods/Core/Tiles/Tiles.json
@@ -6,13 +6,6 @@
 		"description": "Field of grass",
 		"id": "grass_plain",
 		"name": "Plain grass",
-		"references": {
-			"core": {
-				"maps": [
-					"RockyHill_NW"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "1.png"
 	},
@@ -23,13 +16,6 @@
 		"description": "The floor is old and the boards are crooked",
 		"id": "floor_wood_shabby_00",
 		"name": "Low quality wood floor",
-		"references": {
-			"core": {
-				"maps": [
-					"neighborhood_school"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "woodboards.png"
 	},
@@ -85,38 +71,6 @@
 		"description": "A smooth surface for vehicles to drive on",
 		"id": "road_asphalt_basic",
 		"name": "Basic asphalt road",
-		"references": {
-			"core": {
-				"maps": [
-					"urbanroad_t",
-					"urbanroad_corner",
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"store_electronic_clothing",
-					"Generichouse",
-					"Generichouse_00",
-					"store_groceries",
-					"abandoned_building",
-					"generichouse_end",
-					"urbanroad",
-					"urbanroad_cross",
-					"forest_road_straight",
-					"forest_road_corner",
-					"forest_road_t",
-					"forest_road_cross",
-					"subway_station",
-					"parking_garage",
-					"city_square",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"radio_tower",
-					"police_station"
-				]
-			}
-		},
 		"sprite": "asphalt_basic.png"
 	},
 	{
@@ -144,19 +98,6 @@
 		"description": "A smooth surface for vehicles to drive on. It has horizontal markings",
 		"id": "road_asphalt_horizontal",
 		"name": "Asphalt road with horizontal markings",
-		"references": {
-			"core": {
-				"maps": [
-					"store_groceries",
-					"parking_garage",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"radio_tower",
-					"police_station"
-				]
-			}
-		},
 		"sprite": "asphalt_middle_horizontal.png"
 	},
 	{
@@ -176,41 +117,6 @@
 		"description": "Field of grass",
 		"id": "grass_plain_01",
 		"name": "Plain grass",
-		"references": {
-			"core": {
-				"maps": [
-					"field_grass_basic_00",
-					"field_grass_flowers_00",
-					"field_grass_hill_00",
-					"urbanroad_t",
-					"urbanroad_corner",
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"store_electronic_clothing",
-					"Generichouse",
-					"Generichouse_00",
-					"RockyHill_SE",
-					"RockyHill_SW",
-					"store_groceries",
-					"field_grass_hole_00",
-					"RockyHill_NE",
-					"generichouse_end",
-					"RockyHill_NW",
-					"urbanroad",
-					"urbanroad_cross",
-					"subway_station",
-					"parking_garage",
-					"city_square",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"radio_tower",
-					"police_station"
-				]
-			}
-		},
 		"sprite": "basegrass1.png"
 	},
 	{
@@ -221,25 +127,6 @@
 		"description": "Wooden stairs that allow you to move up and down",
 		"id": "wood_stairs",
 		"name": "Wooden stairs",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"Generichouse",
-					"Generichouse_00",
-					"abandoned_building",
-					"generichouse_end",
-					"subway_station",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"radio_tower"
-				]
-			}
-		},
 		"shape": "slope",
 		"sprite": "4.png"
 	},
@@ -251,15 +138,6 @@
 		"description": "A solid wall made out of bricks",
 		"id": "brick_wall_00",
 		"name": "Brick wall",
-		"references": {
-			"core": {
-				"maps": [
-					"store_electronic_clothing",
-					"Generichouse",
-					"two_story_house"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "brickroad2.png"
 	},
@@ -271,24 +149,6 @@
 		"description": "A warm red carpet",
 		"id": "red_carpet_00",
 		"name": "Red carpet",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"store_electronic_clothing",
-					"Generichouse",
-					"Generichouse_00",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"radio_tower"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "redcarpet.png"
 	},
@@ -300,23 +160,6 @@
 		"description": "A warm blue carpet",
 		"id": "blue_carpet_00",
 		"name": "Blue carpet",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"Generichouse",
-					"Generichouse_00",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"store_electronic_clothing"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "bluecarpet.png"
 	},
@@ -328,23 +171,6 @@
 		"description": "A warm orange carpet",
 		"id": "orange_carpet_00",
 		"name": "Orange carpet",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"Generichouse",
-					"Generichouse_00",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"store_electronic_clothing"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "browncarpet.png"
 	},
@@ -356,19 +182,6 @@
 		"description": "A road made out of stones shaped like a beehive",
 		"id": "beehive_stones_00",
 		"name": "Beehive stones",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"store_electronic_clothing",
-					"Generichouse",
-					"Generichouse_00",
-					"generichouse_end"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "beehive1.png"
 	},
@@ -380,24 +193,6 @@
 		"description": "Simple wooden floor boards that may be laid in a decorative fasion",
 		"id": "floor_wood_boards_00",
 		"name": "Wooden floor boards",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"Generichouse_00",
-					"Generichouse",
-					"store_groceries",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"store_electronic_clothing"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "woodboards10.png"
 	},
@@ -409,24 +204,6 @@
 		"description": "Simple wooden floor boards that may be laid in a decorative fasion",
 		"id": "floor_wood_boards_01",
 		"name": "Wooden floor boards",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_cross",
-					"generichouse_t",
-					"Generichouse_00",
-					"Generichouse",
-					"store_groceries",
-					"generichouse_corner",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"store_electronic_clothing"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "woodboards11.png"
 	},
@@ -438,24 +215,6 @@
 		"description": "Simple wooden floor boards that may be laid in a decorative fasion",
 		"id": "floor_wood_boards_02",
 		"name": "Wooden floor boards",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_corner",
-					"generichouse_t",
-					"Generichouse",
-					"Generichouse_00",
-					"store_groceries",
-					"generichouse_cross",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"store_electronic_clothing"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "woodboards12.png"
 	},
@@ -467,23 +226,6 @@
 		"description": "Simple wooden floor boards that may be laid in a decorative fasion",
 		"id": "floor_wood_boards_03",
 		"name": "Wooden floor boards",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"Generichouse",
-					"Generichouse_00",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"store_electronic_clothing"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "woodboards13.png"
 	},
@@ -495,23 +237,6 @@
 		"description": "Simple wooden floor boards that may be laid in a decorative fasion",
 		"id": "floor_wood_boards_04",
 		"name": "Wooden floor boards",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_corner",
-					"generichouse_cross",
-					"Generichouse",
-					"Generichouse_00",
-					"generichouse_t",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"store_electronic_clothing"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "woodboards14.png"
 	},
@@ -523,21 +248,6 @@
 		"description": "Simple wooden floor boards that may be laid in a decorative fasion",
 		"id": "floor_wood_boards_05",
 		"name": "Wooden floor boards",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"Generichouse",
-					"Generichouse_00",
-					"generichouse_end",
-					"office_building_00",
-					"neighborhood_school",
-					"two_story_house"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "woodboards6.png"
 	},
@@ -549,21 +259,6 @@
 		"description": "Simple wooden floor boards that may be laid in a decorative fasion",
 		"id": "floor_wood_boards_06",
 		"name": "Wooden floor boards",
-		"references": {
-			"core": {
-				"maps": [
-					"Generichouse",
-					"Generichouse_00",
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"generichouse_end",
-					"office_building_00",
-					"neighborhood_school",
-					"two_story_house"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "woodboards7.png"
 	},
@@ -575,24 +270,6 @@
 		"description": "Simple wooden floor boards that may be laid in a decorative fasion",
 		"id": "floor_wood_boards_07",
 		"name": "Wooden floor boards",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"store_electronic_clothing",
-					"Generichouse",
-					"Generichouse_00",
-					"store_groceries",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "woodboards8.png"
 	},
@@ -604,24 +281,6 @@
 		"description": "Simple wooden floor boards that may be laid in a decorative fasion",
 		"id": "floor_wood_boards_08",
 		"name": "Wooden floor boards",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_corner",
-					"generichouse_t",
-					"Generichouse",
-					"Generichouse_00",
-					"store_groceries",
-					"generichouse_cross",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"store_electronic_clothing"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "woodboards9.png"
 	},
@@ -762,13 +421,6 @@
 		"description": "The ground is covered in fine sand",
 		"id": "sand_fine_00",
 		"name": "Fine sand",
-		"references": {
-			"core": {
-				"maps": [
-					"neighborhood_school"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "fineand.png"
 	},
@@ -779,16 +431,6 @@
 		"description": "A hard suface with a dark color.",
 		"id": "rock_floor_00",
 		"name": "Rock floor",
-		"references": {
-			"core": {
-				"maps": [
-					"RockyHill_SE",
-					"RockyHill_SW",
-					"RockyHill_NE",
-					"RockyHill_NW"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "rockyfloor1.png"
 	},
@@ -799,16 +441,6 @@
 		"description": "A hard suface with a dark color.",
 		"id": "rock_floor_01",
 		"name": "Rock floor",
-		"references": {
-			"core": {
-				"maps": [
-					"RockyHill_SE",
-					"RockyHill_SW",
-					"RockyHill_NE",
-					"RockyHill_NW"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "rockyfloor2.png"
 	},
@@ -819,15 +451,6 @@
 		"description": "A hard suface with a dark color.",
 		"id": "rock_floor_02",
 		"name": "Rock floor",
-		"references": {
-			"core": {
-				"maps": [
-					"RockyHill_SE",
-					"RockyHill_SW",
-					"RockyHill_NW"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "rockyfloor3.png"
 	},
@@ -838,16 +461,6 @@
 		"description": "A hard suface with a dark color.",
 		"id": "rock_floor_03",
 		"name": "Rock floor",
-		"references": {
-			"core": {
-				"maps": [
-					"RockyHill_SE",
-					"RockyHill_SW",
-					"RockyHill_NE",
-					"RockyHill_NW"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "rockfloor.png"
 	},
@@ -858,15 +471,6 @@
 		"description": "A hard suface with a dark color.",
 		"id": "rock_floor_04",
 		"name": "Rock floor",
-		"references": {
-			"core": {
-				"maps": [
-					"RockyHill_SE",
-					"RockyHill_SW",
-					"RockyHill_NW"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "rockyfloor4.png"
 	},
@@ -877,16 +481,6 @@
 		"description": "A hard suface with a dark color.",
 		"id": "rock_floor_05",
 		"name": "Rock floor",
-		"references": {
-			"core": {
-				"maps": [
-					"RockyHill_SE",
-					"RockyHill_SW",
-					"RockyHill_NE",
-					"RockyHill_NW"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "rockyfloor5.png"
 	},
@@ -897,16 +491,6 @@
 		"description": "A hard suface with a dark color.",
 		"id": "rock_floor_06",
 		"name": "Rock floor",
-		"references": {
-			"core": {
-				"maps": [
-					"RockyHill_SE",
-					"RockyHill_SW",
-					"RockyHill_NE",
-					"RockyHill_NW"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "rockyfloor6.png"
 	},
@@ -917,18 +501,6 @@
 		"description": "A rocky surface allowing you to move up or down",
 		"id": "rock_slope_00",
 		"name": "Rock slope",
-		"references": {
-			"core": {
-				"maps": [
-					"RockyHill_SE",
-					"RockyHill_SW",
-					"RockyHill_NE",
-					"RockyHill_NW",
-					"parking_garage",
-					"skyscraper"
-				]
-			}
-		},
 		"shape": "slope",
 		"sprite": "rockyfloorrampnorth.png"
 	},
@@ -939,14 +511,6 @@
 		"description": "A rocky surface that doesn't leave any footprints",
 		"id": "rocky_earth_00",
 		"name": "Rock floor",
-		"references": {
-			"core": {
-				"maps": [
-					"Generichouse_00",
-					"RockyHill_SW"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "rockyearth.png"
 	},
@@ -987,13 +551,6 @@
 		"description": "A sturdy metal wall. The surface seems scratched and a bit worn.",
 		"id": "metal_wall_00",
 		"name": "Metal wall",
-		"references": {
-			"core": {
-				"maps": [
-					"radio_tower"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "metalwall1.png"
 	},
@@ -1005,23 +562,6 @@
 		"description": "A tiled floor you would find in a kitchen. The tiles are painted yellow",
 		"id": "kitchen_tiles_yellow_00",
 		"name": "Kitchen tiles (yellow)",
-		"references": {
-			"core": {
-				"maps": [
-					"store_electronic_clothing",
-					"Generichouse",
-					"store_groceries",
-					"Generichouse_00",
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"generichouse_end",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "kitchentiles.png"
 	},
@@ -1033,23 +573,6 @@
 		"description": "A tiled floor you would find in a kitchen. The tiles are painted yellow",
 		"id": "kitchen_tiles_yellow_01",
 		"name": "Kitchen tiles (yellow)",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_cross",
-					"store_electronic_clothing",
-					"Generichouse",
-					"store_groceries",
-					"Generichouse_00",
-					"generichouse_corner",
-					"generichouse_t",
-					"generichouse_end",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "kitchentiles1.png"
 	},
@@ -1061,23 +584,6 @@
 		"description": "A tiled floor you would find in a kitchen. The tiles are painted yellow",
 		"id": "kitchen_tiles_yellow_02",
 		"name": "Kitchen tiles (yellow)",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_t",
-					"store_electronic_clothing",
-					"Generichouse",
-					"store_groceries",
-					"Generichouse_00",
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_end",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "Kitchentiles2.png"
 	},
@@ -1089,24 +595,6 @@
 		"description": "A tiled floor you would find in a kitchen. The tiles are painted mint",
 		"id": "kitchen_tiles_mint_00",
 		"name": "Kitchen tiles (mint)",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_t",
-					"store_electronic_clothing",
-					"Generichouse",
-					"Generichouse_00",
-					"store_groceries",
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "kitchentilesblue.png"
 	},
@@ -1118,24 +606,6 @@
 		"description": "A tiled floor you would find in a kitchen. The tiles are painted mint",
 		"id": "kitchen_tiles_mint_01",
 		"name": "Kitchen tiles (mint)",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"store_electronic_clothing",
-					"Generichouse",
-					"store_groceries",
-					"Generichouse_00",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "kitchentilesblue1.png"
 	},
@@ -1147,23 +617,6 @@
 		"description": "A tiled floor you would find in a kitchen. The tiles are painted mint",
 		"id": "kitchen_tiles_mint_02",
 		"name": "Kitchen tiles (mint)",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_corner",
-					"store_electronic_clothing",
-					"Generichouse",
-					"Generichouse_00",
-					"generichouse_cross",
-					"generichouse_t",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "kitchentilesblue2.png"
 	},
@@ -1175,24 +628,6 @@
 		"description": "A tiled floor you would find in a kitchen. The tiles are painted mint",
 		"id": "kitchen_tiles_mint_03",
 		"name": "Kitchen tiles (mint)",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_corner",
-					"store_electronic_clothing",
-					"Generichouse",
-					"store_groceries",
-					"Generichouse_00",
-					"generichouse_cross",
-					"generichouse_t",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "kitchentilesblue3.png"
 	},
@@ -1204,25 +639,6 @@
 		"description": "A tiled floor you would find in a kitchen. The tiles are painted green",
 		"id": "kitchen_tiles_green_00",
 		"name": "Kitchen tiles (green)",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_t",
-					"Generichouse",
-					"store_groceries",
-					"Generichouse_00",
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"radio_tower",
-					"store_electronic_clothing"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "kitchentilesgreen.png"
 	},
@@ -1234,24 +650,6 @@
 		"description": "A tiled floor you would find in a kitchen. The tiles are painted green",
 		"id": "kitchen_tiles_green_01",
 		"name": "Kitchen tiles (green)",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"Generichouse_00",
-					"Generichouse",
-					"store_groceries",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"store_electronic_clothing"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "kitchentilesgreen1.png"
 	},
@@ -1263,24 +661,6 @@
 		"description": "A tiled floor you would find in a kitchen. The tiles are painted green",
 		"id": "kitchen_tiles_green_02",
 		"name": "Kitchen tiles (green)",
-		"references": {
-			"core": {
-				"maps": [
-					"Generichouse",
-					"store_groceries",
-					"Generichouse_00",
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"store_electronic_clothing"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "kitchentilesgreen2.png"
 	},
@@ -1292,24 +672,6 @@
 		"description": "A tiled floor you would find in a kitchen. The tiles are painted blue",
 		"id": "kitchen_tiles_blue_00",
 		"name": "Kitchen tiles (blue)",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_t",
-					"store_electronic_clothing",
-					"Generichouse",
-					"store_groceries",
-					"Generichouse_00",
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "KitchentilesPurple.png"
 	},
@@ -1321,24 +683,6 @@
 		"description": "A tiled floor you would find in a kitchen. The tiles are painted blue",
 		"id": "kitchen_tiles_blue_01",
 		"name": "Kitchen tiles (blue)",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_corner",
-					"Generichouse",
-					"store_groceries",
-					"Generichouse_00",
-					"generichouse_cross",
-					"generichouse_t",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"store_electronic_clothing"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "kitchentilespurple1.png"
 	},
@@ -1350,24 +694,6 @@
 		"description": "A tiled floor you would find in a kitchen. The tiles are painted blue",
 		"id": "kitchen_tiles_blue_02",
 		"name": "Kitchen tiles (blue)",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_corner",
-					"store_electronic_clothing",
-					"Generichouse_00",
-					"Generichouse",
-					"store_groceries",
-					"generichouse_cross",
-					"generichouse_t",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "Kitchentilespurple2.png"
 	},
@@ -1379,24 +705,6 @@
 		"description": "A tiled floor you would find in a kitchen. The tiles are painted purple",
 		"id": "kitchen_tiles_purple_00",
 		"name": "Kitchen tiles (purple)",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"store_electronic_clothing",
-					"Generichouse_00",
-					"Generichouse",
-					"store_groceries",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "kitchentilespurple3.png"
 	},
@@ -1408,23 +716,6 @@
 		"description": "A tiled floor you would find in a kitchen. The tiles are painted purple",
 		"id": "kitchen_tiles_purple_01",
 		"name": "Kitchen tiles (purple)",
-		"references": {
-			"core": {
-				"maps": [
-					"Generichouse",
-					"store_groceries",
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"store_electronic_clothing"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "kitchentilespurple4.png"
 	},
@@ -1436,23 +727,6 @@
 		"description": "A tiled floor you would find in a kitchen. The tiles are painted purple",
 		"id": "kitchen_tiles_purple_02",
 		"name": "Kitchen tiles (purple)",
-		"references": {
-			"core": {
-				"maps": [
-					"Generichouse",
-					"store_groceries",
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"store_electronic_clothing"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "kitchentilespurple5.png"
 	},
@@ -1463,13 +737,6 @@
 		"description": "The ground is covered with small pebbles",
 		"id": "gravel_00",
 		"name": "Gravel",
-		"references": {
-			"core": {
-				"maps": [
-					"field_grass_hill_00"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "gravel.png"
 	},
@@ -1500,43 +767,6 @@
 		"description": "Dirt is barely visible trough the carpet of grass",
 		"id": "grass_dirt_00",
 		"name": "Grass with dirt",
-		"references": {
-			"core": {
-				"maps": [
-					"field_grass_basic_00",
-					"field_grass_flowers_00",
-					"field_grass_hill_00",
-					"urbanroad_t",
-					"urbanroad_corner",
-					"generichouse_corner",
-					"generichouse_t",
-					"store_electronic_clothing",
-					"forest_basic_00",
-					"RockyHill_SW",
-					"store_groceries",
-					"field_grass_hole_00",
-					"RockyHill_NE",
-					"generichouse_end",
-					"RockyHill_NW",
-					"urbanroad",
-					"urbanroad_cross",
-					"forest_road_straight",
-					"forest_road_corner",
-					"forest_road_t",
-					"forest_road_cross",
-					"subway_station",
-					"parking_garage",
-					"city_square",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"radio_tower",
-					"RockyHill_SE",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "grassdirt.png"
 	},
@@ -1547,43 +777,6 @@
 		"description": "Dirt is barely visible trough the carpet of grass",
 		"id": "grass_dirt_01",
 		"name": "Grass with dirt",
-		"references": {
-			"core": {
-				"maps": [
-					"field_grass_basic_00",
-					"field_grass_flowers_00",
-					"field_grass_hill_00",
-					"urbanroad_t",
-					"urbanroad_corner",
-					"generichouse_corner",
-					"generichouse_t",
-					"forest_basic_00",
-					"Generichouse_00",
-					"RockyHill_SE",
-					"RockyHill_SW",
-					"store_groceries",
-					"field_grass_hole_00",
-					"generichouse_end",
-					"RockyHill_NW",
-					"urbanroad",
-					"urbanroad_cross",
-					"forest_road_straight",
-					"forest_road_corner",
-					"forest_road_t",
-					"forest_road_cross",
-					"subway_station",
-					"parking_garage",
-					"city_square",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"radio_tower",
-					"RockyHill_NE",
-					"store_electronic_clothing",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "grassdirt1.png"
 	},
@@ -1594,42 +787,6 @@
 		"description": "Dirt is barely visible trough the carpet of grass",
 		"id": "grass_dirt_02",
 		"name": "Grass with dirt",
-		"references": {
-			"core": {
-				"maps": [
-					"field_grass_basic_00",
-					"field_grass_flowers_00",
-					"field_grass_hill_00",
-					"urbanroad_t",
-					"urbanroad_corner",
-					"generichouse_corner",
-					"generichouse_t",
-					"store_electronic_clothing",
-					"forest_basic_00",
-					"store_groceries",
-					"field_grass_hole_00",
-					"RockyHill_NE",
-					"generichouse_end",
-					"urbanroad",
-					"urbanroad_cross",
-					"forest_road_straight",
-					"forest_road_corner",
-					"forest_road_t",
-					"forest_road_cross",
-					"subway_station",
-					"parking_garage",
-					"city_square",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"radio_tower",
-					"RockyHill_SE",
-					"RockyHill_NW",
-					"RockyHill_SW",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "grassdirt2.png"
 	},
@@ -1640,45 +797,6 @@
 		"description": "Dirt is visible trough the grass",
 		"id": "grass_medium_dirt_00",
 		"name": "Grass with dirt",
-		"references": {
-			"core": {
-				"maps": [
-					"field_grass_basic_00",
-					"field_grass_flowers_00",
-					"field_grass_hill_00",
-					"urbanroad_t",
-					"urbanroad_corner",
-					"generichouse_corner",
-					"generichouse_t",
-					"store_electronic_clothing",
-					"forest_basic_00",
-					"Generichouse_00",
-					"RockyHill_SE",
-					"RockyHill_SW",
-					"store_groceries",
-					"abandoned_building",
-					"field_grass_hole_00",
-					"RockyHill_NE",
-					"generichouse_end",
-					"RockyHill_NW",
-					"urbanroad",
-					"urbanroad_cross",
-					"forest_road_straight",
-					"forest_road_corner",
-					"forest_road_t",
-					"forest_road_cross",
-					"subway_station",
-					"parking_garage",
-					"city_square",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"radio_tower",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "grasssmalldirt.png"
 	},
@@ -1689,45 +807,6 @@
 		"description": "Dirt is visible trough the grass",
 		"id": "grass_medium_dirt_01",
 		"name": "Grass with dirt",
-		"references": {
-			"core": {
-				"maps": [
-					"field_grass_basic_00",
-					"field_grass_flowers_00",
-					"field_grass_hill_00",
-					"urbanroad_t",
-					"urbanroad_corner",
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"store_electronic_clothing",
-					"forest_basic_00",
-					"Generichouse_00",
-					"RockyHill_SW",
-					"store_groceries",
-					"abandoned_building",
-					"field_grass_hole_00",
-					"RockyHill_NE",
-					"generichouse_end",
-					"urbanroad",
-					"urbanroad_cross",
-					"forest_road_straight",
-					"forest_road_corner",
-					"forest_road_t",
-					"forest_road_cross",
-					"subway_station",
-					"parking_garage",
-					"city_square",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"radio_tower",
-					"RockyHill_SE",
-					"RockyHill_NW",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "grasssmalldirt1.png"
 	},
@@ -1738,44 +817,6 @@
 		"description": "Dirt is visible trough the grass",
 		"id": "grass_medium_dirt_02",
 		"name": "Grass with dirt",
-		"references": {
-			"core": {
-				"maps": [
-					"field_grass_basic_00",
-					"field_grass_flowers_00",
-					"field_grass_hill_00",
-					"urbanroad_t",
-					"urbanroad_corner",
-					"generichouse_corner",
-					"store_electronic_clothing",
-					"forest_basic_00",
-					"Generichouse",
-					"RockyHill_SW",
-					"store_groceries",
-					"abandoned_building",
-					"field_grass_hole_00",
-					"RockyHill_NE",
-					"generichouse_end",
-					"RockyHill_NW",
-					"urbanroad",
-					"urbanroad_cross",
-					"forest_road_straight",
-					"forest_road_corner",
-					"forest_road_t",
-					"forest_road_cross",
-					"subway_station",
-					"parking_garage",
-					"city_square",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"radio_tower",
-					"RockyHill_SE",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "grasssmalldirt2.png"
 	},
@@ -1786,16 +827,6 @@
 		"description": "One side of the terrain is just dirt and no grass",
 		"id": "grass_dirt_north_00",
 		"name": "Grass with a patch of dirt",
-		"references": {
-			"core": {
-				"maps": [
-					"RockyHill_SW",
-					"neighborhood_school",
-					"radio_tower",
-					"RockyHill_NW"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "grassnorthdirt.png"
 	},
@@ -1806,16 +837,6 @@
 		"description": "The center of the terrain is just dirt and no grass",
 		"id": "grass_dirt_center_00",
 		"name": "Grass with a patch of dirt",
-		"references": {
-			"core": {
-				"maps": [
-					"field_grass_hill_00",
-					"RockyHill_NE",
-					"neighborhood_school",
-					"radio_tower"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "grasscenterdirt.png"
 	},
@@ -1826,34 +847,6 @@
 		"description": "Some flowers are sprouting trough the grass",
 		"id": "grass_flowers_00",
 		"name": "Grass with flowers",
-		"references": {
-			"core": {
-				"maps": [
-					"field_grass_flowers_00",
-					"field_grass_hill_00",
-					"urbanroad_t",
-					"urbanroad_corner",
-					"generichouse_corner",
-					"field_grass_basic_00",
-					"RockyHill_SE",
-					"RockyHill_SW",
-					"RockyHill_NE",
-					"generichouse_end",
-					"RockyHill_NW",
-					"urbanroad",
-					"urbanroad_cross",
-					"subway_station",
-					"parking_garage",
-					"city_square",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"radio_tower",
-					"store_electronic_clothing",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "grassflowers2.png"
 	},
@@ -1864,39 +857,6 @@
 		"description": "Some flowers are sprouting trough the grass",
 		"id": "grass_flowers_01",
 		"name": "Grass with flowers",
-		"references": {
-			"core": {
-				"maps": [
-					"field_grass_basic_00",
-					"field_grass_flowers_00",
-					"field_grass_hill_00",
-					"urbanroad_t",
-					"urbanroad_corner",
-					"generichouse_corner",
-					"generichouse_t",
-					"Generichouse",
-					"Generichouse_00",
-					"RockyHill_SE",
-					"RockyHill_SW",
-					"store_groceries",
-					"field_grass_hole_00",
-					"RockyHill_NE",
-					"generichouse_end",
-					"urbanroad",
-					"urbanroad_cross",
-					"subway_station",
-					"parking_garage",
-					"city_square",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"radio_tower",
-					"RockyHill_NW",
-					"store_electronic_clothing",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "grassflowers3.png"
 	},
@@ -1907,37 +867,6 @@
 		"description": "Some flowers are sprouting trough the grass",
 		"id": "grass_flowers_02",
 		"name": "Grass with flowers",
-		"references": {
-			"core": {
-				"maps": [
-					"field_grass_basic_00",
-					"field_grass_flowers_00",
-					"field_grass_hill_00",
-					"urbanroad_t",
-					"urbanroad_corner",
-					"generichouse_corner",
-					"generichouse_t",
-					"RockyHill_SW",
-					"store_groceries",
-					"field_grass_hole_00",
-					"generichouse_end",
-					"RockyHill_NW",
-					"urbanroad",
-					"urbanroad_cross",
-					"subway_station",
-					"parking_garage",
-					"city_square",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"radio_tower",
-					"RockyHill_SE",
-					"RockyHill_NE",
-					"store_electronic_clothing",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "grassflowers4.png"
 	},
@@ -1948,38 +877,6 @@
 		"description": "Some flowers are sprouting trough the grass",
 		"id": "grass_flowers_03",
 		"name": "Grass with flowers",
-		"references": {
-			"core": {
-				"maps": [
-					"field_grass_basic_00",
-					"field_grass_flowers_00",
-					"field_grass_hill_00",
-					"urbanroad_t",
-					"urbanroad_corner",
-					"generichouse_corner",
-					"generichouse_t",
-					"Generichouse",
-					"Generichouse_00",
-					"RockyHill_SE",
-					"RockyHill_SW",
-					"store_groceries",
-					"field_grass_hole_00",
-					"RockyHill_NE",
-					"generichouse_end",
-					"urbanroad",
-					"urbanroad_cross",
-					"subway_station",
-					"city_square",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"radio_tower",
-					"RockyHill_NW",
-					"store_electronic_clothing",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "grasslowers.png"
 	},
@@ -1990,14 +887,6 @@
 		"description": "This ramp is covered with grass. You can go up and down here",
 		"id": "grass_ramp_00",
 		"name": "Grass ramp",
-		"references": {
-			"core": {
-				"maps": [
-					"field_grass_hill_00",
-					"field_grass_hole_00"
-				]
-			}
-		},
 		"shape": "slope",
 		"sprite": "Grassrampnorth1.png"
 	},
@@ -2008,17 +897,6 @@
 		"description": "The ground is littered with twigs, leaves, sticks and all kinds of plant matter. Very tipical of a forest floor",
 		"id": "forest_underbrush_00",
 		"name": "Forest underbrush",
-		"references": {
-			"core": {
-				"maps": [
-					"forest_basic_00",
-					"forest_road_straight",
-					"forest_road_corner",
-					"forest_road_t",
-					"forest_road_cross"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "forestunderbrushscale.png"
 	},
@@ -2029,17 +907,6 @@
 		"description": "The ground is littered with twigs, leaves, sticks and all kinds of plant matter. Very tipical of a forest floor",
 		"id": "forest_underbrush_01",
 		"name": "Forest underbrush",
-		"references": {
-			"core": {
-				"maps": [
-					"forest_basic_00",
-					"forest_road_straight",
-					"forest_road_corner",
-					"forest_road_t",
-					"forest_road_cross"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "forestunderbrushscale1.png"
 	},
@@ -2050,17 +917,6 @@
 		"description": "The ground is littered with twigs, leaves, sticks and all kinds of plant matter. Very tipical of a forest floor",
 		"id": "forest_underbrush_02",
 		"name": "Forest underbrush",
-		"references": {
-			"core": {
-				"maps": [
-					"forest_basic_00",
-					"forest_road_straight",
-					"forest_road_corner",
-					"forest_road_t",
-					"forest_road_cross"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "forestunderbrushscale2.png"
 	},
@@ -2071,18 +927,6 @@
 		"description": "The ground is littered with twigs, leaves, sticks and all kinds of plant matter. Very tipical of a forest floor",
 		"id": "forest_underbrush_03",
 		"name": "Forest underbrush",
-		"references": {
-			"core": {
-				"maps": [
-					"forest_basic_00",
-					"RockyHill_SW",
-					"forest_road_straight",
-					"forest_road_corner",
-					"forest_road_t",
-					"forest_road_cross"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "forestunderbrushscale3.png"
 	},
@@ -2093,17 +937,6 @@
 		"description": "The ground is littered with twigs, leaves, sticks and all kinds of plant matter. Very tipical of a forest floor",
 		"id": "forest_underbrush_04",
 		"name": "Forest underbrush",
-		"references": {
-			"core": {
-				"maps": [
-					"forest_basic_00",
-					"forest_road_straight",
-					"forest_road_corner",
-					"forest_road_t",
-					"forest_road_cross"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "forestunderbrushscale4.png"
 	},
@@ -2114,17 +947,6 @@
 		"description": "The ground is littered with twigs, leaves, sticks and all kinds of plant matter. Very tipical of a forest floor",
 		"id": "forest_underbrush_05",
 		"name": "Forest underbrush",
-		"references": {
-			"core": {
-				"maps": [
-					"forest_basic_00",
-					"forest_road_straight",
-					"forest_road_corner",
-					"forest_road_t",
-					"forest_road_cross"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "forestunderbrushscale5.png"
 	},
@@ -2165,36 +987,6 @@
 		"description": "There is just dirt here. It's color is light",
 		"id": "dirt_light_00",
 		"name": "Dirt",
-		"references": {
-			"core": {
-				"maps": [
-					"field_grass_hill_00",
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"store_electronic_clothing",
-					"forest_basic_00",
-					"Generichouse",
-					"Generichouse_00",
-					"store_groceries",
-					"abandoned_building",
-					"field_grass_hole_00",
-					"generichouse_end",
-					"forest_road_straight",
-					"forest_road_corner",
-					"forest_road_t",
-					"forest_road_cross",
-					"subway_station",
-					"parking_garage",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"radio_tower",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "dirt3.png"
 	},
@@ -2205,29 +997,6 @@
 		"description": "There is just dirt here. It's color is light",
 		"id": "dirt_light_01",
 		"name": "Dirt",
-		"references": {
-			"core": {
-				"maps": [
-					"field_grass_hill_00",
-					"generichouse_corner",
-					"forest_basic_00",
-					"Generichouse",
-					"abandoned_building",
-					"generichouse_end",
-					"forest_road_straight",
-					"forest_road_corner",
-					"forest_road_t",
-					"forest_road_cross",
-					"subway_station",
-					"parking_garage",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "dirt4.png"
 	},
@@ -2238,26 +1007,6 @@
 		"description": "There is just dirt here. It's color is light",
 		"id": "dirt_light_02",
 		"name": "Dirt",
-		"references": {
-			"core": {
-				"maps": [
-					"field_grass_hill_00",
-					"forest_basic_00",
-					"abandoned_building",
-					"forest_road_straight",
-					"forest_road_corner",
-					"forest_road_t",
-					"forest_road_cross",
-					"subway_station",
-					"parking_garage",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "dirt5.png"
 	},
@@ -2268,14 +1017,6 @@
 		"description": "There is dirt here. Part of it is covered with grass",
 		"id": "dirt_light_grass_north_00",
 		"name": "Dirt with grass",
-		"references": {
-			"core": {
-				"maps": [
-					"field_grass_hill_00",
-					"field_grass_hole_00"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "dirtgrass.png"
 	},
@@ -2286,13 +1027,6 @@
 		"description": "There is dirt here. Part of it is covered with grass",
 		"id": "dirt_light_grass_north_01",
 		"name": "Dirt with grass",
-		"references": {
-			"core": {
-				"maps": [
-					"field_grass_hill_00"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "dirt_grass_north.png"
 	},
@@ -2373,13 +1107,6 @@
 		"description": "A tiled floor with colorful stones",
 		"id": "cobblestone_00",
 		"name": "Cobblestone",
-		"references": {
-			"core": {
-				"maps": [
-					"Generichouse"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "cobblestone.png"
 	},
@@ -2390,14 +1117,6 @@
 		"description": "A tiled floor with colorful stones",
 		"id": "cobblestone_01",
 		"name": "Cobblestone",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_corner",
-					"generichouse_end"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "cobblestone2.png"
 	},
@@ -2408,16 +1127,6 @@
 		"description": "A tiled floor with colorful stones",
 		"id": "cobblestone_02",
 		"name": "Cobblestone",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_corner",
-					"generichouse_t",
-					"Generichouse",
-					"generichouse_end"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "cobblestone3.png"
 	},
@@ -2449,23 +1158,6 @@
 		"description": "A solid wall made out of bricks",
 		"id": "brick_wall_01",
 		"name": "Brick wall",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"Generichouse",
-					"Generichouse_00",
-					"store_groceries",
-					"generichouse_end",
-					"office_building_00",
-					"neighborhood_school",
-					"two_story_house",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "brickroad.png"
 	},
@@ -2477,15 +1169,6 @@
 		"description": "A solid wall made out of bricks",
 		"id": "brick_wall_02",
 		"name": "Brick wall",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_corner",
-					"store_electronic_clothing",
-					"generichouse_end"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "brickroad1.png"
 	},
@@ -2508,22 +1191,6 @@
 		"description": "A tiled floor you would find in a bathroom. The tiles are painted blue",
 		"id": "bathroom_tiles_blue_00",
 		"name": "Bathroom tiles (blue)",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_cross",
-					"generichouse_t",
-					"Generichouse",
-					"Generichouse_00",
-					"store_groceries",
-					"generichouse_corner",
-					"generichouse_end",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "bathroomtiles.png"
 	},
@@ -2535,17 +1202,6 @@
 		"description": "A stone floor wihere the stones are shaped like an arch. Used in an urban environement.",
 		"id": "arc_stones_floor_00",
 		"name": "Arc stones floor",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_corner",
-					"store_electronic_clothing",
-					"Generichouse",
-					"Generichouse_00",
-					"generichouse_end"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "arcstones1.png"
 	},
@@ -2557,30 +1213,6 @@
 		"description": "Part of the street that indicates this is a zone for pedestrians to walk on",
 		"id": "sidewalk_00",
 		"name": "Sidewalk",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_corner",
-					"generichouse_t",
-					"generichouse_cross",
-					"store_electronic_clothing",
-					"Generichouse",
-					"Generichouse_00",
-					"store_groceries",
-					"abandoned_building",
-					"generichouse_end",
-					"subway_station",
-					"parking_garage",
-					"city_square",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"radio_tower",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "sidewalk.png"
 	},
@@ -2591,27 +1223,6 @@
 		"description": "Concrete provides a smooth floor for wheels and is hard to break",
 		"id": "concrete_00",
 		"name": "Concrete",
-		"references": {
-			"core": {
-				"maps": [
-					"generichouse_corner",
-					"generichouse_t",
-					"Generichouse",
-					"Generichouse_00",
-					"store_groceries",
-					"abandoned_building",
-					"generichouse_end",
-					"subway_station",
-					"parking_garage",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"radio_tower",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "concrete.png"
 	},
@@ -2622,13 +1233,6 @@
 		"description": "Test",
 		"id": "floor_wood_realistic01",
 		"name": "Old wooden planks",
-		"references": {
-			"core": {
-				"maps": [
-					"Generichouse"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "woodenplanks01.png"
 	},
@@ -2639,13 +1243,6 @@
 		"description": "Test",
 		"id": "realistic_brick01",
 		"name": "Old brick wall",
-		"references": {
-			"core": {
-				"maps": [
-					"Generichouse"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "redbricks02.png"
 	},
@@ -2656,38 +1253,6 @@
 		"description": "A smooth surface for vehicles to drive on. It has horizontal markings",
 		"id": "road_asphalt_horizontal_top",
 		"name": "Asphalt road with horizontal markings",
-		"references": {
-			"core": {
-				"maps": [
-					"Generichouse",
-					"Generichouse_00",
-					"urbanroad_t",
-					"urbanroad_corner",
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"store_electronic_clothing",
-					"store_groceries",
-					"abandoned_building",
-					"generichouse_end",
-					"urbanroad",
-					"urbanroad_cross",
-					"forest_road_straight",
-					"forest_road_corner",
-					"forest_road_t",
-					"forest_road_cross",
-					"subway_station",
-					"parking_garage",
-					"city_square",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"radio_tower",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "asphalt_markings_side_top.png"
 	},
@@ -2699,26 +1264,6 @@
 		"description": "A linoleum floor you would find in a store. It's are painted blue",
 		"id": "linoleum_blue_00",
 		"name": "Linoleum tiles (blue)",
-		"references": {
-			"core": {
-				"maps": [
-					"Generichouse_00",
-					"Generichouse",
-					"store_groceries",
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"radio_tower",
-					"store_electronic_clothing",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "linoleum_blue.png"
 	},
@@ -2730,26 +1275,6 @@
 		"description": "A linoleum floor you would find in a store. It's are painted brown",
 		"id": "linoleum_brown_00",
 		"name": "Linoleum tiles (brown)",
-		"references": {
-			"core": {
-				"maps": [
-					"Generichouse",
-					"store_groceries",
-					"Generichouse_00",
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"radio_tower",
-					"store_electronic_clothing",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "linoleum_brown.png"
 	},
@@ -2761,26 +1286,6 @@
 		"description": "A linoleum floor you would find in a store. It's are painted brown",
 		"id": "linoleum_brown_01",
 		"name": "Linoleum tiles (brown)",
-		"references": {
-			"core": {
-				"maps": [
-					"Generichouse",
-					"store_groceries",
-					"Generichouse_00",
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"radio_tower",
-					"store_electronic_clothing",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "linoleum_brown1.png"
 	},
@@ -2792,26 +1297,6 @@
 		"description": "A linoleum floor you would find in a store. It's are painted green",
 		"id": "linoleum_green_01",
 		"name": "Linoleum tiles (green)",
-		"references": {
-			"core": {
-				"maps": [
-					"Generichouse",
-					"store_groceries",
-					"Generichouse_00",
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"radio_tower",
-					"store_electronic_clothing",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "linoleum_green.png"
 	},
@@ -2823,26 +1308,6 @@
 		"description": "A linoleum floor you would find in a store. It's are painted green",
 		"id": "linoleum_green_00",
 		"name": "Linoleum tiles (green)",
-		"references": {
-			"core": {
-				"maps": [
-					"Generichouse",
-					"store_groceries",
-					"Generichouse_00",
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"radio_tower",
-					"store_electronic_clothing",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "linoleum_green1.png"
 	},
@@ -2854,26 +1319,6 @@
 		"description": "A linoleum floor you would find in a store. It's are painted green",
 		"id": "linoleum_green_02",
 		"name": "Linoleum tiles (green)",
-		"references": {
-			"core": {
-				"maps": [
-					"Generichouse_00",
-					"Generichouse",
-					"store_groceries",
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"radio_tower",
-					"store_electronic_clothing",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "linoleum_green2.png"
 	},
@@ -2885,26 +1330,6 @@
 		"description": "A linoleum floor you would find in a store. It's are painted grey/blue",
 		"id": "linoleum_greyblue_00",
 		"name": "Linoleum tiles (grey-blue)",
-		"references": {
-			"core": {
-				"maps": [
-					"Generichouse_00",
-					"Generichouse",
-					"store_groceries",
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"radio_tower",
-					"store_electronic_clothing",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "linoleum_greyblue.png"
 	},
@@ -2916,26 +1341,6 @@
 		"description": "A linoleum floor you would find in a store. It's are painted lightblue",
 		"id": "linoleum_lightblue_00",
 		"name": "Linoleum tiles (lightblue)",
-		"references": {
-			"core": {
-				"maps": [
-					"Generichouse_00",
-					"Generichouse",
-					"store_groceries",
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"radio_tower",
-					"store_electronic_clothing",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "linoleum_lightblue.png"
 	},
@@ -2947,26 +1352,6 @@
 		"description": "A linoleum floor you would find in a store. It's are painted lightblue",
 		"id": "linoleum_lightblue_01",
 		"name": "Linoleum tiles (lightblue)",
-		"references": {
-			"core": {
-				"maps": [
-					"Generichouse",
-					"store_groceries",
-					"Generichouse_00",
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"radio_tower",
-					"store_electronic_clothing",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "linoleum_lightblue1.png"
 	},
@@ -2978,26 +1363,6 @@
 		"description": "A linoleum floor you would find in a store. It's are painted lightblue",
 		"id": "linoleum_lightblue_02",
 		"name": "Linoleum tiles (lightblue)",
-		"references": {
-			"core": {
-				"maps": [
-					"Generichouse",
-					"store_groceries",
-					"Generichouse_00",
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"radio_tower",
-					"store_electronic_clothing",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "linoleum_lightblue2.png"
 	},
@@ -3009,25 +1374,6 @@
 		"description": "A linoleum floor you would find in a store. It's are painted white",
 		"id": "linoleum_white_00",
 		"name": "Linoleum tiles (white)",
-		"references": {
-			"core": {
-				"maps": [
-					"store_electronic_clothing",
-					"Generichouse",
-					"store_groceries",
-					"Generichouse_00",
-					"generichouse_corner",
-					"generichouse_t",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"radio_tower",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "linoleum_white.png"
 	},
@@ -3039,25 +1385,6 @@
 		"description": "A linoleum floor you would find in a store. It's are painted white",
 		"id": "linoleum_white_01",
 		"name": "Linoleum tiles (white)",
-		"references": {
-			"core": {
-				"maps": [
-					"store_electronic_clothing",
-					"Generichouse",
-					"store_groceries",
-					"Generichouse_00",
-					"generichouse_corner",
-					"generichouse_t",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"radio_tower",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "linoleum_white1.png"
 	},
@@ -3069,26 +1396,6 @@
 		"description": "A linoleum floor you would find in a store. It's are painted white",
 		"id": "linoleum_white_02",
 		"name": "Linoleum tiles (white)",
-		"references": {
-			"core": {
-				"maps": [
-					"store_electronic_clothing",
-					"Generichouse",
-					"store_groceries",
-					"Generichouse_00",
-					"generichouse_corner",
-					"generichouse_cross",
-					"generichouse_t",
-					"generichouse_end",
-					"office_building_00",
-					"skyscraper",
-					"neighborhood_school",
-					"two_story_house",
-					"radio_tower",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "linoleum_white2.png"
 	},
@@ -3099,16 +1406,6 @@
 		"description": "Damaged concrete surfaced with cracks running along it",
 		"id": "concrete__cracked_00",
 		"name": "Cracked concrete",
-		"references": {
-			"core": {
-				"maps": [
-					"abandoned_building",
-					"two_story_house",
-					"radio_tower",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "concrete_cracked_00.png"
 	},
@@ -3119,16 +1416,6 @@
 		"description": "Damaged concrete surfaced with cracks running along it",
 		"id": "concrete__cracked_01",
 		"name": "Cracked concrete",
-		"references": {
-			"core": {
-				"maps": [
-					"abandoned_building",
-					"two_story_house",
-					"radio_tower",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "concrete_cracked_01.png"
 	},
@@ -3139,16 +1426,6 @@
 		"description": "Damaged concrete surfaced with cracks running along it",
 		"id": "concrete__cracked_02",
 		"name": "Cracked concrete",
-		"references": {
-			"core": {
-				"maps": [
-					"abandoned_building",
-					"two_story_house",
-					"radio_tower",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "concrete_cracked_02.png"
 	},
@@ -3159,16 +1436,6 @@
 		"description": "Damaged concrete surfaced with cracks running along it. It is littered with bits of broken concrete.",
 		"id": "concrete__cracked_debris_00",
 		"name": "Cracked concrete with debris",
-		"references": {
-			"core": {
-				"maps": [
-					"abandoned_building",
-					"two_story_house",
-					"radio_tower",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "concrete_cracked_debris_00.png"
 	},
@@ -3179,16 +1446,6 @@
 		"description": "Damaged concrete surfaced with cracks running along it. It is littered with bits of broken concrete.",
 		"id": "concrete__cracked_debris_01",
 		"name": "Cracked concrete with debris",
-		"references": {
-			"core": {
-				"maps": [
-					"abandoned_building",
-					"two_story_house",
-					"radio_tower",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "concrete_cracked_debris_01.png"
 	},
@@ -3199,16 +1456,6 @@
 		"description": "Damaged concrete surfaced with cracks running along it. It is littered with bits of broken concrete.",
 		"id": "concrete__cracked_debris_02",
 		"name": "Cracked concrete with debris",
-		"references": {
-			"core": {
-				"maps": [
-					"abandoned_building",
-					"two_story_house",
-					"radio_tower",
-					"police_station"
-				]
-			}
-		},
 		"shape": "cube",
 		"sprite": "concrete_cracked_debris_02.png"
 	}

--- a/Scenes/ContentManager/Custom_Editors/Scripts/TerrainTileEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/TerrainTileEditor.gd
@@ -20,14 +20,14 @@ signal data_changed()
 var olddata: DTile # Remember what the value of the data was before editing
 var control_elements: Array = []
 # The data that represents this tile
-# The data is selected from the Gamedata.tiles array
+# The data is selected from the Gamedata.mods.by_id("Core").tiles array
 # based on the ID that the user has selected in the content editor
 var dtile: DTile = null:
 	set(value):
 		dtile = value
 		load_tile_data()
-		tileSelector.sprites_collection = Gamedata.tiles.sprites
-		olddata = DTile.new(dtile.get_data().duplicate(true))
+		tileSelector.sprites_collection = Gamedata.mods.by_id("Core").tiles.sprites
+		olddata = DTile.new(dtile.get_data().duplicate(true), null)
 
 
 func _ready():
@@ -56,7 +56,7 @@ func _input(event):
 # This function updates the form based on the dtile that has been loaded
 func load_tile_data():
 	if tileImageDisplay != null and dtile.spriteid:
-		var myTexture: Resource = Gamedata.tiles.sprite_by_file(dtile.spriteid)
+		var myTexture: Resource = Gamedata.mods.by_id("Core").tiles.sprite_by_file(dtile.spriteid)
 		tileImageDisplay.texture = myTexture
 		imageNameStringLabel.text = dtile.spriteid
 	if IDTextLabel != null:
@@ -81,7 +81,7 @@ func _on_close_button_button_up():
 	queue_free()
 
 # This function takes all data from the form elements and stores them in dtile
-# Since dtile is a reference to an item in Gamedata.tiles
+# Since dtile is a reference to an item in Gamedata.mods.by_id("Core").tiles
 # the central array for tile data is updated with the changes as well
 # The function will signal to Gamedata that the data has changed and needs to be saved
 func _on_save_button_button_up():
@@ -95,7 +95,7 @@ func _on_save_button_button_up():
 		dtile.shape = "slope"
 	dtile.changed(olddata)
 	data_changed.emit()
-	olddata = DTile.new(dtile.get_data().duplicate(true))
+	olddata = DTile.new(dtile.get_data().duplicate(true), null)
 
 # When the tileImageDisplay is clicked, the user will be prompted to select an image from
 # "res://Mods/Core/Tiles/". The texture of the tileImageDisplay will change to the selected image

--- a/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
@@ -819,7 +819,7 @@ func update_preview_texture_with_copied_data():
 func get_texture_from_tile_data(tile_data: Dictionary) -> Texture:
 	if tile_data.has("id"):
 		var texture_id = tile_data["id"]
-		return Gamedata.tiles.sprite_by_id(texture_id)
+		return Gamedata.mods.by_id("Core").tiles.sprite_by_id(texture_id)
 	else:
 		return load("res://Scenes/ContentManager/Mapeditor/Images/emptyTile.png")
 

--- a/Scenes/ContentManager/Mapeditor/Scripts/TilebrushList.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/TilebrushList.gd
@@ -72,9 +72,9 @@ func loadFurniture():
 		instanced_brushes.append(brushInstance)
 
 
-# this function will read all files in Gamedata.tiles and creates tilebrushes for each tile in the list. It will make separate lists for each category that the tiles belong to.
+# this function will read all files in Gamedata.mods.by_id("Core").tiles and creates tilebrushes for each tile in the list. It will make separate lists for each category that the tiles belong to.
 func loadTiles():
-	var tileList: Dictionary = Gamedata.tiles.get_all()
+	var tileList: Dictionary = Gamedata.mods.by_id("Core").tiles.get_all()
 
 	for tile: DTile in tileList.values():
 		if tile.spriteid:
@@ -93,7 +93,7 @@ func loadTiles():
 				var imagefileName: String = tile.spriteid
 				imagefileName = imagefileName.get_file()
 				# Get the texture from gamedata
-				var texture: Resource = Gamedata.tiles.sprite_by_file(imagefileName)
+				var texture: Resource = Gamedata.mods.by_id("Core").tiles.sprite_by_file(imagefileName)
 				# Create a TileBrush node
 				var brushInstance = tileBrush.instantiate()
 				# Assign the texture to the TileBrush

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd
@@ -385,7 +385,7 @@ func add_brushes_from_area(entity_list: Array, entity_type: String = "entity"):
 		# Get the appropriate sprite based on the entity type
 		match newtype:
 			"tile":
-				properties["texture"] = Gamedata.tiles.sprite_by_id(entity["id"])
+				properties["texture"] = Gamedata.mods.by_id("Core").tiles.sprite_by_id(entity["id"])
 			"mob":
 				properties["texture"] = Gamedata.mobs.sprite_by_id(entity["id"])
 			"furniture":

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditortile.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditortile.gd
@@ -194,7 +194,7 @@ func set_tile_id(id: String) -> void:
 	if id == "":
 		$TileSprite.texture = load(defaultTexture)
 	else:
-		$TileSprite.texture = Gamedata.tiles.sprite_by_id(id)
+		$TileSprite.texture = Gamedata.mods.by_id("Core").tiles.sprite_by_id(id)
 
 
 # Manages the itemgroups property for the tile. 

--- a/Scenes/ContentManager/Scripts/content_list.gd
+++ b/Scenes/ContentManager/Scripts/content_list.gd
@@ -17,7 +17,7 @@ var mod_id: String = "Core"
 var contentType: DMod.ContentType:
 	set(newData):
 		contentType = newData
-		if newData == DMod.ContentType.STATS or newData == DMod.ContentType.TACTICALMAPS or newData == DMod.ContentType.MAPS:
+		if newData == DMod.ContentType.STATS or newData == DMod.ContentType.TILES or newData == DMod.ContentType.TACTICALMAPS or newData == DMod.ContentType.MAPS:
 			# Use mod-specific data for these content types
 			datainstance = Gamedata.mods.by_id(mod_id).get_data_of_type(contentType)
 		else:

--- a/Scenes/ContentManager/Scripts/contenteditor.gd
+++ b/Scenes/ContentManager/Scripts/contenteditor.gd
@@ -162,7 +162,7 @@ func instantiate_editor(type: DMod.ContentType, itemID: String, newEditor: Packe
 			newContentEditor.data_changed.connect(list.load_data)
 		
 		DMod.ContentType.TILES:
-			newContentEditor.dtile = Gamedata.tiles.by_id(itemID)
+			newContentEditor.dtile = currentmod.tiles.by_id(itemID)
 			newContentEditor.data_changed.connect(list.load_data)
 		
 		DMod.ContentType.MOBS:

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -186,7 +186,7 @@ func create_block_position_dictionary_new_arraymesh() -> Dictionary:
 						if tileJSON.has("id") and tileJSON.id != "":
 							var block_position_key = str(w) + "," + str(level_index-10) + "," + str(h)
 							# Get the shape of the block and the transparency
-							var dtile: DTile = Gamedata.tiles.by_id(tileJSON.id)
+							var dtile: RTile = Runtimedata.tiles.by_id(tileJSON.id)
 							# We only save the data we need, exluding mob and furniture data
 							new_block_positions[block_position_key] = {
 								"id": tileJSON.id,
@@ -596,7 +596,7 @@ func create_atlas() -> Dictionary:
 		var block_data: Dictionary = block_positions[key]
 		var material_id: String = str(block_data["id"]) # Key for material ID
 		if not material_to_blocks.has(material_id):
-			var sprite = Gamedata.tiles.sprite_by_id(material_id)
+			var sprite = Runtimedata.tiles.sprite_by_id(material_id)
 			if sprite:
 				material_to_blocks[material_id] = sprite
 

--- a/Scripts/Gamedata/DMaps.gd
+++ b/Scripts/Gamedata/DMaps.gd
@@ -160,38 +160,3 @@ func get_unique_categories() -> Array:
 			if not unique_categories.has(category):  # Check if category is already added
 				unique_categories.append(category)  # Add only if it's unique
 	return unique_categories  # Return the array of unique categories
-
-
-# Add a reference to the references dictionary
-func add_reference(mapid: String, type: DMod.ContentType, refid: String) -> void:
-	if not mapdict.has(mapid):
-		print_debug("Cannot add reference: Map ID '" + mapid + "' does not exist.")
-		return
-	
-	var mytype: String = DMod.get_content_type_string(type)
-	if not references.has(mapid):
-		references[mapid] = {}
-	if not references[mapid].has(mytype):
-		references[mapid][mytype] = []
-	if not refid in references[mapid][mytype]:
-		references[mapid][mytype].append(refid)
-		save_references()
-
-
-# Remove a reference from the references dictionary
-func remove_reference(mapid: String, type: DMod.ContentType, refid: String) -> void:
-	var mytype: String = DMod.get_content_type_string(type)
-	if references.has(mapid) and references[mapid].has(mytype):
-		references[mapid][mytype].erase(refid)
-		# Clean up empty entries
-		if references[mapid][mytype].is_empty():
-			references[mapid].erase(mytype)
-		if references[mapid].is_empty():
-			references.erase(mapid)
-		save_references()
-
-
-# Save references to references.json
-func save_references() -> void:
-	var reference_json = JSON.stringify(references, "\t")
-	Helper.json_helper.write_json_file(dataPath + "references.json", reference_json)

--- a/Scripts/Gamedata/DMaps.gd
+++ b/Scripts/Gamedata/DMaps.gd
@@ -50,7 +50,6 @@ func load_maps_from_disk() -> void:
 		mapdict[mapid] = map
 
 
-
 func get_all() -> Dictionary:
 	return mapdict
 
@@ -108,23 +107,6 @@ func remove_entity_from_all_maps(entity_type: String, entity_id: String):
 func remove_entity_from_selected_maps(entity_type: String, entity_id: String, maps: Array):
 	for map in maps:
 		mapdict[map].remove_entity_from_map(entity_type, entity_id)
-
-
-# Removes the reference from the selected map
-func remove_reference_from_map(mapid: String, module: String, type: String, refid: String):
-	var mymap: DMap = by_id(mapid)
-	mymap.remove_reference(module, type, refid)
-
-
-# Adds a reference to the references list
-# For example, add "town_00" to references.Core.tacticalmaps
-# mapid: The id of the map to add the reference to
-# module: the mod that the entity belongs to, for example "Core"
-# type: The type of entity, for example "tacticlmaps"
-# refid: The id of the entity to reference, for example "town_00"
-func add_reference_to_map(mapid: String, module: String, type: String, refid: String):
-	var mymap: DMap = by_id(mapid)
-	mymap.add_reference(module, type, refid)
 
 
 # Function to get maps by category

--- a/Scripts/Gamedata/DMod.gd
+++ b/Scripts/Gamedata/DMod.gd
@@ -82,7 +82,7 @@ func _init(modinfo: Dictionary, myparent: DMods):
 	tacticalmaps = DTacticalmaps.new(id)
 	furnitures = DFurnitures.new()
 	items = DItems.new()
-	tiles = DTiles.new()
+	tiles = DTiles.new(id)
 	mobs = DMobs.new()
 	itemgroups = DItemgroups.new()
 	playerattributes = DPlayerAttributes.new()

--- a/Scripts/Gamedata/DOvermaparea.gd
+++ b/Scripts/Gamedata/DOvermaparea.gd
@@ -193,11 +193,11 @@ func changed(olddata: DOvermaparea):
 	# Remove references to map IDs that are in the old data but not in the new data
 	for map_id in old_map_ids:
 		if map_id not in new_map_ids:
-			Gamedata.mods.by_id("Core").maps.remove_reference_from_map(map_id, "core", "overmapareas", id)
+			Gamedata.mods.remove_reference(DMod.ContentType.MAPS, map_id, DMod.ContentType.OVERMAPAREAS, id)
 
 	# Add references to map IDs that are in the new data, even if they were already in the old data
 	for map_id in new_map_ids:
-		Gamedata.mods.by_id("Core").maps.add_reference_to_map(map_id, "core", "overmapareas", id)
+		Gamedata.mods.add_reference(DMod.ContentType.MAPS, map_id, DMod.ContentType.OVERMAPAREAS, id)
 
 	# Save the updated overmap area data to disk
 	Gamedata.overmapareas.save_overmapareas_to_disk()

--- a/Scripts/Gamedata/DOvermaparea.gd
+++ b/Scripts/Gamedata/DOvermaparea.gd
@@ -166,14 +166,14 @@ func get_data() -> Dictionary:
 
 # Method to save any changes to the overmaparea back to disk
 func save_to_disk():
-	Gamedata.overmapareas.save_overmapareas_to_disk()
+	Gamedata.mods.by_id("Core").overmapareas.save_overmapareas_to_disk()
 
 
 # Removes the provided reference from references
 func remove_reference(module: String, type: String, refid: String):
 	var changes_made = Gamedata.dremove_reference(references, module, type, refid)
 	if changes_made:
-		Gamedata.overmapareas.save_overmapareas_to_disk()
+		save_to_disk()
 
 
 # Adds a reference to the references list
@@ -235,3 +235,15 @@ func get_all_map_ids() -> Array:
 			if map_id not in unique_map_ids:
 				unique_map_ids.append(map_id)
 	return unique_map_ids
+
+
+# Function to remove a specific map ID from all regions in the overmap area
+func remove_map_from_all_regions(map_id: String) -> void:
+	for region_key in regions.keys():
+		var region = regions[region_key]
+		# Filter out the map entries that do not match the given map_id
+		region.maps = region.maps.filter(func(map_entry):
+			return map_entry.get("id", "") != map_id
+		)
+	# Save the updated overmap area data to disk
+	save_to_disk()

--- a/Scripts/Gamedata/DTile.gd
+++ b/Scripts/Gamedata/DTile.gd
@@ -16,14 +16,7 @@ extends RefCounted
 #		"categories": [
 #			"Floor",
 #			"Urban"
-#		],
-#		"references": {
-#			"core": {
-#				"maps": [
-#					"generichouse_t"
-#				]
-#			}
-#		}
+#		]
 #	}
 
 # This class represents a piece of item with its properties
@@ -34,7 +27,6 @@ var shape: String
 var sprite: Texture
 var spriteid: String
 var categories: Array
-var references: Dictionary = {}
 var parent: DTiles
 
 # Constructor to initialize tile properties from a dictionary
@@ -46,7 +38,6 @@ func _init(data: Dictionary, myparent: DTiles):
 	shape = data.get("shape", "")
 	spriteid = data.get("sprite", "")
 	categories = data.get("categories", [])
-	references = data.get("references", {})
 
 # Get data function to return a dictionary with all properties
 func get_data() -> Dictionary:
@@ -57,25 +48,11 @@ func get_data() -> Dictionary:
 		"sprite": spriteid,
 		"categories": categories
 	}
-	if not references.is_empty():
-		data["references"] = references
 	
 	if shape and not shape == "":
 		data["shape"] = shape
 
 	return data
-
-# Removes the provided reference from references
-func remove_reference(module: String, type: String, refid: String):
-	var changes_made = Gamedata.dremove_reference(references, module, type, refid)
-	if changes_made:
-		Gamedata.tiles.save_tiles_to_disk()
-
-# Adds a reference to the references list
-func add_reference(module: String, type: String, refid: String):
-	var changes_made = Gamedata.dadd_reference(references, module, type, refid)
-	if changes_made:
-		Gamedata.tiles.save_tiles_to_disk()
 
 # Returns the path of the sprite
 func get_sprite_path() -> String:
@@ -91,16 +68,15 @@ func changed(_olddata: DTile):
 # A tile is being deleted from the data
 # We have to remove it from everything that references it
 func delete():
-	# Check if the tile has references to maps and remove it from those maps
-	var mapsdata = Helper.json_helper.get_nested_data(references, "core.maps")
-	if mapsdata:
-		Gamedata.mods.by_id("Core").maps.remove_entity_from_selected_maps("tile", id, mapsdata)
-
-
-# Executes a callable function on each reference of the given type
-func execute_callable_on_references_of_type(module: String, type: String, callable: Callable):
-	# Check if it contains the specified 'module' and 'type'
-	if references.has(module) and references[module].has(type):
-		# If the type exists, execute the callable on each ID found under this type
-		for ref_id in references[module][type]:
-			callable.call(ref_id)
+	# Check to see if any mod has a copy of this map. if one or more remain, we can keep references
+	# Otherwise, the last copy was removed and we need to remove references
+	var all_results: Array = Gamedata.mods.get_all_content_by_id(DMod.ContentType.TILES, id)
+	if all_results.size() > 0:
+		return
+	
+	# Get a list of all maps that reference this tile
+	var myreferences: Dictionary = parent.references.get(id, {})
+	var mymaps: Array = myreferences.get("maps", [])
+	# For each mod, remove this tile from the maps in this tile's references
+	for mod: DMod in Gamedata.mods.get_all_mods():
+		mod.maps.remove_entity_from_selected_maps("tile", id, mymaps)

--- a/Scripts/Gamedata/DTile.gd
+++ b/Scripts/Gamedata/DTile.gd
@@ -35,9 +35,11 @@ var sprite: Texture
 var spriteid: String
 var categories: Array
 var references: Dictionary = {}
+var parent: DTiles
 
 # Constructor to initialize tile properties from a dictionary
-func _init(data: Dictionary):
+func _init(data: Dictionary, myparent: DTiles):
+	parent = myparent
 	id = data.get("id", "")
 	name = data.get("name", "")
 	description = data.get("description", "")

--- a/Scripts/Gamedata/DTile.gd
+++ b/Scripts/Gamedata/DTile.gd
@@ -4,7 +4,7 @@ extends RefCounted
 
 # There's a D in front of the class name to indicate this class only handles tile data, nothing more
 # This script is intended to be used inside the GameData autoload singleton
-# This script handles the data for one tile. You can access it through Gamedata.tiles
+# This script handles the data for one tile. You can access it through Gamedata.mods.by_id("Core").tiles
 
 #Example tile data:
 #	{
@@ -56,13 +56,13 @@ func get_data() -> Dictionary:
 
 # Returns the path of the sprite
 func get_sprite_path() -> String:
-	return Gamedata.tiles.spritePath + spriteid
+	return parent.spritePath + spriteid
 
 
 # Some tile has been changed
 # INFO if the tiles reference other entities, update them here
 func changed(_olddata: DTile):
-	Gamedata.tiles.save_tiles_to_disk()
+	parent.save_tiles_to_disk()
 
 
 # A tile is being deleted from the data

--- a/Scripts/Gamedata/DTiles.gd
+++ b/Scripts/Gamedata/DTiles.gd
@@ -6,24 +6,37 @@ extends RefCounted
 # This script handles the list of tiles. You can access it trough Gamedata.tiles
 
 
-var dataPath: String = "./Mods/Core/Tiles/Tiles.json"
+var dataPath: String = "./Mods/Core/Tiles/"
+var filePath: String = "./Mods/Core/Tiles/Tiles.json"
 var spritePath: String = "./Mods/Core/Tiles/"
 var tiledict: Dictionary = {}
 var sprites: Dictionary = {}
+var references: Dictionary = {}
 
 
 # Add a mod_id parameter to dynamically initialize paths
 func _init(mod_id: String) -> void:
 	# Update dataPath and spritePath using the provided mod_id
-	dataPath = "./Mods/" + mod_id + "/Tiles/Tiles.json"
+	dataPath = "./Mods/" + mod_id + "/Tiles/"
+	filePath = "./Mods/" + mod_id + "/Tiles/Tiles.json"
 	spritePath = "./Mods/" + mod_id + "/Tiles/"
 	load_sprites()
 	load_tiles_from_disk()
+	load_references()
+
+
+# Load references from references.json
+func load_references() -> void:
+	var path = dataPath + "references.json"
+	if FileAccess.file_exists(path):
+		references = Helper.json_helper.load_json_dictionary_file(path)
+	else:
+		references = {}  # Initialize an empty references dictionary if the file doesn't exist
 
 
 # Load all tiledata from disk into memory
 func load_tiles_from_disk() -> void:
-	var tilelist: Array = Helper.json_helper.load_json_array_file(dataPath)
+	var tilelist: Array = Helper.json_helper.load_json_array_file(filePath)
 	for mytile in tilelist:
 		var tile: DTile = DTile.new(mytile, self)
 		tile.sprite = sprites[tile.spriteid]
@@ -49,7 +62,7 @@ func save_tiles_to_disk() -> void:
 	var save_data: Array = []
 	for tile in tiledict.values():
 		save_data.append(tile.get_data())
-	Helper.json_helper.write_json_file(dataPath, JSON.stringify(save_data, "\t"))
+	Helper.json_helper.write_json_file(filePath, JSON.stringify(save_data, "\t"))
 
 
 func get_all() -> Dictionary:
@@ -96,20 +109,3 @@ func sprite_by_id(tileid: String) -> Texture:
 # tileid: The id of the tile to return the sprite of
 func sprite_by_file(spritefile: String) -> Texture:
 	return sprites[spritefile]
-
-
-# Removes the reference from the selected tile
-func remove_reference_from_tile(tileid: String, module: String, type: String, refid: String):
-	var mytile: DTile = tiledict[tileid]
-	mytile.remove_reference(module, type, refid)
-
-
-# Adds a reference to the references list
-# For example, add "grass_field" to references.Core.maps
-# tileid: The id of the tile to add the reference to
-# module: the mod that the entity belongs to, for example "Core"
-# type: The type of entity, for example "maps"
-# refid: The id of the entity to reference, for example "grass_field"
-func add_reference_to_tile(tileid: String, module: String, type: String, refid: String):
-	var mytile: DTile = tiledict[tileid]
-	mytile.add_reference(module, type, refid)

--- a/Scripts/Gamedata/DTiles.gd
+++ b/Scripts/Gamedata/DTiles.gd
@@ -3,7 +3,7 @@ extends RefCounted
 
 # There's a D in front of the class name to indicate this class only handles tile data, nothing more
 # This script is intended to be used inside the GameData autoload singleton
-# This script handles the list of tiles. You can access it trough Gamedata.tiles
+# This script handles the list of tiles. You can access it trough Gamedata.mods.by_id("Core").tiles
 
 
 var dataPath: String = "./Mods/Core/Tiles/"

--- a/Scripts/Gamedata/DTiles.gd
+++ b/Scripts/Gamedata/DTiles.gd
@@ -12,7 +12,11 @@ var tiledict: Dictionary = {}
 var sprites: Dictionary = {}
 
 
-func _init():
+# Add a mod_id parameter to dynamically initialize paths
+func _init(mod_id: String) -> void:
+	# Update dataPath and spritePath using the provided mod_id
+	dataPath = "./Mods/" + mod_id + "/Tiles/Tiles.json"
+	spritePath = "./Mods/" + mod_id + "/Tiles/"
 	load_sprites()
 	load_tiles_from_disk()
 
@@ -21,7 +25,7 @@ func _init():
 func load_tiles_from_disk() -> void:
 	var tilelist: Array = Helper.json_helper.load_json_array_file(dataPath)
 	for mytile in tilelist:
-		var tile: DTile = DTile.new(mytile)
+		var tile: DTile = DTile.new(mytile, self)
 		tile.sprite = sprites[tile.spriteid]
 		tiledict[tile.id] = tile
 
@@ -58,13 +62,13 @@ func duplicate_to_disk(tileid: String, newtileid: String) -> void:
 	# So we delete the references from the duplicated data if it is present
 	tiledata.erase("references")
 	tiledata.id = newtileid
-	var newtile: DTile = DTile.new(tiledata)
+	var newtile: DTile = DTile.new(tiledata, self)
 	tiledict[newtileid] = newtile
 	save_tiles_to_disk()
 
 
 func add_new(newid: String) -> void:
-	var newtile: DTile = DTile.new({"id":newid})
+	var newtile: DTile = DTile.new({"id":newid}, self)
 	tiledict[newtile.id] = newtile
 	save_tiles_to_disk()
 

--- a/Scripts/Runtimedata/RTile.gd
+++ b/Scripts/Runtimedata/RTile.gd
@@ -1,0 +1,93 @@
+class_name RTile
+extends RefCounted
+
+# This class represents a tile with its properties
+# Only used while the game is running
+# Example tile data:
+#	{
+#		"id": "kitchen_tiles_green_00",
+#		"name": "Kitchen tiles (green)",
+#		"description": "A tiled floor you would find in a kitchen. The tiles are painted green",
+#		"shape": "cube",
+#		"sprite": "kitchentilesgreen.png",
+#		"categories": [
+#			"Floor",
+#			"Urban"
+#		],
+#		"references": {
+#			"core": {
+#				"maps": [
+#					"generichouse_t"
+#				]
+#			}
+#		}
+#	}
+
+# Properties defined in the tile
+var id: String
+var name: String
+var description: String
+var shape: String
+var spriteid: String
+var sprite: Texture
+var categories: Array = []
+var references: Dictionary = {}
+var parent: RTiles
+
+# Constructor to initialize tile properties from a dictionary
+# data: the data as loaded from json
+# myparent: The list containing all tiles for this mod
+func _init(myparent: RTiles, newid: String):
+	parent = myparent
+	id = newid
+
+# Overwrite this tile's properties using a DTile
+func overwrite_from_dtile(dtile: DTile) -> void:
+	if not id == dtile.id:
+		print_debug("Cannot overwrite from a different id")
+	name = dtile.name
+	description = dtile.description
+	shape = dtile.shape
+	spriteid = dtile.spriteid
+	sprite = dtile.sprite
+	categories = dtile.categories.duplicate(true)
+	references = dtile.references.duplicate(true)
+
+# Get data function to return a dictionary with all properties
+func get_data() -> Dictionary:
+	var data: Dictionary = {
+		"id": id,
+		"name": name,
+		"description": description,
+		"sprite": spriteid,
+		"categories": categories
+	}
+	if shape and not shape == "":
+		data["shape"] = shape
+	if not references.is_empty():
+		data["references"] = references
+	return data
+
+# Remove a reference from this tile
+func remove_reference(module: String, type: String, refid: String):
+	if references.has(module) and references[module].has(type):
+		references[module][type].erase(refid)
+		if references[module][type].is_empty():
+			references[module].erase(type)
+		if references[module].is_empty():
+			references.erase(module)
+
+# Add a reference to this tile
+func add_reference(module: String, type: String, refid: String):
+	if not references.has(module):
+		references[module] = {}
+	if not references[module].has(type):
+		references[module][type] = []
+	if refid not in references[module][type]:
+		references[module][type].append(refid)
+
+# Execute a callable function on each reference of the given type
+func execute_callable_on_references_of_type(module: String, type: String, callable: Callable):
+	if references.has(module) and references[module].has(type):
+		for refid in references[module][type]:
+			callable.call(refid)

--- a/Scripts/Runtimedata/RTiles.gd
+++ b/Scripts/Runtimedata/RTiles.gd
@@ -34,14 +34,6 @@ func _init() -> void:
 			# Overwrite the RTile properties with the DTile properties
 			rtile.overwrite_from_dtile(dtile)
 
-	# Load sprites for runtime usage
-	load_sprites()
-
-# Loads sprites and assigns them to the sprites dictionary
-func load_sprites() -> void:
-	for tile in tiledict.values():
-		tile.sprite = sprites.get(tile.spriteid, null)
-
 # Returns the dictionary containing all tiles
 func get_all() -> Dictionary:
 	return tiledict

--- a/Scripts/Runtimedata/RTiles.gd
+++ b/Scripts/Runtimedata/RTiles.gd
@@ -1,0 +1,74 @@
+class_name RTiles
+extends RefCounted
+
+# There's an R in front of the class name to indicate this class only handles runtime tile data, nothing more
+# This script is intended to be used inside the Runtime autoload singleton
+# This script handles the list of tiles. You can access it through Runtime.mods.by_id("Core").tiles
+
+# Paths for tiles data and sprites
+var tiledict: Dictionary = {}
+var sprites: Dictionary = {}
+
+# Constructor
+func _init() -> void:
+	# Get all mods and their IDs
+	var mod_ids: Array = Gamedata.mods.get_all_mod_ids()
+
+	# Loop through each mod to get its DTiles
+	for mod_id in mod_ids:
+		var dtiles: DTiles = Gamedata.mods.by_id(mod_id).tiles
+
+		# Loop through each DTile in the mod
+		for dtile_id: String in dtiles.get_all().keys():
+			var dtile: DTile = dtiles.by_id(dtile_id)
+
+			# Check if the tile exists in tiledict
+			var rtile: RTile
+			if not tiledict.has(dtile_id):
+				# If it doesn't exist, create a new RTile
+				rtile = add_new(dtile_id)
+			else:
+				# If it exists, get the existing RTile
+				rtile = tiledict[dtile_id]
+
+			# Overwrite the RTile properties with the DTile properties
+			rtile.overwrite_from_dtile(dtile)
+
+	# Load sprites for runtime usage
+	load_sprites()
+
+# Loads sprites and assigns them to the sprites dictionary
+func load_sprites() -> void:
+	for tile in tiledict.values():
+		tile.sprite = sprites.get(tile.spriteid, null)
+
+# Returns the dictionary containing all tiles
+func get_all() -> Dictionary:
+	return tiledict
+
+# Adds a new tile with a given ID
+func add_new(newid: String) -> RTile:
+	var newtile: RTile = RTile.new(self, newid)
+	tiledict[newtile.id] = newtile
+	return newtile
+
+# Deletes a tile by its ID
+func delete_by_id(tileid: String) -> void:
+	tiledict[tileid].delete()
+	tiledict.erase(tileid)
+
+# Returns a tile by its ID
+func by_id(tileid: String) -> RTile:
+	return tiledict[tileid]
+
+# Checks if a tile exists by its ID
+func has_id(tileid: String) -> bool:
+	return tiledict.has(tileid)
+
+# Returns the sprite of the tile
+func sprite_by_id(tileid: String) -> Texture:
+	return tiledict[tileid].sprite
+
+# Returns the sprite of the tile by its file name
+func sprite_by_file(spritefile: String) -> Texture:
+	return sprites.get(spritefile, null)

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -5,7 +5,6 @@ extends Node
 var mods: DMods
 var furnitures: DFurnitures
 var items: DItems
-var tiles: DTiles
 var mobs: DMobs
 var itemgroups: DItemgroups
 var playerattributes: DPlayerAttributes
@@ -53,7 +52,6 @@ func _ready():
 	mods = DMods.new()
 	furnitures = DFurnitures.new()
 	items = DItems.new()
-	tiles = DTiles.new()
 	mobs = DMobs.new()
 	itemgroups = DItemgroups.new()
 	playerattributes = DPlayerAttributes.new()
@@ -71,7 +69,7 @@ func _ready():
 		DMod.ContentType.FURNITURES: furnitures,
 		DMod.ContentType.ITEMGROUPS: itemgroups,
 		DMod.ContentType.ITEMS: items,
-		DMod.ContentType.TILES: tiles,
+		DMod.ContentType.TILES: mods.by_id("Core").tiles,
 		DMod.ContentType.MOBS: mobs,
 		DMod.ContentType.PLAYERATTRIBUTES: playerattributes,
 		DMod.ContentType.WEARABLESLOTS: wearableslots,

--- a/Scripts/runtimedata.gd
+++ b/Scripts/runtimedata.gd
@@ -6,7 +6,7 @@ var maps: RMaps
 var tacticalmaps: RTacticalmaps
 var furnitures: DFurnitures
 var items: DItems
-var tiles: DTiles
+var tiles: RTiles
 var mobs: DMobs
 var itemgroups: DItemgroups
 var playerattributes: DPlayerAttributes
@@ -31,10 +31,12 @@ func reconstruct() -> void:
 	stats = RStats.new()
 	tacticalmaps = RTacticalmaps.new()
 	maps = RMaps.new()
+	tiles = RTiles.new()
 	
 	# Populate the gamedata_map with the instantiated objects
 	gamedata_map = {
 		DMod.ContentType.STATS: stats,
 		DMod.ContentType.MAPS: maps,
-		DMod.ContentType.TACTICALMAPS: tacticalmaps
+		DMod.ContentType.TACTICALMAPS: tacticalmaps,
+		DMod.ContentType.TILES: tiles
 	}


### PR DESCRIPTION
Requires #520 
Fixes #519 


Removes unused functions regarding references.
When a map is deleted, it will also delete it from overmapareas.