### PR TITLE
Enable modding of itemgroups

### DIFF
--- a/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
@@ -298,11 +298,18 @@ func _on_container_check_box_toggled(toggled_on):
 
 # Called when the user has successfully dropped data onto the ItemGroupTextEdit
 # We have to check the dropped_data for the id property
+# We are expecting a dictionary like this:
+#	{
+#		"id": selected_item_id,
+#		"text": selected_item_text,
+#		"mod_id": mod_id,
+#		"contentType": contentType
+#	}
 func itemgroup_drop(dropped_data: Dictionary, texteditcontrol: HBoxContainer) -> void:
 	# Assuming dropped_data is a Dictionary that includes an 'id'
 	if dropped_data and "id" in dropped_data:
 		var itemgroup_id = dropped_data["id"]
-		if not Gamedata.itemgroups.has_id(itemgroup_id):
+		if not Gamedata.mods.by_id(dropped_data["mod_id"]).itemgroups.has_id(itemgroup_id):
 			print_debug("No item data found for ID: " + itemgroup_id)
 			return
 		texteditcontrol.set_text(itemgroup_id)
@@ -317,13 +324,20 @@ func itemgroup_drop(dropped_data: Dictionary, texteditcontrol: HBoxContainer) ->
 		print_debug("Dropped data does not contain an 'id' key.")
 
 
+# We are expecting a dictionary like this:
+#	{
+#		"id": selected_item_id,
+#		"text": selected_item_text,
+#		"mod_id": mod_id,
+#		"contentType": contentType
+#	}
 func can_itemgroup_drop(dropped_data: Dictionary):
 	# Check if the data dictionary has the 'id' property
 	if not dropped_data or not dropped_data.has("id"):
 		return false
 	
 	# Fetch itemgroup data by ID from the Gamedata to ensure it exists and is valid
-	if not Gamedata.itemgroups.has_id(dropped_data["id"]):
+	if not Gamedata.mods.by_id(dropped_data["mod_id"]).itemgroups.has_id(dropped_data["id"]):
 		return false
 
 	# If all checks pass, return true

--- a/Scenes/ContentManager/Custom_Editors/Scripts/ItemgroupEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/ItemgroupEditor.gd
@@ -33,7 +33,7 @@ var ditemgroup: DItemgroup = null:
 		ditemgroup = value
 		load_itemgroup_data()
 		itemgroupSelector.sprites_collection = Gamedata.itemgroups.sprites
-		olddata = DItemgroup.new(ditemgroup.get_data().duplicate(true))
+		olddata = DItemgroup.new(ditemgroup.get_data().duplicate(true), null)
 
 
 func _ready():
@@ -198,7 +198,7 @@ func _on_save_button_button_up():
 	ditemgroup.items = new_items
 	ditemgroup.changed(olddata)
 	data_changed.emit()
-	olddata = DItemgroup.new(ditemgroup.get_data().duplicate(true))
+	olddata = DItemgroup.new(ditemgroup.get_data().duplicate(true), null)
 
 
 

--- a/Scenes/ContentManager/Custom_Editors/Scripts/ItemgroupEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/ItemgroupEditor.gd
@@ -26,13 +26,13 @@ signal data_changed()
 
 var olddata: DItemgroup # Remember what the value of the data was before editing
 # The data that represents this itemgroup
-# The data is selected from the Gamedata.itemgroups dictionary
+# The data is selected from the ditemgroup.parent dictionary
 # based on the ID that the user has selected in the content editor
 var ditemgroup: DItemgroup = null:
 	set(value):
 		ditemgroup = value
 		load_itemgroup_data()
-		itemgroupSelector.sprites_collection = Gamedata.itemgroups.sprites
+		itemgroupSelector.sprites_collection = ditemgroup.parent.sprites
 		olddata = DItemgroup.new(ditemgroup.get_data().duplicate(true), null)
 
 

--- a/Scenes/ContentManager/Custom_Editors/Scripts/MobEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/MobEditor.gd
@@ -149,13 +149,20 @@ func _on_sprite_selector_sprite_selected_ok(clicked_sprite) -> void:
 	PathTextLabel.text = mobTexture.resource_path.get_file()
 
 # This function should return true if the dragged data can be dropped here
+# We are expecting a dictionary like this:
+#	{
+#		"id": selected_item_id,
+#		"text": selected_item_text,
+#		"mod_id": mod_id,
+#		"contentType": contentType
+#	}
 func _can_drop_data(_newpos, data) -> bool:
 	# Check if the data dictionary has the 'id' property
 	if not data or not data.has("id"):
 		return false
 	
 	# Fetch itemgroup data by ID from the Gamedata to ensure it exists and is valid
-	if not Gamedata.itemgroups.has_id(data["id"]):
+	if not Gamedata.mods.by_id(data["mod_id"]).itemgroups.has_id(data["id"]):
 		return false
 
 	# If all checks pass, return true
@@ -168,11 +175,18 @@ func _drop_data(newpos, data) -> void:
 
 # Called when the user has successfully dropped data onto the ItemGroupTextEdit
 # We have to check the dropped_data for the id property
+# We are expecting a dictionary like this:
+#	{
+#		"id": selected_item_id,
+#		"text": selected_item_text,
+#		"mod_id": mod_id,
+#		"contentType": contentType
+#	}
 func _handle_item_drop(dropped_data, _newpos) -> void:
 	# Assuming dropped_data is a Dictionary that includes an 'id'
 	if dropped_data and "id" in dropped_data:
 		var item_id = dropped_data["id"]
-		if not Gamedata.itemgroups.has_id(item_id):
+		if not Gamedata.mods.by_id(dropped_data["mod_id"]).itemgroups.has_id(item_id):
 			print_debug("No item data found for ID: " + item_id)
 			return
 		ItemGroupTextEdit.text = item_id
@@ -248,7 +262,6 @@ func _get_attributes_from_ui() -> Dictionary:
 			target_attributes["all_of"].append({"id": label.text, "damage": spinbox.value})
 
 	return target_attributes
-
 
 
 # Delete an attribute entry from a specified grid container

--- a/Scenes/ContentManager/Custom_Widgets/Scripts/Editable_Item_List.gd
+++ b/Scenes/ContentManager/Custom_Widgets/Scripts/Editable_Item_List.gd
@@ -90,7 +90,11 @@ func _on_delete_button_button_up():
 
 
 # This function should return true if the dragged data can be dropped onto the lsit
-func _can_drop_mydata(_myposition: Vector2, data: String) -> bool:
+func _can_drop_mydata(_myposition: Vector2, data: Variant) -> bool:
+	# Check if the data is a string; if not, return false
+	if typeof(data) != TYPE_STRING:
+		return false
+
 	# Check if the data is valid and corresponds to a mod ID
 	if data.is_empty():
 		return false
