### PR TITLE
move wearableslots to mods

### DIFF
--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="ItemProtoset" load_steps=2 format=3 uid="uid://yal8y66ryr33"]
+[gd_resource type="Resource" script_class="ItemProtoset" load_steps=2 format=3 uid="uid://cgkq7vfjq07jm"]
 
 [ext_resource type="Script" path="res://addons/gloot/core/item_protoset.gd" id="1_o35lu"]
 
@@ -747,6 +747,9 @@ json_data = "[
 		\"weight\": 1
 	},
 	{
+		\"Wearable\": {
+			\"slot\": \"torso\"
+		},
 		\"description\": \"A piece of clothing that offers protection from ballistic forces\",
 		\"id\": \"vest_ballistic\",
 		\"image\": \"./Mods/Core/Items/vest_ballistic_32.png\",

--- a/Mods/Core/Items/Items.json
+++ b/Mods/Core/Items/Items.json
@@ -741,6 +741,9 @@
 		"weight": 1
 	},
 	{
+		"Wearable": {
+			"slot": "torso"
+		},
 		"description": "A piece of clothing that offers protection from ballistic forces",
 		"id": "vest_ballistic",
 		"image": "./Mods/Core/Items/vest_ballistic_32.png",

--- a/Mods/Core/Wearableslots/Wearableslots.json
+++ b/Mods/Core/Wearableslots/Wearableslots.json
@@ -3,85 +3,36 @@
 		"description": "Holds equipment on your torso",
 		"id": "torso",
 		"name": "Torso",
-		"references": {
-			"core": {
-				"items": [
-					"jacket",
-					"tshirt",
-					"sweater"
-				]
-			}
-		},
 		"sprite": "wearableslot_torso_32.png"
 	},
 	{
 		"description": "Holds equipment on your legs",
 		"id": "legs",
 		"name": "Legs",
-		"references": {
-			"core": {
-				"items": [
-					"jeans",
-					"shorts"
-				]
-			}
-		},
 		"sprite": "wearableslot_legs_32.png"
 	},
 	{
 		"description": "Holds equipment on your feet",
 		"id": "feet",
 		"name": "Feet",
-		"references": {
-			"core": {
-				"items": [
-					"boots",
-					"socks"
-				]
-			}
-		},
 		"sprite": "wearableslot_feet_32.png"
 	},
 	{
 		"description": "Holds equipment on your hands",
 		"id": "hands",
 		"name": "Hands",
-		"references": {
-			"core": {
-				"items": [
-					"gloves_leather",
-					"wrist_watch"
-				]
-			}
-		},
 		"sprite": "wearableslot_hands_32.png"
 	},
 	{
 		"description": "Holds equipment on your head",
 		"id": "head",
 		"name": "Head",
-		"references": {
-			"core": {
-				"items": [
-					"gas_mask",
-					"hat_baseball",
-					"scarf"
-				]
-			}
-		},
 		"sprite": "wearableslot_head_32.png"
 	},
 	{
 		"description": "Holds equipment on your back",
 		"id": "back",
 		"name": "Back",
-		"references": {
-			"core": {
-				"items": [
-					"mailbag"
-				]
-			}
-		},
 		"sprite": "wearableslot_back_32.png"
 	}
 ]

--- a/Mods/Core/Wearableslots/references.json
+++ b/Mods/Core/Wearableslots/references.json
@@ -1,0 +1,7 @@
+{
+	"torso": {
+		"items": [
+			"vest_ballistic"
+		]
+	}
+}

--- a/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemWearableEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemWearableEditor.tscn
@@ -1,11 +1,12 @@
-[gd_scene load_steps=3 format=3 uid="uid://65bjwo1b3je2"]
+[gd_scene load_steps=4 format=3 uid="uid://65bjwo1b3je2"]
 
 [ext_resource type="Script" path="res://Scripts/ItemWearableEditor.gd" id="1_o5i08"]
