### PR TITLE
Mod load order

### DIFF
--- a/Scenes/ContentManager/Scripts/addremovemods.gd
+++ b/Scenes/ContentManager/Scripts/addremovemods.gd
@@ -1,7 +1,5 @@
 extends Control
 
-
-
 # This script belongs to the `addremovemods.tscn` scene. It allows you to add and remove mods
 # Mods are loaded as modinfo.json files and added to mods_item_list
 # Each modinfo.json file is located in the respective mods folder
@@ -39,6 +37,10 @@ extends Control
 
 @export var pupup_ID: Popup = null
 @export var popup_textedit: TextEdit = null
+
+# Constants for background colors
+const enabled_color: Color = Color(0, 0.5, 0, 0.3)  # Darker green for enabled mods
+const disabled_color: Color = Color(1, 0, 0, 0.3)  # Red for disabled mods
 
 
 func _ready():
@@ -161,10 +163,44 @@ func populate_mods_item_list() -> void:
 	# Clear the mods_item_list
 	mods_item_list.clear()
 
-	# Iterate through Gamedata.mods to populate the mods_item_list
-	for mod: DMod in Gamedata.mods.get_all_mods():
-		mods_item_list.add_item(mod.name)
-		mods_item_list.set_item_metadata(mods_item_list.get_item_count() - 1, mod.id)
+	# Attempt to load the saved mod list state
+	var config = ConfigFile.new()
+	var path = "user://mods_state.cfg"
+	var mod_states = []
+
+	if config.load(path) == OK:
+		mod_states = config.get_value("mods", "states", [])
+	else:
+		print_debug("No saved mod list state found. Loading mods in default order.")
+
+	# If a saved state exists, load mods in the saved order
+	if not mod_states.is_empty():
+		for mod_state in mod_states:
+			var mod_id = mod_state["id"]
+			var mod_enabled = mod_state["enabled"]
+
+			if Gamedata.mods.has_id(mod_id):
+				var mod = Gamedata.mods.by_id(mod_id)
+				mods_item_list.add_item(mod.name)
+				mods_item_list.set_item_metadata(mods_item_list.get_item_count() - 1, mod_id)
+
+				# Update the item's background color based on its enabled status
+				var bg_color = enabled_color if mod_enabled else disabled_color
+				mods_item_list.set_item_custom_bg_color(mods_item_list.get_item_count() - 1, bg_color)
+
+				# Set the enabled status in the mod object
+				mod.is_enabled = mod_enabled
+	else:
+		# If no saved state, load mods in default order from Gamedata.mods
+		for mod: DMod in Gamedata.mods.get_all_mods():
+			mods_item_list.add_item(mod.name)
+			mods_item_list.set_item_metadata(mods_item_list.get_item_count() - 1, mod.id)
+
+			# Default to all mods being enabled if no state is present
+			mods_item_list.set_item_custom_bg_color(mods_item_list.get_item_count() - 1, enabled_color)
+			mod.is_enabled = true
+
+	print_debug("Populated mods_item_list successfully.")
 
 
 # When the user presses the save button
@@ -274,3 +310,158 @@ func _create_drag_data(_at_position: Vector2) -> Variant:
 
 	# Return the data associated with the dragged mod
 	return mod_id