@@ -103,7 +107,11 @@ func _can_drop_mydata(_myposition: Vector2, data: String) -> bool:
 	return true
 
 # This function handles the data being dropped onto the list
-func _drop_mydata(myposition: Vector2, data: String) -> void:
+func _drop_mydata(myposition: Vector2, data: Variant) -> void:
+	# Check if the data is a string; if not, return false
+	if typeof(data) != TYPE_STRING:
+		return
+
 	if _can_drop_mydata(myposition, data):
 		# Add the data to the list
 		add_item_to_list(data)

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd
@@ -217,13 +217,20 @@ func get_tilerotation(original_rotation: int) -> int:
 
 # Custom function to determine if data can be dropped at the current location
 # It will only accept itemgroups
+# We are expecting a dictionary like this:
+#	{
+#		"id": selected_item_id,
+#		"text": selected_item_text,
+#		"mod_id": mod_id,
+#		"contentType": contentType
+#	}
 func custom_can_drop_data(_mypos, dropped_data: Dictionary) -> bool:
 	# Check if the data dictionary has the 'id' property
 	if not dropped_data or not dropped_data.has("id"):
 		return false
 	
 	# Fetch itemgroup data by ID from the Gamedata to ensure it exists and is valid
-	if not Gamedata.itemgroups.has_id(dropped_data["id"]):
+	if not Gamedata.mods.by_id(dropped_data["mod_id"]).itemgroups.has_id(dropped_data["id"]):
 		return false
 
 	# If all checks pass, return true
@@ -232,16 +239,23 @@ func custom_can_drop_data(_mypos, dropped_data: Dictionary) -> bool:
 
 # Custom function to process the data drop
 # It only accepts itemgroups and creates a brush out of it
+# We are expecting a dictionary like this:
+#	{
+#		"id": selected_item_id,
+#		"text": selected_item_text,
+#		"mod_id": mod_id,
+#		"contentType": contentType
+#	}
 func custom_drop_data(_mypos, dropped_data):
 	# Dropped_data is a Dictionary that includes an 'id'
 	if dropped_data and "id" in dropped_data:
 		var itemgroup_id = dropped_data["id"]
-		if not Gamedata.itemgroups.has_id(itemgroup_id):
-			print_debug("No item data found for ID: " + itemgroup_id)
+		if not Gamedata.mods.by_id(dropped_data["mod_id"]).itemgroups.has_id(itemgroup_id):
+			print_debug("No data found for ID: " + itemgroup_id)
 			return
 		
 		var properties: Dictionary = {
-			"texture": Gamedata.itemgroups.sprite_by_id(itemgroup_id),
+			"texture": Gamedata.mods.by_id(dropped_data["mod_id"]).itemgroups.sprite_by_id(itemgroup_id),
 			"entityID": itemgroup_id,
 			"entityType": "itemgroup"
 		}
@@ -391,7 +405,7 @@ func add_brushes_from_area(entity_list: Array, entity_type: String = "entity"):
 			"furniture":
 				properties["texture"] = Gamedata.furnitures.sprite_by_id(entity["id"])
 			"itemgroup":
-				properties["texture"] = Gamedata.itemgroups.sprite_by_id(entity["id"])
+				properties["texture"] = Gamedata.mods.get_content_by_id(DMod.ContentType.ITEMGROUPS,entity["id"]).sprite
 			"mobgroup":  # Add support for mobgroup
 				properties["texture"] = Gamedata.mods.get_content_by_id(DMod.ContentType.MOBGROUPS,entity["id"]).sprite
 			_:

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditortile.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditortile.gd
@@ -194,7 +194,7 @@ func set_tile_id(id: String) -> void:
 	if id == "":
 		$TileSprite.texture = load(defaultTexture)
 	else:
-		$TileSprite.texture = Gamedata.mods.by_id("Core").tiles.sprite_by_id(id)
+		$TileSprite.texture = Gamedata.mods.get_content_by_id(DMod.ContentType.TILES,id).sprite
 
 
 # Manages the itemgroups property for the tile. 
@@ -211,6 +211,6 @@ func set_tile_itemgroups(tileData: Dictionary) -> void:
 	else:
 		# Apply the itemgroup to the tile and update ObjectSprite with a random sprite
 		var random_itemgroup: String = itemgroups.pick_random()
-		$ObjectSprite.texture = Gamedata.itemgroups.sprite_by_id(random_itemgroup)
+		$ObjectSprite.texture = Gamedata.mods.get_content_by_id(DMod.ContentType.ITEMGROUPS,random_itemgroup).sprite
 		$ObjectSprite.show()
 		$ObjectSprite.rotation_degrees = 0

--- a/Scenes/ContentManager/Scripts/content_list.gd
+++ b/Scenes/ContentManager/Scripts/content_list.gd
@@ -17,7 +17,7 @@ var mod_id: String = "Core"
 var contentType: DMod.ContentType:
 	set(newData):
 		contentType = newData
-		if newData == DMod.ContentType.STATS or newData == DMod.ContentType.MOBGROUPS or newData == DMod.ContentType.MOBS or newData == DMod.ContentType.WEARABLESLOTS or newData == DMod.ContentType.PLAYERATTRIBUTES or newData == DMod.ContentType.QUESTS or newData == DMod.ContentType.SKILLS or newData == DMod.ContentType.OVERMAPAREAS or newData == DMod.ContentType.TILES or newData == DMod.ContentType.TACTICALMAPS or newData == DMod.ContentType.MAPS:
+		if newData == DMod.ContentType.STATS or newData == DMod.ContentType.ITEMGROUPS or newData == DMod.ContentType.MOBGROUPS or newData == DMod.ContentType.MOBS or newData == DMod.ContentType.WEARABLESLOTS or newData == DMod.ContentType.PLAYERATTRIBUTES or newData == DMod.ContentType.QUESTS or newData == DMod.ContentType.SKILLS or newData == DMod.ContentType.OVERMAPAREAS or newData == DMod.ContentType.TILES or newData == DMod.ContentType.TACTICALMAPS or newData == DMod.ContentType.MAPS:
 			# Use mod-specific data for these content types
 			datainstance = Gamedata.mods.by_id(mod_id).get_data_of_type(contentType)
 		else:
@@ -260,7 +260,7 @@ func load_list():
 			contentItems.set_item_icon(item_index, entry.sprite)
 
 func delete(selected_id) -> void:
