### PR TITLE
Now the relation type is displayed in label_instance (MobFactionEditor)

### DIFF
--- a/Mods/Core/Mobfaction/Mobfactions.json
+++ b/Mods/Core/Mobfaction/Mobfactions.json
@@ -1,30 +1,134 @@
 [
 	{
-		"description": "The unholy remainders of our past sins.",
-		"id": "undead",
-		"name": "The Undead",
+		"description": "Unholy remainders of our greatest sins.",
+		"id": "zombie",
+		"name": "The Undead People",
 		"relations": [
 			{
-				"mobgroup": "basic_zombies",
+				"mob": "basic_zombie_1",
 				"relation_type": "core"
 			},
 			{
-				"mobgroup": "security_robots",
+				"mob": "basic_zombie_2",
+				"relation_type": "core"
+			},
+			{
+				"mob": "bloated_zombie",
+				"relation_type": "core"
+			},
+			{
+				"mob": "rushing_zombie",
+				"relation_type": "core"
+			},
+			{
+				"mob": "charred_zombie",
+				"relation_type": "core"
+			},
+			{
+				"mob": "heavy_zombie",
+				"relation_type": "core"
+			},
+			{
+				"mob": "skeleton_zombie",
+				"relation_type": "core"
+			},
+			{
+				"mob": "limping_zombie",
+				"relation_type": "core"
+			},
+			{
+				"mob": "scrapwalker",
+				"relation_type": "hostile"
+			},
+			{
+				"mob": "rust_sentinel",
+				"relation_type": "hostile"
+			},
+			{
+				"mob": "scavenger_skitter",
+				"relation_type": "hostile"
+			},
+			{
+				"mob": "iron_stalker",
+				"relation_type": "hostile"
+			},
+			{
+				"mob": "disruptor_drone",
+				"relation_type": "hostile"
+			},
+			{
+				"mob": "venom_crawler",
+				"relation_type": "hostile"
+			},
+			{
+				"mob": "outpost_guardian",
 				"relation_type": "hostile"
 			}
 		]
 	},
 	{
-		"description": "Developed by the rich to opress the poor, ironically they cannot tell apart from one another.",
-		"id": "robot",
+		"description": "A faction of security robots employed by the law enforcement, mostly deals with violent riots and protesters.",
+		"id": "security_robots",
 		"name": "The Iron Force",
 		"relations": [
 			{
-				"mobgroup": "security_robots",
+				"mob": "scrapwalker",
 				"relation_type": "core"
 			},
 			{
-				"mobgroup": "basic_zombies",
+				"mob": "rust_sentinel",
+				"relation_type": "core"
+			},
+			{
+				"mob": "scavenger_skitter",
+				"relation_type": "core"
+			},
+			{
+				"mob": "iron_stalker",
+				"relation_type": "core"
+			},
+			{
+				"mob": "disruptor_drone",
+				"relation_type": "core"
+			},
+			{
+				"mob": "venom_crawler",
+				"relation_type": "core"
+			},
+			{
+				"mob": "outpost_guardian",
+				"relation_type": "core"
+			},
+			{
+				"mob": "basic_zombie_1",
+				"relation_type": "hostile"
+			},
+			{
+				"mob": "basic_zombie_2",
+				"relation_type": "hostile"
+			},
+			{
+				"mob": "bloated_zombie",
+				"relation_type": "hostile"
+			},
+			{
+				"mob": "rushing_zombie",
+				"relation_type": "hostile"
+			},
+			{
+				"mob": "charred_zombie",
+				"relation_type": "hostile"
+			},
+			{
+				"mob": "heavy_zombie",
+				"relation_type": "hostile"
+			},
+			{
+				"mob": "skeleton_zombie",
+				"relation_type": "hostile"
+			},
+			{
+				"mob": "limping_zombie",
 				"relation_type": "hostile"
 			}
 		]

--- a/Mods/Core/Mobgroups/Mobgroups.json
+++ b/Mods/Core/Mobgroups/Mobgroups.json
@@ -21,9 +21,7 @@
 				"quests": [
 					"starter_tutorial_00",
 					"quest_holy_crusade_01",
-					"zombie",
-					"robot",
-					"undead"
+					"zombie"
 				]
 			}
 		},
@@ -45,9 +43,7 @@
 		"references": {
 			"core": {
 				"quests": [
-					"zombie",
-					"robot",
-					"undead"
+					"zombie"
 				]
 			}
 		},

--- a/Mods/Core/Mobs/Mobs.json
+++ b/Mods/Core/Mobs/Mobs.json
@@ -1,5 +1,6 @@
 [
 	{
+		"default_faction": "",
 		"description": "A small robot",
 		"health": 80,
 		"hearing_range": 1000,
@@ -27,7 +28,8 @@
 					"security_robots"
 				],
 				"quests": [
-					"zombie"
+					"zombie",
+					"security_robots"
 				]
 			}
 		},