+
+
+# The user has activated a mod in the modlist by double clicking or pressing enter
+# We will toggle the enabled status of the mod
+# the item's custom background color will reflect the activated status
+# Toggles the enabled status of the mod and updates its appearance in the mod list
+func _on_mods_item_list_item_activated(index: int) -> void:
+	var mod_id = mods_item_list.get_item_metadata(index)
+	var mod_enabled = Gamedata.mods.by_id(mod_id).is_enabled
+
+	# Toggle the enabled status
+	Gamedata.mods.by_id(mod_id).is_enabled = not mod_enabled
+
+	# Update the item's background color based on its enabled status
+	var bg_color = enabled_color if Gamedata.mods.by_id(mod_id).is_enabled else disabled_color
+	mods_item_list.set_item_custom_bg_color(index, bg_color)
+
+	# Save the mod list state
+	save_mod_list_state()
+
+
+# The user pressed the move down button in the mod editor
+# Moves the selected mod down in the list and preserves its state and color
+func _on_move_down_button_button_up() -> void:
+	var selected_index = mods_item_list.get_selected_items()
+	if selected_index.size() == 0:
+		return  # No item selected
+
+	selected_index = selected_index[0]
+	if selected_index >= mods_item_list.get_item_count() - 1:
+		return  # Already at the bottom
+
+	# Get the properties of the current item
+	var mod_text = mods_item_list.get_item_text(selected_index)
+	var mod_metadata = mods_item_list.get_item_metadata(selected_index)
+	var mod_color = mods_item_list.get_item_custom_bg_color(selected_index)
+
+	# Get the properties of the next item
+	var next_text = mods_item_list.get_item_text(selected_index + 1)
+	var next_metadata = mods_item_list.get_item_metadata(selected_index + 1)
+	var next_color = mods_item_list.get_item_custom_bg_color(selected_index + 1)
+
+	# Swap text, metadata, and colors
+	mods_item_list.set_item_text(selected_index, next_text)
+	mods_item_list.set_item_metadata(selected_index, next_metadata)
+	mods_item_list.set_item_custom_bg_color(selected_index, next_color)
+
+	mods_item_list.set_item_text(selected_index + 1, mod_text)
+	mods_item_list.set_item_metadata(selected_index + 1, mod_metadata)
+	mods_item_list.set_item_custom_bg_color(selected_index + 1, mod_color)
+
+	# Select the moved mod
+	mods_item_list.select(selected_index + 1)
+
+	# Save the mod list state
+	save_mod_list_state()
+
+
+
+# The user pressed the move up button in the mod editor
+# Moves the selected mod up in the list and preserves its state and color
+func _on_move_up_button_button_up() -> void:
+	var selected_index = mods_item_list.get_selected_items()
+	if selected_index.size() == 0:
+		return  # No item selected
+
+	selected_index = selected_index[0]
+	if selected_index <= 0:
+		return  # Already at the top
+
+	# Get the properties of the current item
+	var mod_text = mods_item_list.get_item_text(selected_index)
+	var mod_metadata = mods_item_list.get_item_metadata(selected_index)
+	var mod_color = mods_item_list.get_item_custom_bg_color(selected_index)
+
+	# Get the properties of the previous item
+	var prev_text = mods_item_list.get_item_text(selected_index - 1)
+	var prev_metadata = mods_item_list.get_item_metadata(selected_index - 1)
+	var prev_color = mods_item_list.get_item_custom_bg_color(selected_index - 1)
+
+	# Swap text, metadata, and colors
+	mods_item_list.set_item_text(selected_index, prev_text)
+	mods_item_list.set_item_metadata(selected_index, prev_metadata)
+	mods_item_list.set_item_custom_bg_color(selected_index, prev_color)
+
+	mods_item_list.set_item_text(selected_index - 1, mod_text)
+	mods_item_list.set_item_metadata(selected_index - 1, mod_metadata)
+	mods_item_list.set_item_custom_bg_color(selected_index - 1, mod_color)
+
+	# Select the moved mod
+	mods_item_list.select(selected_index - 1)
+
+	# Save the mod list state
+	save_mod_list_state()
+
+
+# The state or order of one or more mods has changed
+# We save the mod list order and the state of each mod
+# the state of the mod can be "enabled" or "disabled" and is visualized by the background color
+# Saves the state and order of mods to a configuration file
+func save_mod_list_state():
+	var config = ConfigFile.new()
+	var path = "user://mods_state.cfg"
+	
+	# Create a dictionary to store mod states and order
+	var mod_states = []
+	for i in range(mods_item_list.get_item_count()):
+		mod_states.append({
+			"id": mods_item_list.get_item_metadata(i),
+			"enabled": Gamedata.mods.by_id(mods_item_list.get_item_metadata(i)).is_enabled
+		})
+
+	# Save the mod states to the configuration file
+	config.set_value("mods", "states", mod_states)
+
+	if config.save(path) != OK:
+		print_debug("Failed to save mod list state.")
+	else:
+		print_debug("Successfully saved mod list state.")
+
+
+# Processes the mod list states and updates the UI accordingly
+# mod_states example: 
+#[
+#    { "id": "core", "enabled": true },
+#    { "id": "mod_1", "enabled": false },
+#    { "id": "mod_2", "enabled": true }
+#]
+func apply_mod_list_states(mod_states: Array) -> void:
+	mods_item_list.clear()
+	
+	for mod_state in mod_states:
+		var mod_id = mod_state["id"]
+		var mod_enabled = mod_state["enabled"]
+		
+		if Gamedata.mods.has_id(mod_id):
+			var mod = Gamedata.mods.by_id(mod_id)
+			mods_item_list.add_item(mod.name)
+			mods_item_list.set_item_metadata(mods_item_list.get_item_count() - 1, mod_id)
+
+			# Update the item's background color based on its enabled status
+			var bg_color = enabled_color if mod_enabled else disabled_color
+			mods_item_list.set_item_custom_bg_color(mods_item_list.get_item_count() - 1, bg_color)
+
+			# Set the enabled status in the mod object
+			mod.is_enabled = mod_enabled
+
+	print_debug("Applied mod list states successfully.")
+
+
+# Wrapper function that integrates the two steps: loading and applying the mod list state
+func load_mod_list_state() -> void:
+	var mod_states = Gamedata.mods.get_mod_list_states()
+	if not mod_states.empty():
+		apply_mod_list_states(mod_states)