+[ext_resource type="PackedScene" uid="uid://dsax7il2yggw8" path="res://Scenes/ContentManager/Custom_Widgets/DropEnabledTextEdit.tscn" id="2_aft7y"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_o3shf"]
 bg_color = Color(0.72927, 0.567349, 0.365251, 1)
 
-[node name="ItemWearableEditor" type="Control" node_paths=PackedStringArray("SlotOptionButton", "attributtes_grid_container")]
+[node name="ItemWearableEditor" type="Control" node_paths=PackedStringArray("slot_drop_enabled_text_edit", "attributtes_grid_container")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -13,7 +14,7 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_o5i08")
-SlotOptionButton = NodePath("Wearable/SlotOptionButton")
+slot_drop_enabled_text_edit = NodePath("Wearable/SlotDropEnabledTextEdit")
 attributtes_grid_container = NodePath("Wearable/AttributesPanelContainer/AttributtesGridContainer")
 
 [node name="Wearable" type="GridContainer" parent="."]
@@ -25,8 +26,12 @@ columns = 2
 layout_mode = 2
 text = "Wearable slot"
 
-[node name="SlotOptionButton" type="OptionButton" parent="Wearable"]
+[node name="SlotDropEnabledTextEdit" parent="Wearable" instance=ExtResource("2_aft7y")]
 layout_mode = 2
+tooltip_text = "The slot that this item will fit on. Drag a wearableslot from the list on the 
+left onto this field to set it. If no slot is set, it will not fit anywhere. In-game, 
+the player will be able to drag the item to this slot in the inventory window."
+myplaceholdertext = "Drop a Wearable Slot from the list on the left"
 
 [node name="PlayerAttributeLabel" type="Label" parent="Wearable"]
 layout_mode = 2

--- a/Scenes/ContentManager/Custom_Editors/Scripts/WearableslotEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/WearableslotEditor.gd
@@ -19,14 +19,14 @@ signal data_changed()
 var olddata: DWearableSlot # Remember what the value of the data was before editing
 
 # The data that represents this slot
-# The data is selected from the Gamedata.wearableslots
+# The data is selected from the dwearableslot.parent.wearableslots
 # based on the ID that the user has selected in the content editor
 var dwearableslot: DWearableSlot = null:
 	set(value):
 		dwearableslot = value
 		load_slot_data()
-		slotSelector.sprites_collection = Gamedata.wearableslots.sprites
-		olddata = DWearableSlot.new(dwearableslot.get_data().duplicate(true))
+		slotSelector.sprites_collection = dwearableslot.parent.sprites
+		olddata = DWearableSlot.new(dwearableslot.get_data().duplicate(true), null)
 
 
 # This function updates the form based on the DWearableSlot that has been loaded
@@ -47,7 +47,7 @@ func _on_close_button_button_up() -> void:
 	queue_free()
 
 # This function takes all data from the form elements and stores them in the DWearableSlot instance
-# Since dwearableslot is a reference to an item in Gamedata.wearableslots
+# Since dwearableslot is a reference to an item in dwearableslot.parent.wearableslots
 # the central array for slot data is updated with the changes as well
 # The function will signal to Gamedata that the data has changed and needs to be saved
 func _on_save_button_button_up() -> void:
@@ -57,7 +57,7 @@ func _on_save_button_button_up() -> void:
 	dwearableslot.sprite = slotImageDisplay.texture
 	dwearableslot.save_to_disk()
 	data_changed.emit()
-	olddata = DWearableSlot.new(dwearableslot.get_data().duplicate(true))
+	olddata = DWearableSlot.new(dwearableslot.get_data().duplicate(true), null)
 
 # When the slotImageDisplay is clicked, the user will be prompted to select an image from 
 # "res://Mods/Core/slots/". The texture of the slotImageDisplay will change to the selected image

--- a/Scenes/ContentManager/Scripts/content_list.gd
+++ b/Scenes/ContentManager/Scripts/content_list.gd
@@ -17,7 +17,7 @@ var mod_id: String = "Core"
 var contentType: DMod.ContentType:
 	set(newData):
 		contentType = newData
-		if newData == DMod.ContentType.STATS or newData == DMod.ContentType.PLAYERATTRIBUTES or newData == DMod.ContentType.QUESTS or newData == DMod.ContentType.SKILLS or newData == DMod.ContentType.OVERMAPAREAS or newData == DMod.ContentType.TILES or newData == DMod.ContentType.TACTICALMAPS or newData == DMod.ContentType.MAPS:
+		if newData == DMod.ContentType.STATS or newData == DMod.ContentType.WEARABLESLOTS or newData == DMod.ContentType.PLAYERATTRIBUTES or newData == DMod.ContentType.QUESTS or newData == DMod.ContentType.SKILLS or newData == DMod.ContentType.OVERMAPAREAS or newData == DMod.ContentType.TILES or newData == DMod.ContentType.TACTICALMAPS or newData == DMod.ContentType.MAPS:
 			# Use mod-specific data for these content types
 			datainstance = Gamedata.mods.by_id(mod_id).get_data_of_type(contentType)
 		else:

--- a/Scenes/ContentManager/Scripts/contenteditor.gd
+++ b/Scenes/ContentManager/Scripts/contenteditor.gd
@@ -174,7 +174,7 @@ func instantiate_editor(type: DMod.ContentType, itemID: String, newEditor: Packe
 			newContentEditor.data_changed.connect(list.load_data)
 		
 		DMod.ContentType.WEARABLESLOTS:
-			newContentEditor.dwearableslot = Gamedata.wearableslots.by_id(itemID)
+			newContentEditor.dwearableslot = currentmod.wearableslots.by_id(itemID)
 			newContentEditor.data_changed.connect(list.load_data)
 		
 		DMod.ContentType.STATS:

--- a/Scripts/Gamedata/DItem.gd
+++ b/Scripts/Gamedata/DItem.gd
@@ -344,9 +344,9 @@ class Wearable:
 
 	# Get data function to return a dictionary with all properties
 	func get_data() -> Dictionary:
-		var mydata: Dictionary = {
-			"slot": slot
-		}
+		var mydata: Dictionary = {}
+		if slot:
+			mydata["slot"] = slot
 		if not player_attributes.is_empty():
 			mydata["player_attributes"] = player_attributes
 		return mydata
@@ -354,12 +354,12 @@ class Wearable:
 	# Function to add a reference for the wearable slot
 	func add_reference(item_id: String):
 		if slot != "":
-			Gamedata.wearableslots.add_reference(slot, "core", "items", item_id)
+			Gamedata.mods.add_reference(DMod.ContentType.WEARABLESLOTS, slot, DMod.ContentType.ITEMS, item_id)
 
 	# Function to remove a reference for the wearable slot
 	func remove_reference(item_id: String):
 		if slot != "":
-			Gamedata.wearableslots.remove_reference(slot, "core", "items", item_id)
+			Gamedata.mods.remove_reference(DMod.ContentType.WEARABLESLOTS, slot, DMod.ContentType.ITEMS, item_id)
 
 	# Function to get the value of a specific player attribute by ID
 	func get_attribute_value(attribute_id: String) -> Variant:
@@ -472,7 +472,9 @@ func get_data() -> Dictionary:
 		data["Ammo"] = ammo.get_data()
 
 	if wearable:
-		data["Wearable"] = wearable.get_data()
+		var wearabledata = wearable.get_data()
+		if not wearabledata.is_empty():
+			data["Wearable"] = wearabledata
 
 	return data
 

--- a/Scripts/Gamedata/DMod.gd
+++ b/Scripts/Gamedata/DMod.gd
@@ -87,7 +87,7 @@ func _init(modinfo: Dictionary, myparent: DMods):
 	mobs = DMobs.new()
 	itemgroups = DItemgroups.new()
 	playerattributes = DPlayerAttributes.new(id)
-	wearableslots = DWearableSlots.new()
+	wearableslots = DWearableSlots.new(id)
 	skills = DSkills.new(id)
 	stats = DStats.new(id)  # Pass the mod_id for stats initialization
 	quests = DQuests.new(id)

--- a/Scripts/Gamedata/DMods.gd
+++ b/Scripts/Gamedata/DMods.gd
@@ -90,8 +90,8 @@ func get_content_by_id(contentType: DMod.ContentType, id: String) -> RefCounted:
 # The returned value may be an array of DMap, DItem, DMobgroup or anything
 # If more then one is returned, that means that this id is contained within more then one mod
 # We will expect two of them to be duplicates of eachother.
-func get_all_content_by_id(contentType: DMod.ContentType, id: String) -> Array:
-	var results: Array = []
+func get_all_content_by_id(contentType: DMod.ContentType, id: String) -> Array[RefCounted]:
+	var results: Array[RefCounted] = []
 	
 	# Loop over all mods in the moddict
 	for mod in moddict.values():

--- a/Scripts/Gamedata/DWearableSlot.gd
+++ b/Scripts/Gamedata/DWearableSlot.gd
@@ -25,15 +25,16 @@ var name: String
 var description: String
 var spriteid: String
 var sprite: Texture
-var references: Dictionary = {}
+var parent: DWearableSlots
 
-# Constructor to initialize wearable slot properties from a dictionary
-func _init(data: Dictionary):
+# Constructor to initialize quest properties from a dictionary
+# myparent: The list containing all quests for this mod
+func _init(data: Dictionary, myparent: DWearableSlots):
+	parent = myparent
 	id = data.get("id", "")
 	name = data.get("name", "")
 	description = data.get("description", "")
 	spriteid = data.get("sprite", "")
-	references = data.get("references", {})
 
 # Get data function to return a dictionary with all properties
 func get_data() -> Dictionary:
@@ -43,60 +44,44 @@ func get_data() -> Dictionary:
 		"description": description,
 		"sprite": spriteid
 	}
-	if not references.is_empty():
-		data["references"] = references
 	return data
 
 # Method to save any changes to the wearable slot back to disk
 func save_to_disk():
-	Gamedata.wearableslots.save_wearableslots_to_disk()
-
-
-# Removes the provided reference from references
-func remove_reference(module: String, type: String, refid: String):
-	var changes_made = Gamedata.dremove_reference(references, module, type, refid)
-	if changes_made:
-		Gamedata.wearableslots.save_wearableslots_to_disk()
-
-
-# Adds a reference to the references list
-func add_reference(module: String, type: String, refid: String):
-	var changes_made = Gamedata.dadd_reference(references, module, type, refid)
-	if changes_made:
-		Gamedata.wearableslots.save_wearableslots_to_disk()
+	parent.save_wearableslots_to_disk()
 
 
 # Some wearableslot has been changed
 # INFO if the wearableslot reference other entities, update them here
 func changed(_olddata: DItemgroup):
-	Gamedata.wearableslots.save_wearableslots_to_disk()
+	parent.save_wearableslots_to_disk()
 
-
-# A wearableslot is being deleted from the data
-# We have to remove it from everything that references it
-func delete():
-	var changes: Dictionary = {"made":false}
-	
-	# This callable will remove this slot from items that reference this slot.
-	var myfunc: Callable = func (item_id):
-		var item_data: DItem = Gamedata.items.by_id(item_id)
-		item_data.wearable = null
-		changes.made = true
-	# Pass the callable to every item in the wearableslot's references
-	# It will call myfunc on every item in wearableslot_data.references.core.items
-	execute_callable_on_references_of_type("core", "items", myfunc)
-	
-	# Save changes to the data file if any changes were made
-	if changes.made:
-		Gamedata.items.save_items_to_disk()
-	else:
-		print_debug("No changes needed for item", id)
-
-
-# Executes a callable function on each reference of the given type
-func execute_callable_on_references_of_type(module: String, type: String, callable: Callable):
-	# Check if it contains the specified 'module' and 'type'
-	if references.has(module) and references[module].has(type):
-		# If the type exists, execute the callable on each ID found under this type
-		for ref_id in references[module][type]:
-			callable.call(ref_id)
+#
+## A wearableslot is being deleted from the data
+## We have to remove it from everything that references it
+#func delete():
+	#var changes: Dictionary = {"made":false}
+	#
+	## This callable will remove this slot from items that reference this slot.
+	#var myfunc: Callable = func (item_id):
+		#var item_data: DItem = Gamedata.items.by_id(item_id)
+		#item_data.wearable = null
+		#changes.made = true
+	## Pass the callable to every item in the wearableslot's references
+	## It will call myfunc on every item in wearableslot_data.references.core.items
+	#execute_callable_on_references_of_type("core", "items", myfunc)
+	#
+	## Save changes to the data file if any changes were made
+	#if changes.made:
+		#Gamedata.items.save_items_to_disk()
+	#else:
+		#print_debug("No changes needed for item", id)
+#
+#
+## Executes a callable function on each reference of the given type
+#func execute_callable_on_references_of_type(module: String, type: String, callable: Callable):
+	## Check if it contains the specified 'module' and 'type'
+	#if references.has(module) and references[module].has(type):
+		## If the type exists, execute the callable on each ID found under this type
+		#for ref_id in references[module][type]:
+			#callable.call(ref_id)

--- a/Scripts/InventoryWindow.gd
+++ b/Scripts/InventoryWindow.gd
@@ -79,7 +79,7 @@ func equip_loaded_items():
 # The first to children of EquipmentSlotList are static slots and we should ignore them
 # It will get the "name" property from the slot data and set it to the instance's "myLabel" property
 func instantiate_wearable_slots():
-	var slots: Dictionary = Gamedata.wearableslots.get_all()
+	var slots: Dictionary = Runtimedata.wearableslots.get_all()
 
 	# Clear any dynamically created slots first to avoid duplicates and skip the first two
 	while EquipmentSlotList.get_child_count() > 2:

--- a/Scripts/Runtimedata/RWearableSlot.gd
+++ b/Scripts/Runtimedata/RWearableSlot.gd
@@ -1,0 +1,55 @@
+class_name RWearableSlot
+extends RefCounted
+
+# This class represents a wearable slot with its properties
+# Only used while the game is running
+# Example wearable slot data:
+# {
+#     "description": "Holds equipment on your torso",
+#     "id": "torso",
+#     "name": "Torso",
+#     "sprite": "wearableslot_torso_32.png",
+#     "references": {
+#         "core": {
+#             "items": [
+#                 "jacket",
+#                 "tshirt",
+#                 "sweater"
+#             ]
+#         }
+#     }
+# }
+
+# Properties defined in the wearable slot
+var id: String
+var name: String
+var description: String
+var spriteid: String
+var sprite: Texture
+var parent: RWearableSlots  # Reference to the list containing all runtime wearable slots for this mod
+
+# Constructor to initialize wearable slot properties from a dictionary
+# myparent: The list containing all wearable slots for this mod
+# newid: The ID of the wearable slot being created
+func _init(myparent: RWearableSlots, newid: String):
+	parent = myparent
+	id = newid
+
+# Overwrite this wearable slot's properties using a DWearableSlot
+func overwrite_from_dwearableslot(dwearableslot: DWearableSlot) -> void:
+	if not id == dwearableslot.id:
+		print_debug("Cannot overwrite from a different id")
+	name = dwearableslot.name
+	description = dwearableslot.description
+	spriteid = dwearableslot.spriteid
+	sprite = dwearableslot.sprite
+
+# Get data function to return a dictionary with all properties
+func get_data() -> Dictionary:
+	var data: Dictionary = {
+		"id": id,
+		"name": name,
+		"description": description,
+		"sprite": spriteid
+	}
+	return data

--- a/Scripts/Runtimedata/RWearableSlots.gd
+++ b/Scripts/Runtimedata/RWearableSlots.gd
@@ -1,0 +1,75 @@
+class_name RWearableSlots
+extends RefCounted
+
+# There's an R in front of the class name to indicate this class only handles runtime wearable slot data
+# This script is intended to be used inside the Runtime autoload singleton
+# This script handles the list of wearable slots. You can access it through Runtime.mods.by_id("Core").wearableslots
+
+# Paths for wearable slot data and sprites
+var wearableslotdict: Dictionary = {}  # Holds runtime wearable slot instances
+var sprites: Dictionary = {}  # Holds wearable slot sprites
+
+# Constructor
+func _init() -> void:
+	# Get all mods and their IDs
+	var mod_ids: Array = Gamedata.mods.get_all_mod_ids()
+
+	# Loop through each mod to get its DWearableSlots
+	for mod_id in mod_ids:
+		var dwearableslots: DWearableSlots = Gamedata.mods.by_id(mod_id).wearableslots
+
+		# Loop through each DWearableSlot in the mod
+		for dwearableslot_id: String in dwearableslots.get_all().keys():
+			var dwearableslot: DWearableSlot = dwearableslots.by_id(dwearableslot_id)
+
+			# Check if the wearable slot exists in wearableslotdict
+			var rwearableslot: RWearableSlot
+			if not wearableslotdict.has(dwearableslot_id):
+				# If it doesn't exist, create a new RWearableSlot
+				rwearableslot = add_new(dwearableslot_id)
+			else:
+				# If it exists, get the existing RWearableSlot
+				rwearableslot = wearableslotdict[dwearableslot_id]
+
+			# Overwrite the RWearableSlot properties with the DWearableSlot properties
+			rwearableslot.overwrite_from_dwearableslot(dwearableslot)
+
+# Returns the dictionary containing all wearable slots
+func get_all() -> Dictionary:
+	return wearableslotdict
+
+# Adds a new wearable slot with a given ID
+func add_new(newid: String) -> RWearableSlot:
+	var newwearableslot: RWearableSlot = RWearableSlot.new(self, newid)
+	wearableslotdict[newwearableslot.id] = newwearableslot
+	return newwearableslot
+
+# Deletes a wearable slot by its ID
+func delete_by_id(wearableslotid: String) -> void:
+	wearableslotdict[wearableslotid].delete()
+	wearableslotdict.erase(wearableslotid)
+
+# Returns a wearable slot by its ID
+func by_id(wearableslotid: String) -> RWearableSlot:
+	return wearableslotdict[wearableslotid]
+
+# Checks if a wearable slot exists by its ID
+func has_id(wearableslotid: String) -> bool:
+	return wearableslotdict.has(wearableslotid)
+
+# Returns the sprite of the wearable slot
+func sprite_by_id(wearableslotid: String) -> Texture:
+	return wearableslotdict[wearableslotid].sprite
+
+# Returns the sprite by its file name
+func sprite_by_file(spritefile: String) -> Texture:
+	return sprites.get(spritefile, null)
+
+# Loads sprites and assigns them to the proper dictionary
+func load_sprites(sprite_path: String) -> void:
+	var png_files: Array = Helper.json_helper.file_names_in_dir(sprite_path, ["png"])
+	for png_file in png_files:
+		# Load the .png file as a texture
+		var texture := load(sprite_path + png_file)
+		# Add the texture to the dictionary
+		sprites[png_file] = texture

--- a/Scripts/WearableSlot.gd
+++ b/Scripts/WearableSlot.gd
@@ -1,7 +1,7 @@
 extends Control
 
 # This script is intended to be used with the WearableSlot scene
-# This script is expected to work with Gamedata.wearableslots
+# This script is expected to work with Gamedata.mods.by_id("Core").wearableslots
 # The wearable will hold one piece of wearable
 # The wearable will be represented by en InventoryItem
 # The wearable will be visualized by a texture provided by the InventoryItem

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -50,7 +50,6 @@ func _ready():
 	items = DItems.new()
 	mobs = DMobs.new()
 	itemgroups = DItemgroups.new()
-	wearableslots = DWearableSlots.new()
 	mobgroups = DMobgroups.new()
 	mobfactions = DMobfactions.new()
 
@@ -64,7 +63,7 @@ func _ready():
 		DMod.ContentType.TILES: mods.by_id("Core").tiles,
 		DMod.ContentType.MOBS: mobs,
 		DMod.ContentType.PLAYERATTRIBUTES: mods.by_id("Core").playerattributes,
-		DMod.ContentType.WEARABLESLOTS: wearableslots,
+		DMod.ContentType.WEARABLESLOTS: mods.by_id("Core").wearableslots,
 		DMod.ContentType.STATS: mods.by_id("Core").stats,
 		DMod.ContentType.SKILLS: mods.by_id("Core").skills,
 		DMod.ContentType.QUESTS: mods.by_id("Core").quests,

--- a/Scripts/runtimedata.gd
+++ b/Scripts/runtimedata.gd
@@ -10,7 +10,7 @@ var tiles: RTiles
 var mobs: DMobs
 var itemgroups: DItemgroups
 var playerattributes: RPlayerAttributes
-var wearableslots: DWearableSlots
+var wearableslots: RWearableSlots
 var skills: RSkills
 var stats: RStats
 var quests: RQuests
@@ -37,6 +37,7 @@ func reconstruct() -> void:
 	overmapareas = ROvermapareas.new()
 	quests = RQuests.new()
 	playerattributes = RPlayerAttributes.new()
+	wearableslots = RWearableSlots.new()
 	
 	# Populate the gamedata_map with the instantiated objects
 	gamedata_map = {
@@ -47,5 +48,6 @@ func reconstruct() -> void:
 		DMod.ContentType.TILES: tiles,
 		DMod.ContentType.OVERMAPAREAS: overmapareas,
 		DMod.ContentType.QUESTS: quests,
-		DMod.ContentType.PLAYERATTRIBUTES: playerattributes
+		DMod.ContentType.PLAYERATTRIBUTES: playerattributes,
+		DMod.ContentType.WEARABLESLOTS: wearableslots
 	}


### PR DESCRIPTION
Move wearableslots to mods.

Also made a change to the itemwearableslotseditor, which is part of the item editor. Instead of having wearableslots listed in a dropdown menu, the user can now drop a wearableslot onto the text field to set it.