-	if contentType == DMod.ContentType.STATS or contentType == DMod.ContentType.MOBGROUPS or contentType == DMod.ContentType.MOBS or contentType == DMod.ContentType.WEARABLESLOTS or contentType == DMod.ContentType.PLAYERATTRIBUTES or contentType == DMod.ContentType.QUESTS or contentType == DMod.ContentType.SKILLS or contentType == DMod.ContentType.OVERMAPAREAS or contentType == DMod.ContentType.TILES or contentType == DMod.ContentType.TACTICALMAPS or contentType == DMod.ContentType.MAPS:
+	if contentType == DMod.ContentType.STATS or contentType == DMod.ContentType.ITEMGROUPS or contentType == DMod.ContentType.MOBGROUPS or contentType == DMod.ContentType.MOBS or contentType == DMod.ContentType.WEARABLESLOTS or contentType == DMod.ContentType.PLAYERATTRIBUTES or contentType == DMod.ContentType.QUESTS or contentType == DMod.ContentType.SKILLS or contentType == DMod.ContentType.OVERMAPAREAS or contentType == DMod.ContentType.TILES or contentType == DMod.ContentType.TACTICALMAPS or contentType == DMod.ContentType.MAPS:
 		# Use mod-specific data for these content types
 		Gamedata.mods.by_id(mod_id).get_data_of_type(contentType).delete_by_id(selected_id)
 	else:

--- a/Scenes/ContentManager/Scripts/contenteditor.gd
+++ b/Scenes/ContentManager/Scripts/contenteditor.gd
@@ -154,7 +154,7 @@ func instantiate_editor(type: DMod.ContentType, itemID: String, newEditor: Packe
 			newContentEditor.data_changed.connect(list.load_data)
 		
 		DMod.ContentType.ITEMGROUPS:
-			newContentEditor.ditemgroup = Gamedata.itemgroups.by_id(itemID)
+			newContentEditor.ditemgroup = currentmod.itemgroups.by_id(itemID)
 			newContentEditor.data_changed.connect(list.load_data)
 		
 		DMod.ContentType.ITEMS:

--- a/Scripts/FurniturePhysicsSrv.gd
+++ b/Scripts/FurniturePhysicsSrv.gd
@@ -410,22 +410,22 @@ func create_loot() -> void:
 	if not itemgroup or itemgroup == "":
 		return  # No itemgroup to populate from
 	
-	var ditemgroup: DItemgroup = Gamedata.itemgroups.by_id(itemgroup)
-	if ditemgroup:
-		if ditemgroup.mode == "Collection":
-			_add_items_to_inventory_collection_mode(ditemgroup.items)
-		elif ditemgroup.mode == "Distribution":
-			_add_items_to_inventory_distribution_mode(ditemgroup.items)
+	var ritemgroup: RItemgroup = Runtimedata.itemgroups.by_id(itemgroup)
+	if ritemgroup:
+		if ritemgroup.mode == "Collection":
+			_add_items_to_inventory_collection_mode(ritemgroup.items)
+		elif ritemgroup.mode == "Distribution":
+			_add_items_to_inventory_distribution_mode(ritemgroup.items)
 
 # Populate the container with items based on the itemgroup's collection mode
-func _add_items_to_inventory_collection_mode(items: Array[DItemgroup.Item]) -> void:
+func _add_items_to_inventory_collection_mode(items: Array[RItemgroup.Item]) -> void:
 	for item_object in items:
 		if randi_range(0, 100) <= item_object.probability:
 			var quantity = randi_range(item_object.minc, item_object.maxc)
 			_add_item_to_inventory(item_object.id, quantity)
 
 # Populate the container with a randomly selected item based on distribution mode
-func _add_items_to_inventory_distribution_mode(items: Array[DItemgroup.Item]) -> void:
+func _add_items_to_inventory_distribution_mode(items: Array[RItemgroup.Item]) -> void:
 	var total_probability = 0
 	for item_object in items:
 		total_probability += item_object.probability

--- a/Scripts/FurnitureStaticSrv.gd
+++ b/Scripts/FurnitureStaticSrv.gd
@@ -556,15 +556,15 @@ func create_loot():
 	# A flag to track whether items were added
 	var item_added: bool = false
 	# Attempt to retrieve the itemgroup data from Gamedata
-	var ditemgroup: DItemgroup = Gamedata.itemgroups.by_id(itemgroup)
+	var ritemgroup: RItemgroup = Runtimedata.itemgroups.by_id(itemgroup)
 	
 	# Check if the itemgroup data exists and has items
-	if ditemgroup:
-		var groupmode: String = ditemgroup.mode  # can be "Collection" or "Distribution".
+	if ritemgroup:
+		var groupmode: String = ritemgroup.mode  # can be "Collection" or "Distribution".
 		if groupmode == "Collection":
-			item_added = _add_items_to_inventory_collection_mode(ditemgroup.items)
+			item_added = _add_items_to_inventory_collection_mode(ritemgroup.items)
 		elif groupmode == "Distribution":
-			item_added = _add_items_to_inventory_distribution_mode(ditemgroup.items)
+			item_added = _add_items_to_inventory_distribution_mode(ritemgroup.items)
 
 	# Set the material if items were added
 	if item_added:
@@ -576,10 +576,10 @@ func create_loot():
 
 
 # Takes a list of items and adds them to the inventory in Collection mode.
-func _add_items_to_inventory_collection_mode(items: Array[DItemgroup.Item]) -> bool:
+func _add_items_to_inventory_collection_mode(items: Array[RItemgroup.Item]) -> bool:
 	var item_added: bool = false
 	# Loop over each item object in the itemgroup's 'items' property
-	for item_object: DItemgroup.Item in items:
+	for item_object: RItemgroup.Item in items:
 		# Each item_object is expected to be a dictionary with id, probability, min, max
 		var item_id = item_object.id
 		var item_probability = item_object.probability
@@ -592,7 +592,7 @@ func _add_items_to_inventory_collection_mode(items: Array[DItemgroup.Item]) -> b
 
 
 # Takes a list of items and adds one to the inventory based on probabilities in Distribution mode.
-func _add_items_to_inventory_distribution_mode(items: Array[DItemgroup.Item]) -> bool:
+func _add_items_to_inventory_distribution_mode(items: Array[RItemgroup.Item]) -> bool:
 	var total_probability = 0
 	# Calculate the total probability
 	for item_object in items:
@@ -603,7 +603,7 @@ func _add_items_to_inventory_distribution_mode(items: Array[DItemgroup.Item]) ->
 	var cumulative_probability = 0
 
 	# Iterate through items to select one based on the random value
-	for item_object: DItemgroup.Item in items:
+	for item_object: RItemgroup.Item in items:
 		cumulative_probability += item_object.probability
 		# Check if the random value falls within the current item's range
 		if random_value < cumulative_probability:

--- a/Scripts/Gamedata/DFurniture.gd
+++ b/Scripts/Gamedata/DFurniture.gd
@@ -211,22 +211,34 @@ func on_data_changed(olddfurniture: DFurniture):
 	var old_destruction_group = olddfurniture.destruction.group
 	var old_disassembly_group = olddfurniture.disassembly.group
 
-	# Handle container itemgroup changes
-	Gamedata.itemgroups.update_reference(old_container_group, new_container_group, "furniture", id)
-
-	# Handle destruction group changes
-	Gamedata.itemgroups.update_reference(old_destruction_group, destruction.group, "furniture", id)
-
-	# Handle disassembly group changes
-	Gamedata.itemgroups.update_reference(old_disassembly_group, disassembly.group, "furniture", id)
+	if not old_container_group == new_container_group:
+		# Remove from old group if necessary
+		if old_container_group != "":
+			Gamedata.mods.remove_reference(DMod.ContentType.ITEMGROUPS, old_container_group, DMod.ContentType.FURNITURES, id)
+		if new_container_group != "":
+			Gamedata.mods.add_reference(DMod.ContentType.ITEMGROUPS, new_container_group, DMod.ContentType.FURNITURES, id)
+		
+	if not old_destruction_group == destruction.group:
+		# Remove from old group if necessary
+		if old_destruction_group != "":
+			Gamedata.mods.remove_reference(DMod.ContentType.ITEMGROUPS, old_destruction_group, DMod.ContentType.FURNITURES, id)
+		if destruction.group != "":
+			Gamedata.mods.add_reference(DMod.ContentType.ITEMGROUPS, destruction.group, DMod.ContentType.FURNITURES, id)
+		
+	if not old_disassembly_group == disassembly.group:
+		# Remove from old group if necessary
+		if old_disassembly_group != "":
+			Gamedata.mods.remove_reference(DMod.ContentType.ITEMGROUPS, old_disassembly_group, DMod.ContentType.FURNITURES, id)
+		if disassembly.group != "":
+			Gamedata.mods.add_reference(DMod.ContentType.ITEMGROUPS, disassembly.group, DMod.ContentType.FURNITURES, id)
 
 
 # Some furniture is being deleted from the data
 # We have to remove it from everything that references it
 func delete():
-	Gamedata.itemgroups.remove_reference(function.container_group, "core", "furniture", id)
-	Gamedata.itemgroups.remove_reference(destruction.group, "core", "furniture", id)
-	Gamedata.itemgroups.remove_reference(disassembly.group, "core", "furniture", id)
+	Gamedata.mods.remove_reference(DMod.ContentType.ITEMGROUPS, function.container_group, DMod.ContentType.FURNITURES, id)
+	Gamedata.mods.remove_reference(DMod.ContentType.ITEMGROUPS, destruction.group, DMod.ContentType.FURNITURES, id)
+	Gamedata.mods.remove_reference(DMod.ContentType.ITEMGROUPS, disassembly.container_group, DMod.ContentType.FURNITURES, id)
 	
 	# Remove references to maps
 	var mapsdata: Array = Helper.json_helper.get_nested_data(references, "core.maps")

--- a/Scripts/Gamedata/DItem.gd
+++ b/Scripts/Gamedata/DItem.gd
@@ -657,12 +657,9 @@ func update_item_attribute_references(olddata: DItem):
 func delete():
 	var changes_made = { "value": false }
 	
-	# This callable will remove this item from itemgroups that reference this item.
-	var myfunc: Callable = func (itemgroup_id):
-		var ditemgroup: DItemgroup = Gamedata.itemgroups.by_id(itemgroup_id)
-		ditemgroup.remove_item_by_id(id)
-
-	execute_callable_on_references_of_type("core", "itemgroups", myfunc)
+	# For each mod, remove this item from the itemgroup in this item's references
+	for mod: DMod in Gamedata.mods.get_all_mods():
+		mod.itemgroups.remove_item_by_id(id)
 	
 	# This callable will handle the removal of this item from all crafting recipes in other items
 	var remove_from_item: Callable = func(other_item_id: String):

--- a/Scripts/Gamedata/DItemgroup.gd
+++ b/Scripts/Gamedata/DItemgroup.gd
@@ -4,7 +4,7 @@ extends RefCounted
 
 # There's a D in front of the class name to indicate this class only handles itemgroup data, nothing more
 # This script is intended to be used inside the GameData autoload singleton
-# This script handles the data for one itemgroup. You can access it through Gamedata.itemgroups
+# This script handles the data for one itemgroup. You can access it through parent
 
 
 # This class represents a itemgroup with its properties
@@ -136,7 +136,7 @@ func changed(olddata: DItemgroup):
 		if item_id not in oldlist:
 			Gamedata.items.add_reference(item_id, "core", "itemgroups", itemgroup)
 
-	Gamedata.itemgroups.save_itemgroups_to_disk()
+	parent.save_itemgroups_to_disk()
 
 
 # A itemgroup is being deleted from the data
@@ -196,4 +196,4 @@ func remove_item_by_id(item_id: String) -> void:
 
 	if item_to_remove:
 		items.erase(item_to_remove)
-		Gamedata.itemgroups.save_itemgroups_to_disk()
+		parent.save_itemgroups_to_disk()

--- a/Scripts/Gamedata/DItemgroup.gd
+++ b/Scripts/Gamedata/DItemgroup.gd
@@ -47,7 +47,8 @@ extends RefCounted
 #				]
 #			}
 #		},
-#		"sprite": "machete_32.png"
+#		"sprite": "machete_32.png",
+#		"use_sprite": true
 #	}
 
 # Subclass to represent individual items in the itemgroup

--- a/Scripts/Gamedata/DItemgroup.gd
+++ b/Scripts/Gamedata/DItemgroup.gd
@@ -83,17 +83,18 @@ var sprite: Texture
 # this itemgroup if it is spawned in a ContainerItem on the map
 var use_sprite: bool = false
 var items: Array[Item] = []
-var references: Dictionary = {}
+var parent: DItemgroups
 
 # Constructor to initialize itemgroup properties from a dictionary
-func _init(data: Dictionary):
+# myparent: The list containing all itemgroups for this mod
+func _init(data: Dictionary, myparent: DItemgroups):
+	parent = myparent
 	id = data.get("id", "")
 	name = data.get("name", "")
 	description = data.get("description", "")
 	mode = data.get("mode", "Collection")
 	spriteid = data.get("sprite", "")
 	use_sprite = data.get("use_sprite", false)
-	references = data.get("references", {})
 	
 	var item_data = data.get("items", [])
 	for item in item_data:
@@ -114,23 +115,7 @@ func get_data() -> Dictionary:
 		"use_sprite": use_sprite,
 		"items": item_data
 	}