--- a/Scenes/ContentManager/Scripts/addremovemods.gd
+++ b/Scenes/ContentManager/Scripts/addremovemods.gd
@@ -162,16 +162,7 @@ func delete_mod(mod_id: String) -> void:
 func populate_mods_item_list() -> void:
 	# Clear the mods_item_list
 	mods_item_list.clear()
-
-	# Attempt to load the saved mod list state
-	var config = ConfigFile.new()
-	var path = "user://mods_state.cfg"
-	var mod_states = []
-
-	if config.load(path) == OK:
-		mod_states = config.get_value("mods", "states", [])
-	else:
-		print_debug("No saved mod list state found. Loading mods in default order.")
+	var mod_states = Gamedata.mods.get_mod_list_states()
 
 	# If a saved state exists, load mods in the saved order
 	if not mod_states.is_empty():

--- a/Scenes/ContentManager/addremovemods.tscn
+++ b/Scenes/ContentManager/addremovemods.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=4 format=3 uid="uid://cis7fd3ko7xfp"]
+[gd_scene load_steps=4 format=3 uid="uid://dfj0pswk2qi6"]
 
 [ext_resource type="Script" path="res://Scenes/ContentManager/Scripts/addremovemods.gd" id="1_87j7f"]
 [ext_resource type="PackedScene" uid="uid://b8i6wfk3fngy4" path="res://Scenes/ContentManager/Custom_Widgets/Editable_Item_List.tscn" id="2_r6poh"]
@@ -97,8 +97,22 @@ columns = 2
 layout_mode = 2
 text = "Tools"
 
-[node name="SaveButton" type="Button" parent="VBoxContainer/MainHBoxContainer/FormPanelContainer/FormGridContainer"]
+[node name="ToolsHBoxContainer" type="HBoxContainer" parent="VBoxContainer/MainHBoxContainer/FormPanelContainer/FormGridContainer"]
 layout_mode = 2
