### PR TITLE
Enable modding of playerattributes

### DIFF
--- a/Mods/Core/PlayerAttributes/PlayerAttributes.json
+++ b/Mods/Core/PlayerAttributes/PlayerAttributes.json
@@ -14,40 +14,6 @@
 		"description": "You starve when this is empty. You are full when this is full.",
 		"id": "food",
 		"name": "Food",
-		"references": {
-			"core": {
-				"items": [
-					"canned_food",
-					"tofu",
-					"bottle_yogurt",
-					"condensed_milk",
-					"bag_bacon",
-					"bread",
-					"slice_of_pizza",
-					"vacuum_sealed_fish",
-					"tomato",
-					"lettuce",
-					"chocolate",
-					"jar_olives",
-					"jar_mustard",
-					"bottle_ketchup",
-					"stale_bread",
-					"orange",
-					"apple",
-					"potato",
-					"carrot",
-					"eggs",
-					"butter",
-					"cheese",
-					"berries_wild",
-					"bird_egg",
-					"mushrooms_forest",
-					"rotten_flesh_chunk",
-					"zombie_eye",
-					"zombie_organ"
-				]
-			}
-		},
 		"sprite": "apple_32.png"
 	},
 	{
@@ -65,28 +31,6 @@
 		"description": "The amount of water the player has in their body. Running out will mean death.",
 		"id": "water",
 		"name": "Water",
-		"references": {
-			"core": {
-				"items": [
-					"bottle_plastic_water",
-					"bottle_yogurt",
-					"condensed_milk",
-					"wine_bottle",
-					"tomato",
-					"lettuce",
-					"orange",
-					"apple",
-					"eggs",
-					"can_energydrink",
-					"can_soda",
-					"berries_wild",
-					"bird_egg",
-					"rotten_flesh_chunk",
-					"zombie_eye",
-					"zombie_organ"
-				]
-			}
-		},
 		"sprite": "waterbottle_32.png"
 	},
 	{
@@ -104,33 +48,6 @@
 		"description": "The health of the player's head. Critical for survival.",
 		"id": "head_health",
 		"name": "Head Health",
-		"references": {
-			"core": {
-				"items": [
-					"bandage_basic",
-					"bottle_antibiotics",
-					"bottle_disinfectant",
-					"insulin",
-					"epipen",
-					"painkiller"
-				],
-				"mobs": [
-					"scrapwalker",
-					"rust_sentinel",
-					"scavenger_skitter",
-					"iron_stalker",
-					"outpost_guardian",
-					"basic_zombie_1",
-					"basic_zombie_2",
-					"bloated_zombie",
-					"rushing_zombie",
-					"charred_zombie",
-					"heavy_zombie",
-					"skeleton_zombie",
-					"limping_zombie"
-				]
-			}
-		},
 		"sprite": "head_32.png"
 	},
 	{
@@ -148,33 +65,6 @@
 		"description": "The health of the player's torso. Vital for survival.",
 		"id": "torso_health",
 		"name": "Torso Health",
-		"references": {
-			"core": {
-				"items": [
-					"bandage_basic",
-					"bottle_antibiotics",
-					"bottle_disinfectant",
-					"insulin",
-					"epipen",
-					"painkiller"
-				],
-				"mobs": [
-					"scrapwalker",
-					"rust_sentinel",
-					"scavenger_skitter",
-					"iron_stalker",
-					"outpost_guardian",
-					"basic_zombie_1",
-					"basic_zombie_2",
-					"bloated_zombie",
-					"rushing_zombie",
-					"charred_zombie",
-					"heavy_zombie",
-					"skeleton_zombie",
-					"limping_zombie"
-				]
-			}
-		},
 		"sprite": "torso_32.png"
 	},
 	{
@@ -192,33 +82,6 @@
 		"description": "The health of the player's left arm.",
 		"id": "left_arm_health",
 		"name": "Left Arm Health",
-		"references": {
-			"core": {
-				"items": [
-					"bandage_basic",
-					"bottle_antibiotics",
-					"bottle_disinfectant",
-					"insulin",
-					"epipen",
-					"painkiller"
-				],
-				"mobs": [
-					"scrapwalker",
-					"rust_sentinel",
-					"scavenger_skitter",
-					"iron_stalker",
-					"outpost_guardian",
-					"basic_zombie_1",
-					"basic_zombie_2",
-					"bloated_zombie",
-					"rushing_zombie",
-					"charred_zombie",
-					"heavy_zombie",
-					"skeleton_zombie",
-					"limping_zombie"
-				]
-			}
-		},
 		"sprite": "left_arm_32.png"
 	},
 	{
@@ -236,33 +99,6 @@
 		"description": "The health of the player's right arm.",
 		"id": "right_arm_health",
 		"name": "Right Arm Health",
-		"references": {
-			"core": {
-				"items": [
-					"bandage_basic",
-					"bottle_antibiotics",
-					"bottle_disinfectant",
-					"insulin",
-					"epipen",
-					"painkiller"
-				],
-				"mobs": [
-					"scrapwalker",
-					"rust_sentinel",
-					"scavenger_skitter",
-					"iron_stalker",
-					"outpost_guardian",
-					"basic_zombie_1",
-					"basic_zombie_2",
-					"bloated_zombie",
-					"rushing_zombie",
-					"charred_zombie",
-					"heavy_zombie",
-					"skeleton_zombie",
-					"limping_zombie"
-				]
-			}
-		},
 		"sprite": "right_arm_32.png"
 	},
 	{
@@ -280,33 +116,6 @@
 		"description": "The health of the player's left leg.",
 		"id": "left_leg_health",
 		"name": "Left Leg Health",
-		"references": {
-			"core": {
-				"items": [
-					"bandage_basic",
-					"bottle_antibiotics",
-					"bottle_disinfectant",
-					"insulin",
-					"epipen",
-					"painkiller"
-				],
-				"mobs": [
-					"scrapwalker",
-					"rust_sentinel",
-					"scavenger_skitter",
-					"iron_stalker",
-					"outpost_guardian",
-					"basic_zombie_1",
-					"basic_zombie_2",
-					"bloated_zombie",
-					"rushing_zombie",
-					"charred_zombie",
-					"heavy_zombie",
-					"skeleton_zombie",
-					"limping_zombie"
-				]
-			}
-		},
 		"sprite": "left_leg_32.png"
 	},
 	{
@@ -324,33 +133,6 @@
 		"description": "The health of the player's right leg.",
 		"id": "right_leg_health",
 		"name": "Right Leg Health",
-		"references": {
-			"core": {
-				"items": [
-					"bandage_basic",
-					"bottle_antibiotics",
-					"bottle_disinfectant",
-					"insulin",
-					"epipen",
-					"painkiller"
-				],
-				"mobs": [
-					"scrapwalker",
-					"rust_sentinel",
-					"scavenger_skitter",
-					"iron_stalker",
-					"outpost_guardian",
-					"basic_zombie_1",
-					"basic_zombie_2",
-					"bloated_zombie",
-					"rushing_zombie",
-					"charred_zombie",
-					"heavy_zombie",
-					"skeleton_zombie",
-					"limping_zombie"
-				]
-			}
-		},
 		"sprite": "right_leg_32.png"
 	},
 	{
@@ -360,16 +142,6 @@
 		},
 		"id": "inventory_space",
 		"name": "Inventory space",
