### PR TITLE
Load sprites from the mod

### DIFF
--- a/Scenes/ContentManager/Custom_Editors/Scripts/TerrainTileEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/TerrainTileEditor.gd
@@ -26,7 +26,7 @@ var dtile: DTile = null:
 	set(value):
 		dtile = value
 		load_tile_data()
-		tileSelector.sprites_collection = Gamedata.mods.by_id("Core").tiles.sprites
+		tileSelector.sprites_collection = dtile.parent.sprites
 		olddata = DTile.new(dtile.get_data().duplicate(true), null)
 
 

--- a/Scripts/Gamedata/DTiles.gd
+++ b/Scripts/Gamedata/DTiles.gd
@@ -39,7 +39,8 @@ func load_tiles_from_disk() -> void:
 	var tilelist: Array = Helper.json_helper.load_json_array_file(filePath)
 	for mytile in tilelist:
 		var tile: DTile = DTile.new(mytile, self)
-		tile.sprite = sprites[tile.spriteid]
+		if tile.spriteid:
+			tile.sprite = sprites[tile.spriteid]
 		tiledict[tile.id] = tile
 
 


### PR DESCRIPTION
Tiles were not loaded from the mod you create, only from the core mod.

This pr fixes that. Also put a safeguard in case the game starts with a tile that has no sprite.