-	if not references.is_empty():
-		data["references"] = references
 	return data
-
-
-# Removes the provided reference from references
-func remove_reference(module: String, type: String, refid: String):
-	var changes_made = Gamedata.dremove_reference(references, module, type, refid)
-	if changes_made:
-		Gamedata.itemgroups.save_itemgroups_to_disk()
-
-
-# Adds a reference to the references list
-func add_reference(module: String, type: String, refid: String):
-	var changes_made = Gamedata.dadd_reference(references, module, type, refid)
-	if changes_made:
-		Gamedata.itemgroups.save_itemgroups_to_disk()
 
 
 # Some itemgroup has been changed
@@ -157,33 +142,47 @@ func changed(olddata: DItemgroup):
 # A itemgroup is being deleted from the data
 # We have to remove it from everything that references it
 func delete():
-	# Callable to remove the itemgroup from every furniture that references this itemgroup.
-	var myfunc: Callable = func(furn_id):
-		var furniture: DFurniture = Gamedata.furnitures.by_id(furn_id)
-		furniture.remove_itemgroup(id)
-
-	# Pass the callable to every furniture in the itemgroup's references
-	# It will call myfunc on every furniture in itemgroup_data.references.core.furniture
-	execute_callable_on_references_of_type("core", "furniture", myfunc)
+	# Check to see if any mod has a copy of this tile. if one or more remain, we can keep references
+	# Otherwise, the last copy was removed and we need to remove references
+	var all_results: Array = Gamedata.mods.get_all_content_by_id(DMod.ContentType.MOBS, id)
+	if all_results.size() > 1:
+		return
+	
+	# Get a list of all maps that reference this mob
+	var myreferences: Dictionary = parent.references.get(id, {})
+	var myfurnitures: Array = myreferences.get("furnitures", [])
+	for furniture in myfurnitures:
+		Gamedata.furnitures.by_id(furniture).remove_itemgroup(id)
 
 	# Remove references to this itemgroup from items listed in the itemgroup data.
 	for item in items:
 		Gamedata.items.remove_reference(item.id, "core", "itemgroups", id)
 
-	# Remove references to maps
-	var mapsdata: Array = Helper.json_helper.get_nested_data(references, "core.maps")
-	for mymap: String in mapsdata:
-		var mymaps: Array = Gamedata.mods.get_all_content_by_id(DMod.ContentType.MAPS, mymap)
-		for dmap: DMaps in mymaps:
-			dmap.remove_entity_from_selected_maps("itemgroup", id, mapsdata)
+	# This callable will handle the removal of this mob from all steps in maps
+	var mymapslist: Array = myreferences.get("maps", [])
+	var remove_from_map: Callable = func(map_id: String):
+		# Get all copies of the maps with map_id from all mods
+		var mymaps: Array = Gamedata.mods.get_all_content_by_id(DMod.ContentType.MAPS, map_id)
+		for dmap: DMap in mymaps:
+			dmap.remove_entity_from_map("itemgroup", id)
+
+	# Pass the callable to every map in the mob's references
+	# It will call remove_from_map on every map in this mob's references
+	execute_callable_on_references_of_type(DMod.ContentType.MAPS, remove_from_map)
 
 
 # Executes a callable function on each reference of the given type
-func execute_callable_on_references_of_type(module: String, type: String, callable: Callable):
+# type: The type of entity that you want to execute the callable for
+# callable: The function that will be executed for every entity of this type
+func execute_callable_on_references_of_type(type: DMod.ContentType, callable: Callable):
+	# myreferences will ba dictionary that contains entity types that have references to this skill's id
+	# See DMod.add_reference for an example structure of references
+	var myreferences: Dictionary = parent.references.get(id, {})
+	var type_string: String = DMod.get_content_type_string(type)
 	# Check if it contains the specified 'module' and 'type'
-	if references.has(module) and references[module].has(type):
+	if myreferences.has(type_string):
 		# If the type exists, execute the callable on each ID found under this type
-		for ref_id in references[module][type]:
+		for ref_id in myreferences[type_string]:
 			callable.call(ref_id)
 
 

--- a/Scripts/Gamedata/DItemgroups.gd
+++ b/Scripts/Gamedata/DItemgroups.gd
@@ -3,7 +3,7 @@ extends RefCounted
 
 # There's a D in front of the class name to indicate this class only handles itemgroup data, nothing more
 # This script is intended to be used inside the GameData autoload singleton
-# This script handles the list of itemgroups. You can access it trough Gamedata.itemgroups
+# This script handles the list of itemgroups. You can access it trough Gamedata.mods.by_id("Core").itemgroups
 
 
 var dataPath: String = "./Mods/Core/Itemgroups/"

--- a/Scripts/Gamedata/DMap.gd
+++ b/Scripts/Gamedata/DMap.gd
@@ -243,8 +243,7 @@ func remove_my_reference_from_all_entities() -> void:
 			elif entity_type == "mobs":
 				Gamedata.mods.remove_reference(DMod.ContentType.MOBS, entity_id, DMod.ContentType.MAPS, id)
 			elif entity_type == "itemgroups":
-				var ditemgroup: DItemgroup = Gamedata.itemgroups.by_id(entity_id)
-				ditemgroup.remove_reference("core","maps",id)
+				Gamedata.mods.remove_reference(DMod.ContentType.ITEMGROUPS, entity_id, DMod.ContentType.MAPS, id)
 
 
 # Function to update map entity references when a map's data changes
@@ -271,8 +270,7 @@ func data_changed(oldmap: DMap):
 				Gamedata.mods.add_reference(DMod.ContentType.MOBGROUPS, entity_id, DMod.ContentType.MAPS, id)
 		elif entity_type == "itemgroups":
 			for entity_id in new_entities[entity_type]:
-				var ditemgroup: DItemgroup = Gamedata.itemgroups.by_id(entity_id)
-				ditemgroup.add_reference("core","maps",id)
+				Gamedata.mods.add_reference(DMod.ContentType.ITEMGROUPS, entity_id, DMod.ContentType.MAPS, id)
 
 	# Remove references for entities not present in new data
 	for entity_type in old_entities.keys():
@@ -288,8 +286,7 @@ func data_changed(oldmap: DMap):
 		elif entity_type == "itemgroups":
 			for entity_id in old_entities[entity_type]:
 				if not new_entities[entity_type].has(entity_id):
