### PR TITLE
Create runtimedata in test environment

### DIFF
--- a/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd
@@ -1313,6 +1313,6 @@ func _on_save_and_test_button_button_up() -> void:
 	save_map_json_file()
 	# Save the current map ID to the test_map_name
 	Helper.test_map_name = mapEditor.currentMap.id
-	
+	Runtimedata.reconstruct() # Load all mod data in the proper way
 	# Switch to the test environment scene
 	get_tree().change_scene_to_file("res://test_environment.tscn")


### PR DESCRIPTION
Since maps are able to be modded, we need to read the data from runtimedata. However, the runtimedata was not initialized in the test environment.

This might lead to issues when loading the game afterwards, but we'll see.