### PR TITLE
prevent Loading screen from disappearing when returning to main menu

### DIFF
--- a/Scripts/EscapeMenu.gd
+++ b/Scripts/EscapeMenu.gd
@@ -84,5 +84,3 @@ func _disable_all_controls():
 		return_button.disabled = true
 	if save_button:
 		save_button.disabled = true
-	if loadingscreen:
-		loadingscreen.visible = false  # Optionally hide the loading screen control

--- a/Scripts/EscapeMenu.gd
+++ b/Scripts/EscapeMenu.gd
@@ -68,7 +68,21 @@ func _resume_game():
 # Handle the return to the main menu, unpause the game, save the game, and change the scene.
 func _return_to_main_menu():
 	if is_inside_tree():
+		_disable_all_controls()  # Disable controls before exiting
 		get_tree().paused = false
 		Helper.signal_broker.game_terminated.emit()
 		loadingscreen.on_exit_game()
 		Helper.save_and_exit_game()
+
+
+# Function to disable all the controls in this script
+func _disable_all_controls():
+	# Disable each control by setting their disabled property
+	if resume_button:
+		resume_button.disabled = true
+	if return_button:
+		return_button.disabled = true
+	if save_button:
+		save_button.disabled = true
+	if loadingscreen:
+		loadingscreen.visible = false  # Optionally hide the loading screen control

--- a/hud.tscn
+++ b/hud.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="Script" path="res://Scripts/hud.gd" id="1_s3xoj"]
 [ext_resource type="Script" path="res://Scripts/NonHUDclick.gd" id="2_kpbhl"]
 [ext_resource type="Texture2D" uid="uid://7hppy1l45loq" path="res://Textures/bar_progress.png" id="3_83uwt"]
-[ext_resource type="Resource" path="res://ItemProtosets.tres" id="3_jmlkb"]
+[ext_resource type="Resource" uid="uid://cgkq7vfjq07jm" path="res://ItemProtosets.tres" id="3_jmlkb"]
 [ext_resource type="Texture2D" uid="uid://dcgwgmsmi7mjn" path="res://Textures/bar_border.png" id="3_y43f5"]
 [ext_resource type="PackedScene" uid="uid://b6ooia1084wfx" path="res://Scenes/UI/AttributesWindow.tscn" id="6_6e87o"]
 [ext_resource type="PackedScene" uid="uid://drjw0yaxf8x1p" path="res://Scenes/UI/QuestTrackerUI.tscn" id="7_bbed4"]

--- a/hud.tscn
+++ b/hud.tscn
@@ -201,7 +201,6 @@ loadingscreen = NodePath("../LoadingScreen")
 visible = false
 
 [node name="LoadingScreen" parent="." instance=ExtResource("20_kxcpa")]
-visible = false
 
 [connection signal="timeout" from="ProgressBar/ProgressBarTimer" to="." method="_on_progress_bar_timer_timeout"]
 [connection signal="mouse_entered" from="OutsideOfHUD" to="OutsideOfHUD" method="_on_mouse_entered"]

--- a/level_generation.tscn
+++ b/level_generation.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" path="res://LevelGenerator.gd" id="1_i8qa4"]
 [ext_resource type="Script" path="res://LevelManager.gd" id="2_gm6x7"]
-[ext_resource type="PackedScene" uid="uid://bisxe8aexlshr" path="res://day_night.tscn" id="3_0lu7f"]
+[ext_resource type="PackedScene" path="res://day_night.tscn" id="3_0lu7f"]
 [ext_resource type="Script" path="res://Scripts/ConstructionGhost.gd" id="5_iwiv4"]
 [ext_resource type="Script" path="res://Scripts/BuildManager.gd" id="6_y7rk5"]
 [ext_resource type="Texture2D" uid="uid://d33h00t0fl7x" path="res://Defaults/Player/VestDude01.png" id="7_jr4x1"]


### PR DESCRIPTION
Fixes #547 

The loading screen was invisible when starting the game. I must've committed a change when I was testing something in the past. The loading screen is visible again now.

For good measure, I will disable the controls on the escape menu when returning to the main menu.