-					var itemgroup: DItemgroup = Gamedata.itemgroups.by_id(entity_id)
-					itemgroup.remove_reference("core","maps",id)
+					Gamedata.mods.remove_reference(DMod.ContentType.ITEMGROUPS, entity_id,DMod.ContentType.MAPS,id)
 		elif entity_type == "mobs":
 			for entity_id in old_entities[entity_type]:
 				if not new_entities[entity_type].has(entity_id):
@@ -302,8 +299,6 @@ func data_changed(oldmap: DMap):
 	# Save changes to the data files if there were any updates
 	if new_entities["furniture"].size() > 0 or old_entities["furniture"].size() > 0:
 		Gamedata.furnitures.save_furnitures_to_disk()
-	if new_entities["itemgroups"].size() > 0 or old_entities["itemgroups"].size() > 0:
-		Gamedata.itemgroups.save_itemgroups_to_disk()
 
 
 # Function to collect unique entities from each level in newdata and olddata

--- a/Scripts/Gamedata/DMob.gd
+++ b/Scripts/Gamedata/DMob.gd
@@ -84,8 +84,8 @@ var sprite: Texture
 var targetattributes: Dictionary = {}
 var parent: DMobs
 
-# Constructor to initialize quest properties from a dictionary
-# myparent: The list containing all quests for this mod
+# Constructor to initialize mob properties from a dictionary
+# myparent: The list containing all mobs for this mod
 func _init(data: Dictionary, myparent: DMobs):
 	parent = myparent
 	id = data.get("id", "")

--- a/Scripts/Gamedata/DMob.gd
+++ b/Scripts/Gamedata/DMob.gd
@@ -156,10 +156,10 @@ func changed(olddata: DMob):
 	# Exit if old_group and new_group are the same
 	if old_loot_group and not old_loot_group == loot_group:
 		# This mob will be removed from the old itemgroup's references
-		Gamedata.itemgroups.remove_reference(old_loot_group, "core", "mobs", id)
+		Gamedata.mods.remove_reference(DMod.ContentType.ITEMGROUPS, old_loot_group, DMod.ContentType.MOBS, id)
 		
-		# This mob will be added to the new itemgroup's references
-		Gamedata.itemgroups.add_reference(loot_group, "core", "mobs", id)
+	# This mob will be added to the new itemgroup's references
+	Gamedata.mods.add_reference(DMod.ContentType.ITEMGROUPS, loot_group, DMod.ContentType.MOBS, id)
 	update_mob_attribute_references(olddata)
 	parent.save_mobs_to_disk() # Save changes regardless of whether or not a reference was updated
 
@@ -175,7 +175,6 @@ func delete():
 
 	# Get a list of all maps that reference this mob
 	var myreferences: Dictionary = parent.references.get(id, {})
-	var mymaps: Array = myreferences.get("maps", [])
 	var mymobgroups: Array = myreferences.get("mobgroups", [])
 	# For each mod, remove this mob from the maps in this mob's references
 	for mod: DMod in Gamedata.mods.get_all_mods():