@@ -65,6 +67,7 @@
 		}
 	},
 	{
+		"default_faction": "",
 		"description": "A slightly more advanced robot but still considered a weaker enemy in the robot faction. The Rust Sentinel stands tall and imposing, with a sturdy build. Its design incorporates rusted and recycled metal parts, giving it a rugged, battle-worn appearance.\n\nThe Rust Sentinel features a broad, slightly dome-shaped head with glowing red eyes that serve as visual sensors. Its torso is bulkier, reinforced with scrap metal plates, and it has two powerful arms ending in claws. The legs are designed for stability and power rather than speed. Its color scheme is a mix of rusted orange, steel gray, and hints of worn-out blue paint, suggesting it was once part of a larger machinery or vehicle.\n\nThe Rust Sentinel moves with deliberate, heavy steps, making it slower but more resilient. It's equipped with basic tools and weaponry, which it uses to scavenges and patrol.",
 		"health": 120,
 		"hearing_range": 1000,
@@ -89,7 +92,8 @@
 					"security_robots"
 				],
 				"quests": [
-					"zombie"
+					"zombie",
+					"security_robots"
 				]
 			}
 		},
@@ -127,6 +131,7 @@
 		}
 	},
 	{
+		"default_faction": "",
 		"description": "A swift, dog-sized robot equipped with sharp claws and sensors. The Scavenger Skitter patrols ruins, darting quickly to attack when it detects motion. Its lightweight build allows it to move at high speeds but makes it vulnerable to powerful attacks.",
 		"health": 50,
 		"hearing_range": 800,
@@ -148,6 +153,10 @@
 					"RockyHill_SW"
 				],
 				"mobgroups": [
+					"security_robots"
+				],
+				"quests": [
+					"zombie",
 					"security_robots"
 				]
 			}
@@ -193,6 +202,7 @@
 		}
 	},
 	{
+		"default_faction": "",
 		"description": "A heavily armored robot that advances slowly but relentlessly. The Iron Stalker is outfitted with reinforced plating, making it resistant to bullets and physical attacks. It uses a powerful hydraulic punch that can stagger players if hit.",
 		"health": 200,
 		"hearing_range": 900,
@@ -214,6 +224,10 @@
 					"RockyHill_SW"
 				],
 				"mobgroups": [
+					"security_robots"
+				],
+				"quests": [
+					"zombie",
 					"security_robots"
 				]
 			}
@@ -257,6 +271,7 @@
 		}
 	},
 	{
+		"default_faction": "",
 		"description": "A mid-sized drone that hovers silently above the ground. The Disruptor Drone can emit a pulse to disable nearby electronic equipment temporarily, making it dangerous for players who rely on tech.",
 		"health": 70,
 		"hearing_range": 1200,
@@ -281,7 +296,9 @@
 					"security_robots"
 				],
 				"quests": [
-					"quest_radio_signal_01"
+					"quest_radio_signal_01",
+					"zombie",
+					"security_robots"
 				]
 			}
 		},
@@ -299,6 +316,7 @@
 		}
 	},
 	{
+		"default_faction": "",
 		"description": "A compact, spider-like bot specialized in ambush tactics. The Venom Crawler injects a corrosive fluid into its target, damaging armor and slowly weakening the player over time.",
 		"health": 60,
 		"hearing_range": 700,
@@ -320,6 +338,10 @@
 				],
 				"mobgroups": [
 					"security_robots"
+				],
+				"quests": [
+					"zombie",
+					"security_robots"
 				]
 			}
 		},
@@ -337,6 +359,7 @@
 		}
 	},
 	{
+		"default_faction": "",
 		"description": "A towering, sentinel-like robot with a focus on ranged combat. The Outpost Guardian uses built-in projectile launchers to strike players from afar, aiming at any perceived threat.",
 		"health": 150,
 		"hearing_range": 1000,
@@ -351,6 +374,10 @@
 		"references": {
 			"core": {
 				"mobgroups": [
+					"security_robots"
+				],
+				"quests": [
+					"zombie",
 					"security_robots"
 				]
 			}
@@ -389,6 +416,7 @@
 		}
 	},
 	{
+		"default_faction": "",
 		"description": "A slow-moving, decaying zombie with tattered clothes. It's barely able to walk, but it will still attempt to grab and bite anything in its way.",
 		"health": 40,
 		"hearing_range": 500,
@@ -424,6 +452,10 @@
 				],
 				"mobgroups": [
 					"basic_zombies"
+				],
+				"quests": [
+					"zombie",
+					"security_robots"
 				]
 			}
 		},