+
+[node name="MoveUpButton" type="Button" parent="VBoxContainer/MainHBoxContainer/FormPanelContainer/FormGridContainer/ToolsHBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Move up"
+
+[node name="MoveDownButton" type="Button" parent="VBoxContainer/MainHBoxContainer/FormPanelContainer/FormGridContainer/ToolsHBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Move down"
+
+[node name="SaveButton" type="Button" parent="VBoxContainer/MainHBoxContainer/FormPanelContainer/FormGridContainer/ToolsHBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
 text = "Save"
 
 [node name="IdLabel" type="Label" parent="VBoxContainer/MainHBoxContainer/FormPanelContainer/FormGridContainer"]
@@ -227,7 +241,10 @@ text = "Cancel"
 [connection signal="button_up" from="VBoxContainer/HeaderHBoxContainer/BackButton" to="." method="_on_back_button_button_up"]
 [connection signal="button_up" from="VBoxContainer/MainHBoxContainer/ListVBoxContainer/ButtonsHBoxContainer/AddButton" to="." method="_on_add_button_button_up"]
 [connection signal="button_up" from="VBoxContainer/MainHBoxContainer/ListVBoxContainer/ButtonsHBoxContainer/RemoveButton" to="." method="_on_remove_button_button_up"]
+[connection signal="item_activated" from="VBoxContainer/MainHBoxContainer/ListVBoxContainer/ModsItemList" to="." method="_on_mods_item_list_item_activated"]
 [connection signal="item_selected" from="VBoxContainer/MainHBoxContainer/ListVBoxContainer/ModsItemList" to="." method="_on_mods_item_list_item_selected"]
-[connection signal="button_up" from="VBoxContainer/MainHBoxContainer/FormPanelContainer/FormGridContainer/SaveButton" to="." method="_on_save_button_button_up"]
+[connection signal="button_up" from="VBoxContainer/MainHBoxContainer/FormPanelContainer/FormGridContainer/ToolsHBoxContainer/MoveUpButton" to="." method="_on_move_up_button_button_up"]
+[connection signal="button_up" from="VBoxContainer/MainHBoxContainer/FormPanelContainer/FormGridContainer/ToolsHBoxContainer/MoveDownButton" to="." method="_on_move_down_button_button_up"]
+[connection signal="button_up" from="VBoxContainer/MainHBoxContainer/FormPanelContainer/FormGridContainer/ToolsHBoxContainer/SaveButton" to="." method="_on_save_button_button_up"]
 [connection signal="button_up" from="ID_Input/VBoxContainer/HBoxContainer/OK" to="." method="_on_ok_button_up"]
 [connection signal="button_up" from="ID_Input/VBoxContainer/HBoxContainer/Cancel" to="." method="_on_cancel_button_up"]

--- a/Scripts/Gamedata/DMod.gd
+++ b/Scripts/Gamedata/DMod.gd
@@ -25,6 +25,7 @@ var dependencies: Array = []
 var homepage: String
 var license: String
 var tags: Array = []
+var is_enabled: bool = true
 var parent: DMods  # Reference to the parent DMods container
 
 var maps: DMaps

--- a/Scripts/Gamedata/DMods.gd
+++ b/Scripts/Gamedata/DMods.gd
@@ -236,16 +236,25 @@ func get_enabled_mod_ids() -> Array:
 
 
 # Returns an array of DMod instances in the order specified by mod_states.
-# If `only_enabled` is true, only enabled mods are included in the result.
+# The "Core" mod is always loaded first, even if it is disabled.
+# If `only_enabled` is true, only enabled mods are included (excluding the "Core" mod's enabled status).
 func get_mods_in_state_order(only_enabled: bool) -> Array[DMod]:
 	var ordered_mods: Array[DMod] = []
 	var mod_states = get_mod_list_states()  # Retrieve the saved mod states
 
-	# Add mods in the order specified by mod_states
+	# Add the "Core" mod first if it exists in the moddict
+	if moddict.has("Core"):
+		ordered_mods.append(moddict["Core"])
+
+	# Add the remaining mods in the order specified by mod_states
 	for mod_state in mod_states:
 		var mod_id = mod_state["id"]
-		var is_enabled = mod_state["enabled"]
 
+		# Skip "Core" as it is already added
+		if mod_id == "Core":
+			continue
+
+		var is_enabled = mod_state["enabled"]
 		if moddict.has(mod_id):
 			if not only_enabled or (only_enabled and is_enabled):
 				ordered_mods.append(moddict[mod_id])

--- a/Scripts/Gamedata/DMods.gd
+++ b/Scripts/Gamedata/DMods.gd
@@ -220,7 +220,7 @@ func get_mod_list_states() -> Array:
 	
 	# Retrieve the saved mod states
 	var mod_states = config.get_value("mods", "states", [])
-	if mod_states.empty():
+	if mod_states.is_empty():
 		print_debug("No mod list state found.")
 		return []
 	
@@ -233,3 +233,21 @@ func get_enabled_mod_ids() -> Array:
 		if moddict[mod_id].is_enabled:
 			enabled_mods.append(mod_id)
 	return enabled_mods
+
+
+# Returns an array of DMod instances in the order specified by mod_states.
+# If `only_enabled` is true, only enabled mods are included in the result.
+func get_mods_in_state_order(only_enabled: bool) -> Array[DMod]:
+	var ordered_mods: Array[DMod] = []
+	var mod_states = get_mod_list_states()  # Retrieve the saved mod states
+
+	# Add mods in the order specified by mod_states
+	for mod_state in mod_states:
+		var mod_id = mod_state["id"]
+		var is_enabled = mod_state["enabled"]
+
+		if moddict.has(mod_id):
+			if not only_enabled or (only_enabled and is_enabled):
+				ordered_mods.append(moddict[mod_id])
+
+	return ordered_mods

--- a/Scripts/Gamedata/DMods.gd
+++ b/Scripts/Gamedata/DMods.gd
@@ -17,6 +17,14 @@ func load_mods_from_disk() -> void:
 	# Clear the moddict dictionary
 	moddict.clear()
 
+	# Get the list of saved mod states
+	var mod_states = get_mod_list_states()
+	var enabled_states: Dictionary = {}
+
+	# Convert the mod_states array into a dictionary for quick lookup
+	for mod_state in mod_states:
+		enabled_states[mod_state["id"]] = mod_state["enabled"]
+
 	# Get the list of folders in the Mods directory using the helper function
 	var folders = Helper.json_helper.folder_names_in_dir("./Mods")
 	
@@ -30,9 +38,13 @@ func load_mods_from_disk() -> void:
 
 			# Validate modinfo data and add it to the moddict dictionary
 			if modinfo.has("id"):
-				# Initialize mod dictionary for this mod_id
-				# Create a new DMods instance for this mod and associate it with the mod_id
-				moddict[modinfo["id"]] = DMod.new(modinfo, self)
+				var mod_id = modinfo["id"]
+				
+				# Initialize the mod instance and set its enabled state
+				var mod = DMod.new(modinfo, self)
+				mod.is_enabled = enabled_states.get(mod_id, true)  # Default to enabled if not in saved states
+
+				moddict[mod_id] = mod
 			else:
 				print_debug("Invalid modinfo.json in folder: " + folder_name)
 		else:
@@ -187,3 +199,37 @@ func save_references(content_instance: RefCounted) -> void:
 	var myreferences: Dictionary = content_instance.references
 	var reference_json = JSON.stringify(myreferences, "\t")
 	Helper.json_helper.write_json_file(content_instance.dataPath + "references.json", reference_json)
+
+
+# Loads mod states from the configuration file and returns them as a list
+# mod_states example: 
+#[
+#    { "id": "core", "enabled": true },
+#    { "id": "mod_1", "enabled": false },
+#    { "id": "mod_2", "enabled": true }
+#]
+func get_mod_list_states() -> Array:
+	var config = ConfigFile.new()
+	var path = "user://mods_state.cfg"
+	
+	# Load the configuration file
+	var err = config.load(path)
+	if err != OK:
+		print_debug("Failed to load mod list state:", err)
+		return []
+	
+	# Retrieve the saved mod states
+	var mod_states = config.get_value("mods", "states", [])
+	if mod_states.empty():
+		print_debug("No mod list state found.")
+		return []
+	
+	return mod_states
+	
+# Returns an array of IDs for all enabled mods
+func get_enabled_mod_ids() -> Array:
+	var enabled_mods: Array = []
+	for mod_id in moddict.keys():
+		if moddict[mod_id].is_enabled:
+			enabled_mods.append(mod_id)
+	return enabled_mods

--- a/Scripts/Runtimedata/RFurnitures.gd
+++ b/Scripts/Runtimedata/RFurnitures.gd
@@ -12,13 +12,10 @@ var shader_materials: Dictionary = {}  # Cache for shader materials by furniture
 var shape_materials: Dictionary = {}  # Cache for shape materials by furniture ID
 
 # Constructor
-func _init() -> void:
-	# Get all mods and their IDs
-	var mod_ids: Array = Gamedata.mods.get_all_mod_ids()
-
-	# Loop through each mod to get its DFurnitures
-	for mod_id in mod_ids:
-		var dfurnitures: DFurnitures = Gamedata.mods.by_id(mod_id).furnitures
+func _init(mod_list: Array[DMod]) -> void:
+	# Loop through each mod
+	for mod in mod_list:
+		var dfurnitures: DFurnitures = mod.furnitures
 
 		# Loop through each DFurniture in the mod
 		for dfurniture_id: String in dfurnitures.get_all().keys():

--- a/Scripts/Runtimedata/RItemgroups.gd
+++ b/Scripts/Runtimedata/RItemgroups.gd
@@ -10,13 +10,10 @@ var itemgroupdict: Dictionary = {}  # Holds runtime item group instances
 var sprites: Dictionary = {}  # Holds item group sprites
 
 # Constructor
-func _init() -> void:
-	# Get all mods and their IDs
-	var mod_ids: Array = Gamedata.mods.get_all_mod_ids()
-
-	# Loop through each mod to get its DItemgroups
-	for mod_id in mod_ids:
-		var ditemgroups: DItemgroups = Gamedata.mods.by_id(mod_id).itemgroups
+func _init(mod_list: Array[DMod]) -> void:
+	# Loop through each mod
+	for mod in mod_list:
+		var ditemgroups: DItemgroups = mod.itemgroups
 
 		# Loop through each DItemgroup in the mod
 		for ditemgroup_id: String in ditemgroups.get_all().keys():

--- a/Scripts/Runtimedata/RItems.gd
+++ b/Scripts/Runtimedata/RItems.gd
@@ -11,13 +11,10 @@ var sprites: Dictionary = {}  # Holds item sprites
 var shader_materials: Dictionary = {}  # Cache for shader materials by item ID
 
 # Constructor
-func _init() -> void:
-	# Get all mods and their IDs
-	var mod_ids: Array = Gamedata.mods.get_all_mod_ids()
-
-	# Loop through each mod to get its DItems
-	for mod_id in mod_ids:
-		var ditems: DItems = Gamedata.mods.by_id(mod_id).items
+func _init(mod_list: Array[DMod]) -> void:
+	# Loop through each mod
+	for mod in mod_list:
+		var ditems: DItems = mod.items
 
 		# Loop through each DItem in the mod
 		for ditem_id: String in ditems.get_all().keys():

--- a/Scripts/Runtimedata/RMaps.gd
+++ b/Scripts/Runtimedata/RMaps.gd
@@ -11,13 +11,10 @@ var sprites: Dictionary = {}
 
 
 # Constructor
-func _init() -> void:
-	# Get all mods and their IDs
-	var mod_ids: Array = Gamedata.mods.get_all_mod_ids()
-
-	# Loop through each mod to get its Dmaps
-	for mod_id in mod_ids:
-		var dmaps: DMaps = Gamedata.mods.by_id(mod_id).maps
+func _init(mod_list: Array[DMod]) -> void:
+	# Loop through each mod
+	for mod in mod_list:
+		var dmaps: DMaps = mod.maps
 
 		# Loop through each Dmap in the mod
 		for dmap_id: String in dmaps.get_all().keys():

--- a/Scripts/Runtimedata/RMobfactions.gd
+++ b/Scripts/Runtimedata/RMobfactions.gd
@@ -10,13 +10,10 @@ var mobfactiondict: Dictionary = {}  # Holds runtime mob faction instances
 var sprites: Dictionary = {}  # Holds mob faction sprites
 
 # Constructor
-func _init() -> void:
-	# Get all mods and their IDs
-	var mod_ids: Array = Gamedata.mods.get_all_mod_ids()
-
-	# Loop through each mod to get its DMobfactions
-	for mod_id in mod_ids:
-		var dmobfactions: DMobfactions = Gamedata.mods.by_id(mod_id).mobfactions
+func _init(mod_list: Array[DMod]) -> void:
+	# Loop through each mod
+	for mod in mod_list:
+		var dmobfactions: DMobfactions = mod.mobfactions
 
 		# Loop through each DMobfaction in the mod
 		for dmobfaction_id: String in dmobfactions.get_all().keys():

--- a/Scripts/Runtimedata/RMobgroups.gd
+++ b/Scripts/Runtimedata/RMobgroups.gd
@@ -10,13 +10,10 @@ var mobgroupdict: Dictionary = {}  # Holds runtime mob group instances
 var sprites: Dictionary = {}  # Holds mob group sprites
 
 # Constructor
-func _init() -> void:
-	# Get all mods and their IDs
-	var mod_ids: Array = Gamedata.mods.get_all_mod_ids()
-
-	# Loop through each mod to get its DMobgroups
-	for mod_id in mod_ids:
-		var dmobgroups: DMobgroups = Gamedata.mods.by_id(mod_id).mobgroups
+func _init(mod_list: Array[DMod]) -> void:
+	# Loop through each mod
+	for mod in mod_list:
+		var dmobgroups: DMobgroups = mod.mobgroups
 
 		# Loop through each DMobgroup in the mod
 		for dmobgroup_id: String in dmobgroups.get_all().keys():

--- a/Scripts/Runtimedata/RMobs.gd
+++ b/Scripts/Runtimedata/RMobs.gd
@@ -10,13 +10,10 @@ var mobdict: Dictionary = {}  # Holds runtime mob instances
 var sprites: Dictionary = {}  # Holds mob sprites
 
 # Constructor
-func _init() -> void:
-	# Get all mods and their IDs
-	var mod_ids: Array = Gamedata.mods.get_all_mod_ids()
-
-	# Loop through each mod to get its DMobs
-	for mod_id in mod_ids:
-		var dmobs: DMobs = Gamedata.mods.by_id(mod_id).mobs
+func _init(mod_list: Array[DMod]) -> void:
+	# Loop through each mod
+	for mod in mod_list:
+		var dmobs: DMobs = mod.mobs
 
 		# Loop through each DMob in the mod
 		for dmob_id: String in dmobs.get_all().keys():

--- a/Scripts/Runtimedata/ROvermapareas.gd
+++ b/Scripts/Runtimedata/ROvermapareas.gd
@@ -10,13 +10,10 @@ var overmapareadict: Dictionary = {}
 var references: Dictionary = {}
 
 # Constructor
-func _init() -> void:
-	# Get all mods and their IDs
-	var mod_ids: Array = Gamedata.mods.get_all_mod_ids()
-
-	# Loop through each mod to get its DOvermapareas
-	for mod_id in mod_ids:
-		var dovermapareas: DOvermapareas = Gamedata.mods.by_id(mod_id).overmapareas
+func _init(mod_list: Array[DMod]) -> void:
+	# Loop through each mod
+	for mod in mod_list:
+		var dovermapareas: DOvermapareas = mod.overmapareas
 
 		# Loop through each DOvermaparea in the mod
 		for dovermaparea_id: String in dovermapareas.get_all().keys():

--- a/Scripts/Runtimedata/RPlayerAttributes.gd
+++ b/Scripts/Runtimedata/RPlayerAttributes.gd
@@ -10,13 +10,10 @@ var playerattributedict: Dictionary = {}  # Holds runtime player attribute insta
 var sprites: Dictionary = {}  # Holds player attribute sprites
 
 # Constructor
-func _init() -> void:
-	# Get all mods and their IDs
-	var mod_ids: Array = Gamedata.mods.get_all_mod_ids()
-
-	# Loop through each mod to get its DPlayerAttributes
-	for mod_id in mod_ids:
-		var dplayerattributes: DPlayerAttributes = Gamedata.mods.by_id(mod_id).playerattributes
+func _init(mod_list: Array[DMod]) -> void:
+	# Loop through each mod
+	for mod in mod_list:
+		var dplayerattributes: DPlayerAttributes = mod.playerattributes
 
 		# Loop through each DPlayerAttribute in the mod
 		for dplayerattribute_id: String in dplayerattributes.get_all().keys():

--- a/Scripts/Runtimedata/RQuests.gd
+++ b/Scripts/Runtimedata/RQuests.gd
@@ -10,13 +10,10 @@ var questdict: Dictionary = {}  # Holds runtime quest instances
 var sprites: Dictionary = {}   # Holds quest sprites
 
 # Constructor
-func _init() -> void:
-	# Get all mods and their IDs
-	var mod_ids: Array = Gamedata.mods.get_all_mod_ids()
-
-	# Loop through each mod to get its DQuests
-	for mod_id in mod_ids:
-		var dquests: DQuests = Gamedata.mods.by_id(mod_id).quests
+func _init(mod_list: Array[DMod]) -> void:
+	# Loop through each mod
+	for mod in mod_list:
+		var dquests: DQuests = mod.quests
 
 		# Loop through each DQuest in the mod
 		for dquest_id: String in dquests.get_all().keys():

--- a/Scripts/Runtimedata/RSkills.gd
+++ b/Scripts/Runtimedata/RSkills.gd
@@ -10,13 +10,10 @@ var skilldict: Dictionary = {}  # Holds runtime skill instances
 var sprites: Dictionary = {}   # Holds skill sprites
 
 # Constructor
-func _init() -> void:
-	# Get all mods and their IDs
-	var mod_ids: Array = Gamedata.mods.get_all_mod_ids()
-
-	# Loop through each mod to get its DSkills
-	for mod_id in mod_ids:
-		var dskills: DSkills = Gamedata.mods.by_id(mod_id).skills
+func _init(mod_list: Array[DMod]) -> void:
+	# Loop through each mod
+	for mod in mod_list:
+		var dskills: DSkills = mod.skills
 
 		# Loop through each DSkill in the mod
 		for dskill_id: String in dskills.get_all().keys():

--- a/Scripts/Runtimedata/RStats.gd
+++ b/Scripts/Runtimedata/RStats.gd
@@ -10,13 +10,10 @@ var statdict: Dictionary = {}
 var sprites: Dictionary = {}
 
 # Constructor
-func _init() -> void:
-	# Get all mods and their IDs
-	var mod_ids: Array = Gamedata.mods.get_all_mod_ids()
-
+func _init(mod_list: Array[DMod]) -> void:
 	# Loop through each mod to get its DStats
-	for mod_id in mod_ids:
-		var dstats: DStats = Gamedata.mods.by_id(mod_id).stats
+	for mod in mod_list:
+		var dstats: DStats = mod.stats
 
 		# Loop through each DStat in the mod
 		for dstat_id: String in dstats.get_all().keys():

--- a/Scripts/Runtimedata/RTacticalmaps.gd
+++ b/Scripts/Runtimedata/RTacticalmaps.gd
@@ -11,13 +11,10 @@ var sprites: Dictionary = {}
 
 
 # Constructor
-func _init() -> void:
-	# Get all mods and their IDs
-	var mod_ids: Array = Gamedata.mods.get_all_mod_ids()
-
-	# Loop through each mod to get its DTacticalmaps
-	for mod_id in mod_ids:
-		var dtacticalmaps: DTacticalmaps = Gamedata.mods.by_id(mod_id).tacticalmaps
+func _init(mod_list: Array[DMod]) -> void:
+	# Loop through each mod
+	for mod in mod_list:
+		var dtacticalmaps: DTacticalmaps = mod.tacticalmaps
 
 		# Loop through each DTacticalmap in the mod
 		for dtacticalmap_id: String in dtacticalmaps.get_all().keys():

--- a/Scripts/Runtimedata/RTiles.gd
+++ b/Scripts/Runtimedata/RTiles.gd
@@ -10,13 +10,10 @@ var tiledict: Dictionary = {}
 var sprites: Dictionary = {}
 
 # Constructor
-func _init() -> void:
-	# Get all mods and their IDs
-	var mod_ids: Array = Gamedata.mods.get_all_mod_ids()
-
-	# Loop through each mod to get its DTiles
-	for mod_id in mod_ids:
-		var dtiles: DTiles = Gamedata.mods.by_id(mod_id).tiles
+func _init(mod_list: Array[DMod]) -> void:
+	# Loop through each mod
+	for mod in mod_list:
+		var dtiles: DTiles = mod.tiles
 
 		# Loop through each DTile in the mod
 		for dtile_id: String in dtiles.get_all().keys():

--- a/Scripts/Runtimedata/RWearableSlots.gd
+++ b/Scripts/Runtimedata/RWearableSlots.gd
@@ -10,13 +10,10 @@ var wearableslotdict: Dictionary = {}  # Holds runtime wearable slot instances
 var sprites: Dictionary = {}  # Holds wearable slot sprites
 
 # Constructor
-func _init() -> void:
-	# Get all mods and their IDs
-	var mod_ids: Array = Gamedata.mods.get_all_mod_ids()
-
-	# Loop through each mod to get its DWearableSlots
-	for mod_id in mod_ids:
-		var dwearableslots: DWearableSlots = Gamedata.mods.by_id(mod_id).wearableslots
+func _init(mod_list: Array[DMod]) -> void:
+	# Loop through each mod
+	for mod in mod_list:
+		var dwearableslots: DWearableSlots = mod.wearableslots
 
 		# Loop through each DWearableSlot in the mod
 		for dwearableslot_id: String in dwearableslots.get_all().keys():

--- a/Scripts/runtimedata.gd
+++ b/Scripts/runtimedata.gd
@@ -28,7 +28,7 @@ func get_data_of_type(type: DMod.ContentType) -> RefCounted:
 
 # Reconstruct function to reset and initialize stats
 func reconstruct() -> void:
-	var enabled_mods: Array = Gamedata.mods.get_mods_in_state_order(true)
+	var enabled_mods: Array[DMod] = Gamedata.mods.get_mods_in_state_order(true)
 	# Clear the stats by resetting the instance
 	stats = RStats.new(enabled_mods)
 	skills = RSkills.new(enabled_mods)

--- a/Scripts/runtimedata.gd
+++ b/Scripts/runtimedata.gd
@@ -28,22 +28,23 @@ func get_data_of_type(type: DMod.ContentType) -> RefCounted:
 
 # Reconstruct function to reset and initialize stats
 func reconstruct() -> void:
+	var enabled_mods: Array = Gamedata.mods.get_mods_in_state_order(true)
 	# Clear the stats by resetting the instance
-	stats = RStats.new()
-	skills = RSkills.new()
-	tacticalmaps = RTacticalmaps.new()
-	maps = RMaps.new()
-	tiles = RTiles.new()
-	overmapareas = ROvermapareas.new()
-	quests = RQuests.new()
-	playerattributes = RPlayerAttributes.new()
-	wearableslots = RWearableSlots.new()
-	mobs = RMobs.new()
-	mobgroups = RMobgroups.new()
-	itemgroups = RItemgroups.new()
-	furnitures = RFurnitures.new()
-	items = RItems.new()
-	mobfactions = RMobfactions.new()
+	stats = RStats.new(enabled_mods)
+	skills = RSkills.new(enabled_mods)
+	tacticalmaps = RTacticalmaps.new(enabled_mods)
+	maps = RMaps.new(enabled_mods)
+	tiles = RTiles.new(enabled_mods)
+	overmapareas = ROvermapareas.new(enabled_mods)
+	quests = RQuests.new(enabled_mods)
+	playerattributes = RPlayerAttributes.new(enabled_mods)
+	wearableslots = RWearableSlots.new(enabled_mods)
+	mobs = RMobs.new(enabled_mods)
+	mobgroups = RMobgroups.new(enabled_mods)
+	itemgroups = RItemgroups.new(enabled_mods)
+	furnitures = RFurnitures.new(enabled_mods)
+	items = RItems.new(enabled_mods)
+	mobfactions = RMobfactions.new(enabled_mods)
 	
 	# Populate the gamedata_map with the instantiated objects
 	gamedata_map = {


### PR DESCRIPTION
Helps #506 

Enables the user to specify a mod load order in the add/remove mods menu. Mods can also be enabled and disabled there. Disabling a mod does not prevent the user from editing it in the content editor, but the mod's content will not be included when the game starts.

The game works when all mods are enabled, but unsurprisingly, an error shows up when the `Dimensionfall` mod is disabled because of some hardcoded values which will be fixed in #506