### PR TITLE
Reduced some excessive code in add_relation_from_data in mob factions editor

### DIFF
--- a/Scenes/ContentManager/Custom_Editors/mobfactions_editor.gd
+++ b/Scenes/ContentManager/Custom_Editors/mobfactions_editor.gd
@@ -146,17 +146,9 @@ func add_relations_controls(hbox: HBoxContainer, relation: Dictionary):
 	hbox.add_child(delete_button)
 
 # This function creates a relation from loaded data
+# This function creates a relation from loaded data
 func add_relation_from_data(relation: Dictionary):
-	var hbox: HBoxContainer
-	match relation["relation_type"]:
-		"core":
-			hbox = add_relation_type(relation)
-		"friendly":
-			hbox = add_relation_type(relation)
-		"neutral":
-			hbox = add_relation_type(relation)
-		"hostile":
-			hbox = add_relation_type(relation)
+	var hbox: HBoxContainer = add_relation_type(relation)
 	add_relations_controls(hbox, relation)
 	relations_container.add_child(hbox)
 


### PR DESCRIPTION
Fixes #513  

The code within func add_relation_from_data was excessive, therefore it was cut down to simplify the code.