@@ -461,6 +493,7 @@
 		}
 	},
 	{
+		"default_faction": "",
 		"description": "A slow-moving, decaying zombie with ragged clothing and a missing arm. Its movements are jerky, but it still tries to grab players within range to infect them.",
 		"health": 40,
 		"hearing_range": 500,
@@ -497,6 +530,10 @@
 				],
 				"mobgroups": [
 					"basic_zombies"
+				],
+				"quests": [
+					"zombie",
+					"security_robots"
 				]
 			}
 		},
@@ -534,6 +571,7 @@
 		}
 	},
 	{
+		"default_faction": "",
 		"description": "A zombie with a swollen abdomen, its flesh hanging loosely. It moves slowly but is tougher, with more resilience to damage than the basic zombie.",
 		"health": 60,
 		"hearing_range": 600,
@@ -570,6 +608,10 @@
 				],
 				"mobgroups": [
 					"basic_zombies"
+				],
+				"quests": [
+					"zombie",
+					"security_robots"
 				]
 			}
 		},
@@ -607,6 +649,7 @@
 		}
 	},
 	{
+		"default_faction": "",
 		"description": "A zombie with a misshapen face and a gaping mouth. It moves quickly and unpredictably, though still relatively weak. It can charge at players in a burst of speed.",
 		"health": 50,
 		"hearing_range": 700,
@@ -643,6 +686,10 @@
 				],
 				"mobgroups": [
 					"basic_zombies"
+				],
+				"quests": [
+					"zombie",
+					"security_robots"
 				]
 			}
 		},
@@ -687,6 +734,7 @@
 		}
 	},
 	{
+		"default_faction": "",
 		"description": "A zombie with burnt, charred skin, likely from a fire. It lumbers forward with erratic movements, but its resilience is higher than most zombies.",
 		"health": 70,
 		"hearing_range": 500,
@@ -723,6 +771,10 @@
 				],
 				"mobgroups": [
 					"basic_zombies"
+				],
+				"quests": [
+					"zombie",
+					"security_robots"
 				]
 			}
 		},
@@ -760,6 +812,7 @@
 		}
 	},
 	{
+		"default_faction": "",
 		"description": "A zombie with its head deformed and swollen, like a bloated corpse. Its movements are slow but it hits hard and has a significant resistance to damage.",
 		"health": 80,
 		"hearing_range": 800,
@@ -796,6 +849,10 @@
 				],
 				"mobgroups": [
 					"basic_zombies"
+				],
+				"quests": [
+					"zombie",
+					"security_robots"
 				]
 			}
 		},
@@ -833,6 +890,7 @@
 		}
 	},
 	{
+		"default_faction": "",
 		"description": "A fast-moving zombie with long, bony limbs. Its skin is pale and thin, making it look almost skeletal. It has moderate strength but is more difficult to hit due to its speed.",
 		"health": 50,
 		"hearing_range": 600,
@@ -869,6 +927,10 @@
 				],
 				"mobgroups": [
 					"basic_zombies"
+				],
+				"quests": [
+					"zombie",
+					"security_robots"
 				]
 			}
 		},
@@ -906,6 +968,7 @@
 		}
 	},
 	{
+		"default_faction": "",
 		"description": "A zombie with a partially broken leg, dragging itself across the ground with an unsettling limp. While it is slow, it can still latch onto players with a strong grip, making it hard to shake off.",
 		"health": 55,
 		"hearing_range": 600,
@@ -942,6 +1005,10 @@
 				],
 				"mobgroups": [
 					"basic_zombies"
+				],
+				"quests": [
+					"zombie",
+					"security_robots"
 				]
 			}
 		},

--- a/Scenes/ContentManager/Custom_Editors/mobfactions_editor.gd
+++ b/Scenes/ContentManager/Custom_Editors/mobfactions_editor.gd
@@ -61,39 +61,19 @@ func _on_save_button_button_up() -> void:
 	for hbox in relations_container.get_children():
 		var relation = {}
 		var relation_type_label = hbox.get_child(0) as Label