-		"references": {
-			"Core": {
-				"item": [
-					"waistbag",
-					"mailbag",
-					"backpack",
-					"jeans"
-				]
-			}
-		},
 		"sprite": "playerattribuge_inventory_space_32.png"
 	},
 	{
@@ -395,19 +167,6 @@
 		"description": "You are poisoned! Your health will be drained until the poison is cured or wears out. If your body is full of poison, you die!",
 		"id": "poison",
 		"name": "Poison",
-		"references": {
-			"core": {
-				"items": [
-					"bottle_antidote",
-					"rotten_flesh_chunk",
-					"zombie_eye",
-					"zombie_organ"
-				],
-				"mobs": [
-					"venom_crawler"
-				]
-			}
-		},
 		"sprite": "skull_poison_32.png"
 	},
 	{
@@ -425,14 +184,6 @@
 		"description": "You are stunned and can't move!",
 		"id": "stun",
 		"name": "Stun",
-		"references": {
-			"core": {
-				"mobs": [
-					"iron_stalker",
-					"disruptor_drone"
-				]
-			}
-		},
 		"sprite": "trapping_32.png"
 	}
 ]

--- a/Mods/Core/PlayerAttributes/references.json
+++ b/Mods/Core/PlayerAttributes/references.json
@@ -1,0 +1,48 @@
+{
+	"food": {
+		"items": [
+			"canned_food"
+		]
+	},
+	"head_health": {
+		"items": [
+			"bandage_basic",
+			"bottle_antibiotics"
+		]
+	},
+	"left_arm_health": {
+		"items": [
+			"bandage_basic",
+			"bottle_antibiotics"
+		]
+	},
+	"left_leg_health": {
+		"items": [
+			"bandage_basic",
+			"bottle_antibiotics"
+		]
+	},
+	"right_arm_health": {
+		"items": [
+			"bandage_basic",
+			"bottle_antibiotics"
+		]
+	},
+	"right_leg_health": {
+		"items": [
+			"bandage_basic",
+			"bottle_antibiotics"
+		]
+	},
+	"torso_health": {
+		"items": [
+			"bandage_basic",
+			"bottle_antibiotics"
+		]
+	},
+	"water": {
+		"items": [
+			"bottle_plastic_water"
+		]
+	}
+}

--- a/Scenes/ContentManager/Custom_Editors/Scripts/MobEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/MobEditor.gd
@@ -196,7 +196,7 @@ func _load_attributes_into_grid(container: GridContainer, attributes: Array) -> 
 
 # Modified function to add a new attribute entry to a specified grid container
 func _add_attribute_entry_to_grid(container: GridContainer, attribute: Dictionary) -> void:
-	var myattribute: DPlayerAttribute = Gamedata.playerattributes.by_id(attribute.id)
+	var myattribute: DPlayerAttribute = Gamedata.mods.by_id("Core").playerattributes.by_id(attribute.id)
 
 	# Create a TextureRect for the sprite
 	var texture_rect = TextureRect.new()
@@ -267,7 +267,7 @@ func _can_drop_attribute_data(_newpos, data) -> bool:
 		return false
 
 	# Fetch attribute by ID from the Gamedata to ensure it exists and is valid
-	if not Gamedata.playerattributes.has_id(data["id"]):
+	if not Gamedata.mods.by_id("Core").playerattributes.has_id(data["id"]):
 		return false
 
 	# Check if the attribute ID already exists in either of the attribute grids
@@ -300,7 +300,7 @@ func _drop_all_of_attribute_data(newpos, data) -> void:
 func _handle_attribute_drop(dropped_data, container: GridContainer) -> void:
 	if dropped_data and "id" in dropped_data:
 		var attribute_id = dropped_data["id"]
-		if not Gamedata.playerattributes.has_id(attribute_id):
+		if not Gamedata.mods.by_id("Core").playerattributes.has_id(attribute_id):
 			print_debug("No attribute data found for ID: " + attribute_id)
 			return
 

--- a/Scenes/ContentManager/Custom_Editors/Scripts/PlayerAttributeEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/PlayerAttributeEditor.gd
@@ -35,14 +35,14 @@ extends Control
 signal data_changed()
 var olddata: DPlayerAttribute # Remember what the value of the data was before editing
 # The data that represents this playerattribute
-# The data is selected from Gamedata.playerattributes
+# The data is selected from dplayerattribute.parent
 # based on the ID that the user has selected in the content editor
 var dplayerattribute: DPlayerAttribute:
 	set(value):
 		dplayerattribute = value
 		load_playerattribute_data()