@@ -201,11 +200,11 @@ func execute_callable_on_references_of_type(type: DMod.ContentType, callable: Ca
 	# myreferences will ba dictionary that contains entity types that have references to this skill's id
 	# See DMod.add_reference for an example structure of references
 	var myreferences: Dictionary = parent.references.get(id, {})
-	var type_string: String = DMod.get_content_type_string(type)
+	var typestring: String = DMod.get_content_type_string(type)
 	# Check if it contains the specified 'module' and 'type'
-	if myreferences.has(type_string):
+	if myreferences.has(typestring):
 		# If the type exists, execute the callable on each ID found under this type
-		for ref_id in myreferences[type_string]:
+		for ref_id in myreferences[typestring]:
 			callable.call(ref_id)
 
 
@@ -222,7 +221,7 @@ func update_mob_attribute_references(olddata: DMob):
 	
 	# Add new attribute references
 	for new_attr_id in new_attr_ids:
-		Gamedata.mods.remove_reference(DMod.ContentType.PLAYERATTRIBUTES, new_attr_id, DMod.ContentType.MOBS, id)
+		Gamedata.mods.add_reference(DMod.ContentType.PLAYERATTRIBUTES, new_attr_id, DMod.ContentType.MOBS, id)
 
 
 # Function to retrieve an array of maps from the references

--- a/Scripts/Gamedata/DMobs.gd
+++ b/Scripts/Gamedata/DMobs.gd
@@ -109,20 +109,3 @@ func sprite_by_id(mobid: String) -> Texture:
 # spritefile: The file of the sprite to return the sprite of
 func sprite_by_file(spritefile: String) -> Texture:
 	return sprites[spritefile]
-
-
-# Removes the reference from the selected mob
-func remove_reference(mobid: String, module: String, type: String, refid: String):
-	var mymob: DMob = mobdict[mobid]
-	mymob.remove_reference(module, type, refid)
-
-
-# Adds a reference to the references list
-# For example, add "grass_field" to references.Core.maps
-# mobid: The id of the mob to add the reference to
-# module: the mod that the entity belongs to, for example "Core"
-# type: The type of entity, for example "maps"
-# refid: The id of the entity to reference, for example "grass_field"
-func add_reference(mobid: String, module: String, type: String, refid: String):
-	var mymob: DMob = mobdict[mobid]
-	mymob.add_reference(module, type, refid)

--- a/Scripts/Gamedata/DMod.gd
+++ b/Scripts/Gamedata/DMod.gd
@@ -85,7 +85,7 @@ func _init(modinfo: Dictionary, myparent: DMods):
 	items = DItems.new()
 	tiles = DTiles.new(id)
 	mobs = DMobs.new(id)
-	itemgroups = DItemgroups.new()
+	itemgroups = DItemgroups.new(id)
 	playerattributes = DPlayerAttributes.new(id)
 	wearableslots = DWearableSlots.new(id)
 	skills = DSkills.new(id)

--- a/Scripts/Runtimedata/RItemgroup.gd
+++ b/Scripts/Runtimedata/RItemgroup.gd
@@ -1,0 +1,89 @@
+class_name RItemgroup
+extends RefCounted
+
+# This class represents an item group with its properties, only used while the game is running.
+# Example itemgroup data:
+# {
+#     "id": "mob_loot",
+#     "name": "Mob loot",
+#     "description": "Loot that's dropped by a mob",
+#     "mode": "Collection",
+#     "items": [
+#         {
+#             "id": "bullet_9mm",
+#             "max": 20,
+#             "min": 10,
+#             "probability": 20
+#         },
+#         {
+#             "id": "pistol_magazine",
+#             "max": 1,
+#             "min": 1,
+#             "probability": 20
+#         }
+#     ]
+# }
+
+# Subclass to represent individual items in the itemgroup
+class Item:
+	var id: String
+	var maxc: int # max count
+	var minc: int # min count
+	var probability: int
+
+	func _init(data: Dictionary):
+		id = data.get("id", "")
+		maxc = data.get("max", 1)
+		minc = data.get("min", 1)
+		probability = data.get("probability", 100)
+
+	func get_data() -> Dictionary:
+		return {
+			"id": id,
+			"max": maxc,
+			"min": minc,
+			"probability": probability
+		}
+
+# Properties defined in the itemgroup
+var id: String
+var name: String
+var description: String
+var mode: String # "Collection" or "Distribution"
+var items: Array[Item] = []
+var parent: RItemgroups  # Reference to the list containing all runtime itemgroups for this mod
+
+# Constructor to initialize itemgroup properties
+# myparent: The list containing all runtime itemgroups for this mod
+# newid: The ID of the itemgroup being created
+func _init(myparent: RItemgroups, newid: String):
+	parent = myparent
+	id = newid
+
+# Overwrite this itemgroup's properties using a DItemgroup
+func overwrite_from_ditemgroup(ditemgroup: DItemgroup) -> void:
+	if not id == ditemgroup.id:
+		print_debug("Cannot overwrite from a different id")
+	name = ditemgroup.name
+	description = ditemgroup.description
+	mode = ditemgroup.mode
+	
+	# Convert DItemgroup items to RItemgroup items
+	items.clear()
+	for ditem in ditemgroup.items:
+		items.append(Item.new(ditem.get_data()))
+
+# Get data function to return a dictionary with all properties
+func get_data() -> Dictionary:
+	var item_data = []
+	for item in items:
+		item_data.append(item.get_data())
+
+	var data: Dictionary = {
+		"id": id,
+		"name": name,
+		"description": description,
+		"mode": mode,
+		"items": item_data
+	}
+	return data

--- a/Scripts/Runtimedata/RItemgroup.gd
+++ b/Scripts/Runtimedata/RItemgroup.gd
@@ -51,6 +51,7 @@ var name: String
 var description: String
 var mode: String # "Collection" or "Distribution"
 var items: Array[Item] = []
+var use_sprite: bool = false
 var parent: RItemgroups  # Reference to the list containing all runtime itemgroups for this mod
 
 # Constructor to initialize itemgroup properties
@@ -67,6 +68,7 @@ func overwrite_from_ditemgroup(ditemgroup: DItemgroup) -> void:
 	name = ditemgroup.name
 	description = ditemgroup.description
 	mode = ditemgroup.mode
+	use_sprite = ditemgroup.use_sprite
 	
 	# Convert DItemgroup items to RItemgroup items
 	items.clear()

--- a/Scripts/Runtimedata/RItemgroups.gd
+++ b/Scripts/Runtimedata/RItemgroups.gd
@@ -1,0 +1,71 @@
+class_name RItemgroups
+extends RefCounted
+
+# There's an R in front of the class name to indicate this class only handles runtime item group data
+# This script is intended to be used inside the Runtime autoload singleton
+# This script handles the list of item groups. You can access it through Runtime.mods.by_id("Core").itemgroups
+
+# Paths for item group data and sprites
+var itemgroupdict: Dictionary = {}  # Holds runtime item group instances
+var sprites: Dictionary = {}  # Holds item group sprites
+
+# Constructor
+func _init() -> void:
+	# Get all mods and their IDs
+	var mod_ids: Array = Gamedata.mods.get_all_mod_ids()
+
+	# Loop through each mod to get its DItemgroups
+	for mod_id in mod_ids:
+		var ditemgroups: DItemgroups = Gamedata.mods.by_id(mod_id).itemgroups
+
+		# Loop through each DItemgroup in the mod
+		for ditemgroup_id: String in ditemgroups.get_all().keys():
+			var ditemgroup: DItemgroup = ditemgroups.by_id(ditemgroup_id)
+
+			# Check if the item group exists in itemgroupdict
+			var ritemgroup: RItemgroup
+			if not itemgroupdict.has(ditemgroup_id):
+				# If it doesn't exist, create a new RItemgroup
+				ritemgroup = add_new(ditemgroup_id)
+			else:
+				# If it exists, get the existing RItemgroup
+				ritemgroup = itemgroupdict[ditemgroup_id]
+
+			# Overwrite the RItemgroup properties with the DItemgroup properties
+			ritemgroup.overwrite_from_ditemgroup(ditemgroup)
+
+# Adds a new runtime item group with a given ID
+func add_new(newid: String) -> RItemgroup:
+	var new_itemgroup: RItemgroup = RItemgroup.new(self, newid)
+	itemgroupdict[new_itemgroup.id] = new_itemgroup
+	return new_itemgroup
+
+# Deletes an item group by its ID
+func delete_by_id(itemgroupid: String) -> void:
+	itemgroupdict[itemgroupid].delete()
+	itemgroupdict.erase(itemgroupid)
+
+# Returns a runtime item group by its ID
+func by_id(itemgroupid: String) -> RItemgroup:
+	return itemgroupdict[itemgroupid]
+
+# Checks if an item group exists by its ID
+func has_id(itemgroupid: String) -> bool:
+	return itemgroupdict.has(itemgroupid)
+
+# Returns the sprite of the item group
+func sprite_by_id(itemgroupid: String) -> Texture:
+	return itemgroupdict[itemgroupid].sprite
+
+# Returns the sprite by its file name
+func sprite_by_file(spritefile: String) -> Texture:
+	return sprites.get(spritefile, null)
+
+# Loads sprites and assigns them to the proper dictionary
+func load_sprites(sprite_path: String) -> void:
+	var png_files: Array = Helper.json_helper.file_names_in_dir(sprite_path, ["png"])
+	for png_file in png_files:
+		# Load the .png file as a texture
+		var texture := load(sprite_path + png_file)
+		# Add the texture to the dictionary
+		sprites[png_file] = texture

--- a/Scripts/container.gd
+++ b/Scripts/container.gd
@@ -11,7 +11,7 @@ var containerpos: Vector3
 var sprite_3d: Sprite3D
 var texture_id: String # The ID of the texture set for this container
 var itemgroup: String # The ID of an itemgroup that it creates loot from
-var ditemgroup: DItemgroup # The ID of an itemgroup that it creates loot from
+var ritemgroup: RItemgroup # The ID of an itemgroup that it creates loot from
 
 
 # Called when the node enters the scene tree for the first time.
@@ -49,9 +49,9 @@ func _initialize_container(item: Dictionary):
 		if itemgroups_array.size() > 0:
 			itemgroup = itemgroups_array.pick_random()
 			# Attempt to retrieve the itemgroup data from Gamedata
-			ditemgroup = Gamedata.itemgroups.by_id(itemgroup)
-			if ditemgroup.use_sprite:
-				texture_id = ditemgroup.spriteid
+			ritemgroup = Runtimedata.itemgroups.by_id(itemgroup)
+			if ritemgroup.use_sprite:
+				texture_id = ritemgroup.spriteid
 
 
 # Will add item to the inventory based on the assigned itemgroup
@@ -63,15 +63,15 @@ func create_loot():
 	var item_added: bool = false
 	
 	# Check if the itemgroup data exists and has items
-	if ditemgroup:
-		var groupmode: String = ditemgroup.mode # can be "Collection" or "Distribution".
+	if ritemgroup:
+		var groupmode: String = ritemgroup.mode # can be "Collection" or "Distribution".
 		if groupmode == "Collection":
-			item_added = _add_items_to_inventory_collection_mode(ditemgroup.items)
+			item_added = _add_items_to_inventory_collection_mode(ritemgroup.items)
 		elif groupmode == "Distribution":
-			item_added = _add_items_to_inventory_distribution_mode(ditemgroup.items)
+			item_added = _add_items_to_inventory_distribution_mode(ritemgroup.items)
 
 	# Set the texture if an item was successfully added and if it hasn't been set by set_texture
-	if item_added and sprite_3d.texture == Gamedata.textures.container and not ditemgroup.use_sprite:
+	if item_added and sprite_3d.texture == Gamedata.textures.container and not ritemgroup.use_sprite:
 		set_random_inventory_item_texture()
 	elif not item_added:
 		 # If no item was added we delete the container if it's not a child of some furniture
@@ -79,10 +79,10 @@ func create_loot():
 
 
 # Takes a list of items and adds them to the inventory in Collection mode.
-func _add_items_to_inventory_collection_mode(items: Array[DItemgroup.Item]) -> bool:
+func _add_items_to_inventory_collection_mode(items: Array[RItemgroup.Item]) -> bool:
 	var item_added: bool = false
 	# Loop over each item object in the itemgroup's 'items' property
-	for item_object: DItemgroup.Item in items:
+	for item_object: RItemgroup.Item in items:
 		# Each item_object is expected to be a dictionary with id, probability, min, max
 		var item_id = item_object.id
 		var item_probability = item_object.probability
@@ -95,7 +95,7 @@ func _add_items_to_inventory_collection_mode(items: Array[DItemgroup.Item]) -> b
 
 
 # Takes a list of items and adds one to the inventory based on probabilities in Distribution mode.
-func _add_items_to_inventory_distribution_mode(items: Array[DItemgroup.Item]) -> bool:
+func _add_items_to_inventory_distribution_mode(items: Array[RItemgroup.Item]) -> bool:
 	var total_probability = 0
 	# Calculate the total probability
 	for item_object in items:
@@ -106,7 +106,7 @@ func _add_items_to_inventory_distribution_mode(items: Array[DItemgroup.Item]) ->
 	var cumulative_probability = 0
 
 	# Iterate through items to select one based on the random value
-	for item_object: DItemgroup.Item in items:
+	for item_object: RItemgroup.Item in items:
 		cumulative_probability += item_object.probability
 		# Check if the random value falls within the current item's range
 		if random_value < cumulative_probability:

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -46,7 +46,6 @@ func _ready():
 	mods = DMods.new()
 	furnitures = DFurnitures.new()
 	items = DItems.new()
-	itemgroups = DItemgroups.new()
 	mobfactions = DMobfactions.new()
 
 	# Populate the gamedata_map with the instantiated objects
@@ -54,7 +53,7 @@ func _ready():
 		DMod.ContentType.TACTICALMAPS: mods.by_id("Core").tacticalmaps,	
 		DMod.ContentType.MAPS: mods.by_id("Core").maps,	
 		DMod.ContentType.FURNITURES: furnitures,
-		DMod.ContentType.ITEMGROUPS: itemgroups,
+		DMod.ContentType.ITEMGROUPS: mods.by_id("Core").itemgroups,
 		DMod.ContentType.ITEMS: items,
 		DMod.ContentType.TILES: mods.by_id("Core").tiles,
 		DMod.ContentType.MOBS: mods.by_id("Core").mobs,

--- a/Scripts/general.gd
+++ b/Scripts/general.gd
@@ -26,7 +26,7 @@ func _ready():
 # Usage example using an inline callable:
 	# This example will call the 'myfunc' callable after the start_action timer runs out
 	# var myfunc: Callable = func (itemgroup_id):
-	#	 var ditemgroup: DItemgroup = Gamedata.itemgroups.by_id(itemgroup_id)
+	#	 var ditemgroup: DItemgroup = Gamedata.mods.by_id("Core").itemgroups.by_id(itemgroup_id)
 	#	 ditemgroup.remove_item_by_id(id)
 	# General.start_action(reload_time, myfunc)
 func start_action(duration: float, callback: Callable):
@@ -48,4 +48,3 @@ func _on_action_timer_timeout():
 	# Reset the callback function
 	action_complete_callback = Callable()
 	# Code to handle the completion of the action
-

--- a/Scripts/runtimedata.gd
+++ b/Scripts/runtimedata.gd
@@ -8,7 +8,7 @@ var furnitures: DFurnitures
 var items: DItems
 var tiles: RTiles
 var mobs: RMobs
-var itemgroups: DItemgroups
+var itemgroups: RItemgroups
 var playerattributes: RPlayerAttributes
 var wearableslots: RWearableSlots
 var skills: RSkills
@@ -40,6 +40,7 @@ func reconstruct() -> void:
 	wearableslots = RWearableSlots.new()
 	mobs = RMobs.new()
 	mobgroups = RMobgroups.new()
+	itemgroups = RItemgroups.new()
 	
 	# Populate the gamedata_map with the instantiated objects
 	gamedata_map = {
@@ -53,5 +54,6 @@ func reconstruct() -> void:
 		DMod.ContentType.PLAYERATTRIBUTES: playerattributes,
 		DMod.ContentType.WEARABLESLOTS: wearableslots,
 		DMod.ContentType.MOBS: mobs,
-		DMod.ContentType.MOBGROUPS: mobgroups
+		DMod.ContentType.MOBGROUPS: mobgroups,
+		DMod.ContentType.ITEMGROUPS: itemgroups
 	}


### PR DESCRIPTION
Helps #533 

Moves itemgroups from gamedata to gamedata.mods. 
Also fixed an issue with the custom item list, where an error will popup if you try to drop a dictionary when it expects a string.