-	
-	# Handle each relation type
-		if relation_type_label.text == "Relation type:":
-			var dropable_control = hbox.get_child(1) as HBoxContainer
-			var mob_or_group = dropable_control.get_text()
-			var entity_type = dropable_control.get_meta("entity_type")
-			var relation_type = dropable_control.get_meta("relation_type")
-			relation["relation_type"] = relation_type
-		if relation_type_label.text == "Relation type:":
-			var dropable_control = hbox.get_child(1) as HBoxContainer
-			var mob_or_group = dropable_control.get_text()
-			var entity_type = dropable_control.get_meta("entity_type")
-			var relation_type = dropable_control.get_meta("relation_type")
-			relation["relation_type"] = relation_type
-		if relation_type_label.text == "Relation type:":
-			var dropable_control = hbox.get_child(1) as HBoxContainer
-			var mob_or_group = dropable_control.get_text()
-			var entity_type = dropable_control.get_meta("entity_type")
-			var relation_type = dropable_control.get_meta("relation_type")
-			relation["relation_type"] = relation_type
-		if relation_type_label.text == "Relation type:":
-			var dropable_control = hbox.get_child(1) as HBoxContainer
-			var mob_or_group = dropable_control.get_text()
-			var entity_type = dropable_control.get_meta("entity_type")
-			var relation_type = dropable_control.get_meta("relation_type")
-			relation["relation_type"] = relation_type
-			# Save as mob or mobgroup based on metadata
-			if entity_type == "mob":
-				relation["mob"] = mob_or_group
-			elif entity_type == "mobgroup":
-				relation["mobgroup"] = mob_or_group
-			else:
-				print_debug("Invalid entity type metadata: " + str(entity_type))
+		# Process each relation type
+		var dropable_control = hbox.get_child(1) as HBoxContainer
+		var mob_or_group = dropable_control.get_text()
+		var entity_type = dropable_control.get_meta("entity_type")
+		var relation_type = dropable_control.get_meta("relation_type")
+		relation["relation_type"] = relation_type
+		# Save as mob or mobgroup based on metadata
+		if entity_type == "mob":
+			relation["mob"] = mob_or_group
+		elif entity_type == "mobgroup":
+			relation["mobgroup"] = mob_or_group
+		else:
+			print_debug("Invalid entity type metadata: " + str(entity_type))
 		dmobfaction.relations.append(relation)
 	dmobfaction.changed(olddata)
 	data_changed.emit()
@@ -120,7 +100,8 @@ func add_relation_type(relation: Dictionary) -> HBoxContainer:
 
 	# Add the label
 	var label_instance: Label = Label.new()
-	label_instance.text = "Relation type:"
+	var selectedrelation = relation.get("relation_type")
+	label_instance.text = selectedrelation
 	hbox.add_child(label_instance)
 
 	# Add the dropable text edit for the mob or mobgroup ID

--- a/Scripts/Gamedata/DMobfaction.gd
+++ b/Scripts/Gamedata/DMobfaction.gd
@@ -65,10 +65,10 @@ func save_to_disk():
 func delete():
 	var relationmobs: Array =  relations.filter(func(relation): return relation.has("mob"))
 	for killrelation in relationmobs:
-		Gamedata.mobs.remove_reference(killrelation.mob, "core", "quests", id)
+		Gamedata.mobs.remove_reference(killrelation.mob, "core", "mobfactions", id)
 	var relationmobgroups: Array = relations.filter(func(relation): return relation.has("mobgroup"))
 	for killrelation in relationmobgroups:
-		Gamedata.mobgroups.remove_reference(killrelation.mobgroup, "core", "quests", id)
+		Gamedata.mobgroups.remove_reference(killrelation.mobgroup, "core", "mobfactions", id)
 
 # Handles quest changes
 func changed(olddata: DMobfaction):
@@ -84,18 +84,18 @@ func changed(olddata: DMobfaction):
 	# Remove references for old mobs that are not in the new data
 	for old_mob in old_quest_mobs:
 		if old_mob not in new_quest_mobs:
-			Gamedata.mobs.remove_reference(old_mob.mob, "core", "quests", faction_id)
+			Gamedata.mobs.remove_reference(old_mob.mob, "core", "mobfactions", faction_id)
 	# Remove references for old mobgroups that are not in the new data
 	for old_mobgroup in old_quest_mobgroups:
 		if old_mobgroup not in new_quest_mobgroups:
-			Gamedata.mobgroups.remove_reference(old_mobgroup.mobgroup, "core", "quests", faction_id)
+			Gamedata.mobgroups.remove_reference(old_mobgroup.mobgroup, "core", "mobfactions", faction_id)
 	
 	# Add references for new mobs
 	for new_mob in new_quest_mobs:
-		Gamedata.mobs.add_reference(new_mob.mob, "core", "quests", faction_id)
+		Gamedata.mobs.add_reference(new_mob.mob, "core", "mobfactions", faction_id)
 	# Add references for new mobgroups
 	for new_mobgroup in new_quest_mobgroups:
-		Gamedata.mobgroups.add_reference(new_mobgroup.mobgroup, "core", "quests", faction_id)
+		Gamedata.mobgroups.add_reference(new_mobgroup.mobgroup, "core", "mobfactions", faction_id)
 	save_to_disk()
 
 # Removes all relations where the mob property matches the given mob_id


### PR DESCRIPTION
Before it always used to say "Relation type:" which would be confusing as you wouldn't know what relation is connected to the mob, now it displays its relation before the mob name in the mob faction editor.