-		sprite_selector.sprites_collection = Gamedata.playerattributes.sprites
-		olddata = DPlayerAttribute.new(dplayerattribute.get_data().duplicate(true))
+		sprite_selector.sprites_collection = dplayerattribute.parent.sprites
+		olddata = DPlayerAttribute.new(dplayerattribute.get_data().duplicate(true), null)
 
 
 func _ready() -> void:
@@ -147,7 +147,7 @@ func _on_save_button_button_up() -> void:
 
 	dplayerattribute.changed(olddata)
 	data_changed.emit()
-	olddata = DPlayerAttribute.new(dplayerattribute.get_data().duplicate(true))
+	olddata = DPlayerAttribute.new(dplayerattribute.get_data().duplicate(true), null)
 
 
 # Function to save data into default mode
@@ -222,7 +222,7 @@ func _get_drain_attributes_from_ui() -> Dictionary:
 
 # Add a new drain attribute entry to the drain_attribute_grid_container
 func _add_drain_attribute_entry(attribute_id: String, amount: float) -> void:
-	var attribute_data = Gamedata.playerattributes.by_id(attribute_id)
+	var attribute_data = dplayerattribute.parent.by_id(attribute_id)
 
 	# Create a TextureRect for the sprite
 	var texture_rect = TextureRect.new()
@@ -263,7 +263,7 @@ func _delete_drain_attribute_entry(elements_to_remove: Array) -> void:
 func _can_drop_attribute_data(_newpos, data) -> bool:
 	if not data or not data.has("id"):
 		return false
-	if not Gamedata.playerattributes.has_id(data["id"]):
+	if not dplayerattribute.parent.has_id(data["id"]):
 		return false
 
 	# Ensure the attribute ID isn't already in the grid
@@ -285,7 +285,7 @@ func _drop_attribute_data(newpos, data) -> void:
 func _handle_drain_attribute_drop(dropped_data) -> void:
 	if dropped_data and "id" in dropped_data:
 		var attribute_id = dropped_data["id"]
-		if Gamedata.playerattributes.has_id(attribute_id):
+		if dplayerattribute.parent.has_id(attribute_id):
 			_add_drain_attribute_entry(attribute_id, 1.0)  # Default value for new attributes
 		else:
 			print_debug("Invalid attribute ID: " + attribute_id)

--- a/Scenes/ContentManager/Scripts/content_list.gd
+++ b/Scenes/ContentManager/Scripts/content_list.gd
@@ -17,7 +17,7 @@ var mod_id: String = "Core"
 var contentType: DMod.ContentType:
 	set(newData):
 		contentType = newData
-		if newData == DMod.ContentType.STATS or newData == DMod.ContentType.QUESTS or newData == DMod.ContentType.SKILLS or newData == DMod.ContentType.OVERMAPAREAS or newData == DMod.ContentType.TILES or newData == DMod.ContentType.TACTICALMAPS or newData == DMod.ContentType.MAPS:
+		if newData == DMod.ContentType.STATS or newData == DMod.ContentType.PLAYERATTRIBUTES or newData == DMod.ContentType.QUESTS or newData == DMod.ContentType.SKILLS or newData == DMod.ContentType.OVERMAPAREAS or newData == DMod.ContentType.TILES or newData == DMod.ContentType.TACTICALMAPS or newData == DMod.ContentType.MAPS:
 			# Use mod-specific data for these content types
 			datainstance = Gamedata.mods.by_id(mod_id).get_data_of_type(contentType)
 		else:

--- a/Scenes/ContentManager/Scripts/contenteditor.gd
+++ b/Scenes/ContentManager/Scripts/contenteditor.gd
@@ -170,7 +170,7 @@ func instantiate_editor(type: DMod.ContentType, itemID: String, newEditor: Packe
 			newContentEditor.data_changed.connect(list.load_data)
 		
 		DMod.ContentType.PLAYERATTRIBUTES:
-			newContentEditor.dplayerattribute = Gamedata.playerattributes.by_id(itemID)
+			newContentEditor.dplayerattribute = currentmod.playerattributes.by_id(itemID)
 			newContentEditor.data_changed.connect(list.load_data)
 		
 		DMod.ContentType.WEARABLESLOTS:

--- a/Scripts/Gamedata/DItem.gd
+++ b/Scripts/Gamedata/DItem.gd
@@ -564,16 +564,14 @@ func process_wearable_player_attributes(olddata: DItem):
 		if olddata.wearable and not olddata.wearable.player_attributes.is_empty():
 			# Loop over old player attributes and remove references
 			for old_attr in olddata.wearable.player_attributes:
-				var old_attr_id = old_attr["id"]
-				Gamedata.playerattributes.remove_reference(old_attr_id, "Core", "item", olddata.id)
+				Gamedata.mods.remove_reference(DMod.ContentType.PLAYERATTRIBUTES, old_attr["id"], DMod.ContentType.ITEMS, id)
 		return  # Exit since there's no wearable in the new data
 	
 	if wearable.player_attributes.is_empty():
 		# If the new wearable has no player attributes, remove all references from olddata if they exist
 		if olddata.wearable and not olddata.wearable.player_attributes.is_empty():
 			for old_attr in olddata.wearable.player_attributes:
-				var old_attr_id = old_attr["id"]
-				Gamedata.playerattributes.remove_reference(old_attr_id, "Core", "item", olddata.id)
+				Gamedata.mods.remove_reference(DMod.ContentType.PLAYERATTRIBUTES, old_attr["id"], DMod.ContentType.ITEMS, id)
 		return  # Exit since there are no player attributes to add
 
 	# Collect new and old player attributes
@@ -589,14 +587,14 @@ func process_wearable_player_attributes(olddata: DItem):
 	for new_attr in new_player_attributes:
 		var attribute_id = new_attr["id"]
 		# Add reference for the new attribute
-		Gamedata.playerattributes.add_reference(attribute_id, "Core", "item", id)
+		Gamedata.mods.add_reference(DMod.ContentType.PLAYERATTRIBUTES, attribute_id, DMod.ContentType.ITEMS, id)
 
 		# Remove the old attribute from the dictionary, as it still exists
 		old_attr_dict.erase(attribute_id)
 
 	# Any remaining attributes in old_attr_dict were removed, so remove their references
 	for old_attr_id in old_attr_dict.keys():
-		Gamedata.playerattributes.remove_reference(old_attr_id, "Core", "item", olddata.id)
+		Gamedata.mods.remove_reference(DMod.ContentType.PLAYERATTRIBUTES, old_attr_id, DMod.ContentType.ITEMS, id)
 
 
 # Collects all skills defined in an item and updates the references to that skill
@@ -645,12 +643,11 @@ func update_item_attribute_references(olddata: DItem):
 	# Remove old attribute references that are not in the new list
 	for old_attr_id in old_attr_ids:
 		if not new_attr_ids.has(old_attr_id):
-			Gamedata.playerattributes.remove_reference(old_attr_id, "core", "items", id)
+			Gamedata.mods.remove_reference(DMod.ContentType.PLAYERATTRIBUTES, old_attr_id, DMod.ContentType.ITEMS, id)
 	
 	# Add new attribute references
 	for new_attr_id in new_attr_ids:
-		Gamedata.playerattributes.add_reference(new_attr_id, "core", "items", id)
-
+		Gamedata.mods.add_reference(DMod.ContentType.PLAYERATTRIBUTES, new_attr_id, DMod.ContentType.ITEMS, id)
 
 
 # An item is being deleted from the data
@@ -686,16 +683,16 @@ func delete():
 	
 	if food and not food.attributes.is_empty():
 		for food_attribute in food.attributes:
-			Gamedata.playerattributes.remove_reference(food_attribute["id"],"Core","item",id)
-	
+			Gamedata.mods.remove_reference(DMod.ContentType.PLAYERATTRIBUTES, food_attribute["id"], DMod.ContentType.ITEMS, id)
+			
 	if medical and not medical.attributes.is_empty():
 		for medical_attribute in medical.attributes:
-			Gamedata.playerattributes.remove_reference(medical_attribute["id"],"Core","item",id)
-	
+			Gamedata.mods.remove_reference(DMod.ContentType.PLAYERATTRIBUTES, medical_attribute["id"], DMod.ContentType.ITEMS, id)
+			
 	if wearable and not wearable.player_attributes.is_empty():
 		for wearableattr in wearable.player_attributes:
-			Gamedata.playerattributes.remove_reference(wearableattr["id"],"Core","item",id)
-	
+			Gamedata.mods.remove_reference(DMod.ContentType.PLAYERATTRIBUTES, wearableattr["id"], DMod.ContentType.ITEMS, id)
+			
 	var skill_ids: Dictionary = {}
 	# Check if 'craft' is not null before proceeding
 	if craft:

--- a/Scripts/Gamedata/DMob.gd
+++ b/Scripts/Gamedata/DMob.gd
@@ -215,11 +215,11 @@ func update_mob_attribute_references(olddata: DMob):
 	# Remove old skill references that are not in the new list
 	for old_attr_id in old_attr_ids:
 		if not new_attr_ids.has(old_attr_id):
-			Gamedata.playerattributes.remove_reference(old_attr_id, "core", "mobs", id)
+			Gamedata.mods.by_id("Core").playerattributes.remove_reference(old_attr_id, "core", "mobs", id)
 	
 	# Add new attribute references
 	for new_attr_id in new_attr_ids:
-		Gamedata.playerattributes.add_reference(new_attr_id, "core", "mobs", id)
+		Gamedata.mods.by_id("Core").playerattributes.add_reference(new_attr_id, "core", "mobs", id)
 
 
 # Function to retrieve an array of maps from the references

--- a/Scripts/Gamedata/DMod.gd
+++ b/Scripts/Gamedata/DMod.gd
@@ -86,7 +86,7 @@ func _init(modinfo: Dictionary, myparent: DMods):
 	tiles = DTiles.new(id)
 	mobs = DMobs.new()
 	itemgroups = DItemgroups.new()
-	playerattributes = DPlayerAttributes.new()
+	playerattributes = DPlayerAttributes.new(id)
 	wearableslots = DWearableSlots.new()
 	skills = DSkills.new(id)
 	stats = DStats.new(id)  # Pass the mod_id for stats initialization

--- a/Scripts/Gamedata/DPlayerAttribute.gd
+++ b/Scripts/Gamedata/DPlayerAttribute.gd
@@ -106,9 +106,12 @@ class FixedMode:
 # Attribute properties stored inside DefaultMode and FixedMode classes
 var default_mode: DefaultMode
 var fixed_mode: FixedMode
+var parent: DPlayerAttributes
 
-# Constructor to initialize the attribute properties from a dictionary
-func _init(data: Dictionary):
+# Constructor to initialize playerattribute properties from a dictionary
+# myparent: The list containing all playerattributes for this mod
+func _init(data: Dictionary, myparent: DPlayerAttributes):
+	parent = myparent
 	id = data.get("id", "")
 	name = data.get("name", "")
 	description = data.get("description", "")
@@ -152,17 +155,17 @@ func get_data() -> Dictionary:
 func remove_reference(module: String, type: String, refid: String):
 	var changes_made = Gamedata.dremove_reference(references, module, type, refid)
 	if changes_made:
-		Gamedata.playerattributes.save_playerattributes_to_disk()
+		parent.save_playerattributes_to_disk()
 
 # Adds a reference to the references list
 func add_reference(module: String, type: String, refid: String):
 	var changes_made = Gamedata.dadd_reference(references, module, type, refid)
 	if changes_made:
-		Gamedata.playerattributes.save_playerattributes_to_disk()
+		parent.save_playerattributes_to_disk()
 
 # Returns the path of the sprite
 func get_sprite_path() -> String:
-	return Gamedata.playerattributes.spritePath + spriteid
+	return parent.spritePath + spriteid
 
 # Handles playerattribute changes and updates references if necessary
 func on_data_changed(_oldplayerattribute: DPlayerAttribute):
@@ -174,7 +177,7 @@ func on_data_changed(_oldplayerattribute: DPlayerAttribute):
 # Some playerattribute has been changed
 # INFO: if the playerattributes reference other entities, update them here
 func changed(_olddata: DPlayerAttribute):
-	Gamedata.playerattributes.save_playerattributes_to_disk()
+	parent.save_playerattributes_to_disk()
 
 # A playerattribute is being deleted from the data
 # We have to remove it from everything that references it

--- a/Scripts/Gamedata/DPlayerAttribute.gd
+++ b/Scripts/Gamedata/DPlayerAttribute.gd
@@ -24,14 +24,6 @@ extends RefCounted
 #		"description": "You starve when this is empty. You are full when this is full.",
 #		"id": "food",
 #		"name": "Food",
-#		"references": {
-#			"core": {
-#				"items": [
-#					"canned_food",
-#					"tofu"
-#				]
-#			}
-#		},
 #		"sprite": "apple_32.png"
 #	}
 

--- a/Scripts/Gamedata/DPlayerAttributes.gd
+++ b/Scripts/Gamedata/DPlayerAttributes.gd
@@ -3,26 +3,34 @@ extends RefCounted
 
 # There's a D in front of the class name to indicate this class only handles player attribute
 # data, nothing more. This script is intended to be used inside the GameData autoload singleton
-# This script handles the list of playerattributes. You can access it trough Gamedata.playerattributes
+# This script handles the list of playerattributes. You can access it trough Gamedata.mods.by_id("Core").playerattributes
 
 
-var dataPath: String = "./Mods/Core/PlayerAttributes/PlayerAttributes.json"
+var dataPath: String = "./Mods/Core/PlayerAttributes/"
+var filePath: String = "./Mods/Core/PlayerAttributes/PlayerAttributes.json"
 var spritePath: String = "./Mods/Core/PlayerAttributes/"
 var playerattributedict: Dictionary = {}
 var sprites: Dictionary = {}
 var hardcoded: Array = ["player_inventory"]
+var references: Dictionary = {}
 
 
-func _init():
+# Add a mod_id parameter to dynamically initialize paths
+func _init(mod_id: String) -> void:
+	# Update dataPath and spritePath using the provided mod_id
+	dataPath = "./Mods/" + mod_id + "/PlayerAttributes/"
+	filePath = "./Mods/" + mod_id + "/PlayerAttributes/PlayerAttributes.json"
+	spritePath = "./Mods/" + mod_id + "/PlayerAttributes/"
+	
 	load_sprites()
 	load_playerattributes_from_disk()
 
 
 # Load all playerattributedata from disk into memory
 func load_playerattributes_from_disk() -> void:
-	var playerattributelist: Array = Helper.json_helper.load_json_array_file(dataPath)
+	var playerattributelist: Array = Helper.json_helper.load_json_array_file(filePath)
 	for myattribute in playerattributelist:
-		var playerattribute: DPlayerAttribute = DPlayerAttribute.new(myattribute)
+		var playerattribute: DPlayerAttribute = DPlayerAttribute.new(myattribute, self)
 		if sprites.has(playerattribute.spriteid):
 			playerattribute.sprite = sprites[playerattribute.spriteid]
 		playerattributedict[playerattribute.id] = playerattribute
@@ -47,7 +55,7 @@ func save_playerattributes_to_disk() -> void:
 	var save_data: Array = []
 	for playerattribute in playerattributedict.values():
 		save_data.append(playerattribute.get_data())
-	Helper.json_helper.write_json_file(dataPath, JSON.stringify(save_data, "\t"))
+	Helper.json_helper.write_json_file(filePath, JSON.stringify(save_data, "\t"))
 
 
 func get_all() -> Dictionary:
@@ -60,13 +68,13 @@ func duplicate_to_disk(playerattributeid: String, newplayerattributeid: String) 
 	# So we delete the references from the duplicated data if it is present
 	playerattributedata.erase("references")
 	playerattributedata.id = newplayerattributeid
-	var newplayerattribute: DPlayerAttribute = DPlayerAttribute.new(playerattributedata)
+	var newplayerattribute: DPlayerAttribute = DPlayerAttribute.new(playerattributedata, self)
 	playerattributedict[newplayerattributeid] = newplayerattribute
 	save_playerattributes_to_disk()
 
 
 func add_new(newid: String) -> void:
-	var newplayerattribute: DPlayerAttribute = DPlayerAttribute.new({"id":newid})
+	var newplayerattribute: DPlayerAttribute = DPlayerAttribute.new({"id":newid}, self)
 	playerattributedict[newplayerattribute.id] = newplayerattribute
 	save_playerattributes_to_disk()
 

--- a/Scripts/Gamedata/DPlayerAttributes.gd
+++ b/Scripts/Gamedata/DPlayerAttributes.gd
@@ -36,6 +36,15 @@ func load_playerattributes_from_disk() -> void:
 		playerattributedict[playerattribute.id] = playerattribute
 
 
+# Load references from references.json
+func load_references() -> void:
+	var path = dataPath + "references.json"
+	if FileAccess.file_exists(path):
+		references = Helper.json_helper.load_json_dictionary_file(path)
+	else:
+		references = {}  # Initialize an empty references dictionary if the file doesn't exist
+
+
 # Loads sprites and assigns them to the proper dictionary
 func load_sprites() -> void:
 	var png_files: Array = Helper.json_helper.file_names_in_dir(spritePath, ["png"])

--- a/Scripts/Gamedata/DSkills.gd
+++ b/Scripts/Gamedata/DSkills.gd
@@ -107,24 +107,3 @@ func sprite_by_id(skillid: String) -> Texture:
 # Returns the sprite by its file name
 func sprite_by_file(spritefile: String) -> Texture:
 	return sprites[spritefile]
-
-# Removes a reference from the selected skill
-func remove_reference(skillid: String, module: String, type: String, refid: String):
-	var myskill: DSkill = skilldict[skillid]
-	myskill.remove_reference(module, type, refid)
-
-# Adds a reference to the references list in the skill
-func add_reference(skillid: String, module: String, type: String, refid: String):
-	var myskill: DSkill = skilldict[skillid]
-	myskill.add_reference(module, type, refid)
-
-# Helper function to update references if they have changed
-func update_reference(old: String, new: String, type: String, refid: String) -> void:
-	if old == new:
-		return  # No change detected, exit early
-
-	# Remove from old group if necessary
-	if old != "":
-		remove_reference(old, "core", type, refid)
-	if new != "":
-		add_reference(new, "core", type, refid)

--- a/Scripts/InventoryWindow.gd
+++ b/Scripts/InventoryWindow.gd
@@ -148,7 +148,7 @@ func _append_medical_attributes(item: InventoryItem, description: String) -> Str
 			for attribute in dmedical.attributes:
 				var attr_id = attribute.get("id", "Unknown")
 				var attr_amount = attribute.get("amount", 0)
-				var attr_name: String = Gamedata.playerattributes.by_id(attr_id).name
+				var attr_name: String = Runtimedata.playerattributes.by_id(attr_id).name
 				
 				# Build the line only if there's something to display
 				var line = " ►" + attr_name + ":"

--- a/Scripts/ItemFoodEditor.gd
+++ b/Scripts/ItemFoodEditor.gd
@@ -93,7 +93,7 @@ func _can_drop_attribute_data(_newpos, data) -> bool:
 		return false
 
 	# Fetch attribute by ID from the Gamedata to ensure it exists and is valid
-	if not Gamedata.playerattributes.has_id(data["id"]):
+	if not Gamedata.mods.by_id("Core").playerattributes.has_id(data["id"]):
 		return false
 
 	# Check if the attribute ID already exists in the attributes grid
@@ -119,7 +119,7 @@ func _handle_attribute_drop(dropped_data, _newpos) -> void:
 	# dropped_data is a Dictionary that includes an 'id'
 	if dropped_data and "id" in dropped_data:
 		var attribute_id = dropped_data["id"]
-		if not Gamedata.playerattributes.has_id(attribute_id):
+		if not Gamedata.mods.by_id("Core").playerattributes.has_id(attribute_id):
 			print_debug("No attribute data found for ID: " + attribute_id)
 			return
 		

--- a/Scripts/ItemMedicalEditor.gd
+++ b/Scripts/ItemMedicalEditor.gd
@@ -88,7 +88,7 @@ func _get_attributes_from_ui() -> Array:
 
 # Add a new attribute entry to the attributes_container
 func _add_attribute_entry(attribute: Dictionary) -> void:
-	var dattribute: DPlayerAttribute = Gamedata.playerattributes.by_id(attribute.id)
+	var dattribute: DPlayerAttribute = Gamedata.mods.by_id("Core").playerattributes.by_id(attribute.id)
 	var sprite: Texture = dattribute.sprite
 	var attribute_name = attribute.id
 	var amount = attribute.amount
@@ -156,7 +156,7 @@ func _can_drop_attribute_data(_newpos, data) -> bool:
 		return false
 
 	# Fetch attribute by ID from the Gamedata to ensure it exists and is valid
-	if not Gamedata.playerattributes.has_id(data["id"]):
+	if not Gamedata.mods.by_id("Core").playerattributes.has_id(data["id"]):
 		return false
 
 	# Check if the attribute ID already exists in the attributes grid
@@ -184,7 +184,7 @@ func _handle_attribute_drop(dropped_data, _newpos) -> void:
 	# dropped_data is a Dictionary that includes an 'id'
 	if dropped_data and "id" in dropped_data:
 		var attribute_id = dropped_data["id"]
-		if not Gamedata.playerattributes.has_id(attribute_id):
+		if not Gamedata.mods.by_id("Core").playerattributes.has_id(attribute_id):
 			print_debug("No attribute data found for ID: " + attribute_id)
 			return
 		

--- a/Scripts/ItemWearableEditor.gd
+++ b/Scripts/ItemWearableEditor.gd
@@ -54,7 +54,7 @@ func save_properties() -> void:
 
 # Add a new attribute entry to the attributtes_grid_container
 func add_attribute_entry(attribute_id: String, value: int = 0, use_loaded_value: bool = false):
-	if not Gamedata.playerattributes.has_id(attribute_id):
+	if not Gamedata.mods.by_id("Core").playerattributes.has_id(attribute_id):
 		print_debug("Invalid attribute ID: " + attribute_id)
 		return
 
@@ -95,7 +95,7 @@ func can_drop_attribute(at_position: Vector2, dropped_data: Dictionary) -> bool:
 		return false
 	
 	# Check if the attribute ID exists in playerattributes
-	if not Gamedata.playerattributes.has_id(dropped_data["id"]):
+	if not Gamedata.mods.by_id("Core").playerattributes.has_id(dropped_data["id"]):
 		return false
 
 	# Prevent duplicates in the attributtes_grid_container

--- a/Scripts/PlayerAttribute.gd
+++ b/Scripts/PlayerAttribute.gd
@@ -5,7 +5,7 @@ extends RefCounted
 # It interacts with the player and handles attribute changes, effects, saving, and loading.
 
 # The DPlayerAttribute data instance
-var attribute_data: DPlayerAttribute
+var attribute_data: RPlayerAttribute
 
 # Reference to the player instance
 var player: Node
@@ -193,7 +193,7 @@ var default_mode: DefaultMode
 var fixed_mode: FixedMode
 
 # Constructor to initialize the controller with a DPlayerAttribute and a player reference
-func _init(data: DPlayerAttribute, player_reference: Node):
+func _init(data: RPlayerAttribute, player_reference: Node):
 	attribute_data = data  # Store attribute data
 	player = player_reference
 

--- a/Scripts/Runtimedata/RPlayerAttribute.gd
+++ b/Scripts/Runtimedata/RPlayerAttribute.gd
@@ -1,0 +1,141 @@
+class_name RPlayerAttribute
+extends RefCounted
+
+# This class represents a player attribute with its properties
+# Only used while the game is running
+# Example player attribute data:
+# {
+#     "default_mode": {
+#         "color": "258d1bff",
+#         "current_amount": 100,
+#         "maxed_effect": "death",
+#         "depletion_effect": "death",
+#         "depleting_effect": "drain",
+#         "depletion_rate": 0.02,
+#         "max_amount": 100,
+#         "min_amount": 0,
+#         "hide_when_empty": false,
+#         "drain_attributes": {
+#             "torso_health": 1.0,
+#             "head_health": 1.0
+#         }
+#     },
+#     "description": "You starve when this is empty. You are full when this is full.",
+#     "id": "food",
+#     "name": "Food",
+#     "references": {
+#         "core": {
+#             "items": [
+#                 "canned_food",
+#                 "tofu"
+#             ]
+#         }
+#     },
+#     "sprite": "apple_32.png"
+# }
+
+# Properties defined in the player attribute
+var id: String
+var name: String
+var description: String
+var spriteid: String
+var sprite: Texture
+var parent: RPlayerAttributes  # Reference to the list containing all runtime player attributes for this mod
+# Attribute properties stored inside DefaultMode and FixedMode classes
+var default_mode: DefaultMode
+var fixed_mode: FixedMode
+
+# Inner class for DefaultMode properties
+class DefaultMode:
+	var min_amount: float
+	var max_amount: float
+	var current_amount: float
+	var depletion_rate: float
+	var ui_color: String
+	var maxed_effect: String
+	var depletion_effect: String
+	var depleting_effect: String
+	var hide_when_empty: bool
+	var drain_attributes: Dictionary
+
+	func _init(data: Dictionary):
+		min_amount = data.get("min_amount", 0.0)
+		max_amount = data.get("max_amount", 100.0)
+		current_amount = data.get("current_amount", max_amount)
+		depletion_rate = data.get("depletion_rate", 0.02)
+		ui_color = data.get("color", "ffffffff")
+		maxed_effect = data.get("maxed_effect", "none")
+		depletion_effect = data.get("depletion_effect", "none")
+		depleting_effect = data.get("depleting_effect", "none")
+		hide_when_empty = data.get("hide_when_empty", false)
+		drain_attributes = data.get("drain_attributes", {})
+
+	func get_data() -> Dictionary:
+		var data = {
+			"min_amount": min_amount,
+			"max_amount": max_amount,
+			"current_amount": current_amount,
+			"depletion_rate": depletion_rate,
+			"color": ui_color,
+			"maxed_effect": maxed_effect,
+			"depletion_effect": depletion_effect,
+			"depleting_effect": depleting_effect,
+			"hide_when_empty": hide_when_empty
+		}
+		if not drain_attributes.is_empty():
+			data["drain_attributes"] = drain_attributes
+		return data
+
+
+# Inner class for FixedMode properties
+class FixedMode:
+	var amount: float  # Single float variable for fixed amount
+	
+	# Constructor to initialize the fixed amount from a dictionary
+	func _init(data: Dictionary):
+		amount = data.get("amount", 0.0)  # Default to 0.0 if not provided
+	
+	# Get data function to return a dictionary with the amount
+	func get_data() -> Dictionary:
+		return {
+			"amount": amount
+		}
+
+
+# Constructor to initialize player attribute properties
+# myparent: The list containing all player attributes for this mod
+# newid: The ID of the player attribute being created
+func _init(myparent: RPlayerAttributes, newid: String):
+	parent = myparent
+	id = newid
+
+# Overwrite this player attribute's properties using a DPlayerAttribute
+func overwrite_from_dplayerattribute(dplayerattribute: DPlayerAttribute) -> void:
+	if not id == dplayerattribute.id:
+		print_debug("Cannot overwrite from a different id")
+	name = dplayerattribute.name
+	description = dplayerattribute.description
+	spriteid = dplayerattribute.spriteid
+	sprite = dplayerattribute.sprite
+	if dplayerattribute.default_mode:
+		default_mode = DefaultMode.new(dplayerattribute.default_mode.get_data())
+	else:
+		default_mode = null
+	if dplayerattribute.fixed_mode:
+		fixed_mode = FixedMode.new(dplayerattribute.fixed_mode.get_data())
+	else:
+		fixed_mode = null
+
+# Get data function to return a dictionary with all properties
+func get_data() -> Dictionary:
+	var data: Dictionary = {
+		"id": id,
+		"name": name,
+		"description": description,
+		"sprite": spriteid
+	}
+	if default_mode:
+		data["default_mode"] = default_mode.get_data()
+	if fixed_mode:
+		data["fixed_mode"] = fixed_mode.get_data()
+	return data

--- a/Scripts/Runtimedata/RPlayerAttributes.gd
+++ b/Scripts/Runtimedata/RPlayerAttributes.gd
@@ -1,0 +1,66 @@
+class_name RPlayerAttributes
+extends RefCounted
+
+# There's an R in front of the class name to indicate this class only handles runtime player attribute data, nothing more
+# This script is intended to be used inside the Runtime autoload singleton
+# This script handles the list of player attributes. You can access it through Runtime.mods.by_id("Core").playerattributes
+
+# Paths for player attribute data and sprites
+var playerattributedict: Dictionary = {}  # Holds runtime player attribute instances
+var sprites: Dictionary = {}  # Holds player attribute sprites
+
+# Constructor
+func _init() -> void:
+	# Get all mods and their IDs
+	var mod_ids: Array = Gamedata.mods.get_all_mod_ids()
+
+	# Loop through each mod to get its DPlayerAttributes
+	for mod_id in mod_ids:
+		var dplayerattributes: DPlayerAttributes = Gamedata.mods.by_id(mod_id).playerattributes
+
+		# Loop through each DPlayerAttribute in the mod
+		for dplayerattribute_id: String in dplayerattributes.get_all().keys():
+			var dplayerattribute: DPlayerAttribute = dplayerattributes.by_id(dplayerattribute_id)
+
+			# Check if the player attribute exists in playerattributedict
+			var rplayerattribute: RPlayerAttribute
+			if not playerattributedict.has(dplayerattribute_id):
+				# If it doesn't exist, create a new RPlayerAttribute
+				rplayerattribute = add_new(dplayerattribute_id)
+			else:
+				# If it exists, get the existing RPlayerAttribute
+				rplayerattribute = playerattributedict[dplayerattribute_id]
+
+			# Overwrite the RPlayerAttribute properties with the DPlayerAttribute properties
+			rplayerattribute.overwrite_from_dplayerattribute(dplayerattribute)
+
+# Returns the dictionary containing all player attributes
+func get_all() -> Dictionary:
+	return playerattributedict
+
+# Adds a new player attribute with a given ID
+func add_new(newid: String) -> RPlayerAttribute:
+	var newplayerattribute: RPlayerAttribute = RPlayerAttribute.new(self, newid)
+	playerattributedict[newplayerattribute.id] = newplayerattribute
+	return newplayerattribute
+
+# Deletes a player attribute by its ID
+func delete_by_id(playerattributeid: String) -> void:
+	playerattributedict[playerattributeid].delete()
+	playerattributedict.erase(playerattributeid)
+
+# Returns a player attribute by its ID
+func by_id(playerattributeid: String) -> RPlayerAttribute:
+	return playerattributedict[playerattributeid]
+
+# Checks if a player attribute exists by its ID
+func has_id(playerattributeid: String) -> bool:
+	return playerattributedict.has(playerattributeid)
+
+# Returns the sprite of the player attribute
+func sprite_by_id(playerattributeid: String) -> Texture:
+	return playerattributedict[playerattributeid].sprite
+
+# Returns the sprite by its file name
+func sprite_by_file(spritefile: String) -> Texture:
+	return sprites.get(spritefile, null)

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -7,7 +7,6 @@ var furnitures: DFurnitures
 var items: DItems
 var mobs: DMobs
 var itemgroups: DItemgroups
-var playerattributes: DPlayerAttributes
 var wearableslots: DWearableSlots
 var mobgroups: DMobgroups
 var mobfactions: DMobfactions
@@ -51,7 +50,6 @@ func _ready():
 	items = DItems.new()
 	mobs = DMobs.new()
 	itemgroups = DItemgroups.new()
-	playerattributes = DPlayerAttributes.new()
 	wearableslots = DWearableSlots.new()
 	mobgroups = DMobgroups.new()
 	mobfactions = DMobfactions.new()
@@ -65,7 +63,7 @@ func _ready():
 		DMod.ContentType.ITEMS: items,
 		DMod.ContentType.TILES: mods.by_id("Core").tiles,
 		DMod.ContentType.MOBS: mobs,
-		DMod.ContentType.PLAYERATTRIBUTES: playerattributes,
+		DMod.ContentType.PLAYERATTRIBUTES: mods.by_id("Core").playerattributes,
 		DMod.ContentType.WEARABLESLOTS: wearableslots,
 		DMod.ContentType.STATS: mods.by_id("Core").stats,
 		DMod.ContentType.SKILLS: mods.by_id("Core").skills,

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -88,7 +88,7 @@ func initialize_condition():
 # The PlayerAttribute manages the actual control of the attribute while
 # DPlayerAttribute only provides the data
 func initialize_attributes():
-	var playerattributes: Dictionary = Gamedata.playerattributes.get_all()
+	var playerattributes: Dictionary = Runtimedata.playerattributes.get_all()
 	for attribute: DPlayerAttribute in playerattributes.values():
 		attributes[attribute.id] = PlayerAttribute.new(attribute, self)
 

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -89,7 +89,7 @@ func initialize_condition():
 # DPlayerAttribute only provides the data
 func initialize_attributes():
 	var playerattributes: Dictionary = Runtimedata.playerattributes.get_all()
-	for attribute: DPlayerAttribute in playerattributes.values():
+	for attribute: RPlayerAttribute in playerattributes.values():
 		attributes[attribute.id] = PlayerAttribute.new(attribute, self)
 
 

--- a/Scripts/runtimedata.gd
+++ b/Scripts/runtimedata.gd
@@ -16,6 +16,7 @@ var stats: RStats
 var quests: RQuests
 var overmapareas: ROvermapareas
 var mobgroups: DMobgroups
+var mobfactions: DMobfactions
 
 # Dictionary to map content types to Gamedata variables
 var gamedata_map: Dictionary = {}

--- a/Scripts/runtimedata.gd
+++ b/Scripts/runtimedata.gd
@@ -9,7 +9,7 @@ var items: DItems
 var tiles: RTiles
 var mobs: DMobs
 var itemgroups: DItemgroups
-var playerattributes: DPlayerAttributes
+var playerattributes: RPlayerAttributes
 var wearableslots: DWearableSlots
 var skills: RSkills
 var stats: RStats
@@ -36,6 +36,7 @@ func reconstruct() -> void:
 	tiles = RTiles.new()
 	overmapareas = ROvermapareas.new()
 	quests = RQuests.new()
+	playerattributes = RPlayerAttributes.new()
 	
 	# Populate the gamedata_map with the instantiated objects
 	gamedata_map = {
@@ -45,5 +46,6 @@ func reconstruct() -> void:
 		DMod.ContentType.TACTICALMAPS: tacticalmaps,
 		DMod.ContentType.TILES: tiles,
 		DMod.ContentType.OVERMAPAREAS: overmapareas,
-		DMod.ContentType.QUESTS: quests
+		DMod.ContentType.QUESTS: quests,
+		DMod.ContentType.PLAYERATTRIBUTES: playerattributes
 	}


### PR DESCRIPTION
Helps to complete #533 

Playerattributes are now part of the mod. All references have been updated. Items still can only use core playerattributes and that will remain the case until items migrate.