### PR TITLE
Various item references fixes

### DIFF
--- a/Mods/Core/PlayerAttributes/references.json
+++ b/Mods/Core/PlayerAttributes/references.json
@@ -1,0 +1,10 @@
+{
+	"inventory_space": {
+		"items": [
+			"jeans",
+			"backpack",
+			"mailbag",
+			"waistbag"
+		]
+	}
+}

--- a/Mods/Dimensionfall/Items/Items.json
+++ b/Mods/Dimensionfall/Items/Items.json
@@ -3784,48 +3784,48 @@
 		"volume": 150,
 		"weight": 10
 	},
-    {
-        "Food": {
-            "attributes": [
-                {
-                    "amount": 3,
-                    "id": "food"
-                },
-                {
-                    "amount": 4,
-                    "id": "water"
-                }
-            ]
-        },
-        "description": "A fresh, juicy kiwi, rich in vitamins and fiber.",
-        "id": "kiwi",
-        "image": "./Mods/Dimensionfall/Items/kiwi_32.png",
-        "max_stack_size": 20,
-        "name": "Kiwi",
-        "sprite": "kiwi_32.png",
-        "stack_size": 1,
-        "two_handed": false,
-        "volume": 8,
-        "weight": 0.2
-    },
-    {
-        "Food": {
-            "attributes": [
-                {
-                    "amount": 15,
-                    "id": "food"
-                }
-            ]
-        },
-        "description": "A piece of uncooked meat, which needs to be cooked before consumption. High in calories but potentially risky if eaten raw.",
-        "id": "uncooked_meat",
-        "image": "./Mods/Dimensionfall/Items/uncooked_meat_32.png",
-        "max_stack_size": 10,
-        "name": "Uncooked Meat",
-        "sprite": "uncooked_meat_32.png",
-        "stack_size": 1,
-        "two_handed": false,
-        "volume": 20,
-        "weight": 0.5
-    }
+	{
+		"Food": {
+			"attributes": [
+				{
+					"amount": 3,
+					"id": "food"
+				},
+				{
+					"amount": 4,
+					"id": "water"
+				}
+			]
+		},
+		"description": "A fresh, juicy kiwi, rich in vitamins and fiber.",
+		"id": "kiwi",
+		"image": "./Mods/Dimensionfall/Items/kiwi_32.png",
+		"max_stack_size": 20,
+		"name": "Kiwi",
+		"sprite": "kiwi_32.png",
+		"stack_size": 1,
+		"two_handed": false,
+		"volume": 8,
+		"weight": 0.2
+	},
+	{
+		"Food": {
+			"attributes": [
+				{
+					"amount": 15,
+					"id": "food"
+				}
+			]
+		},
+		"description": "A piece of uncooked meat, which needs to be cooked before consumption. High in calories but potentially risky if eaten raw.",
+		"id": "uncooked_meat",
+		"image": "./Mods/Dimensionfall/Items/uncooked_meat_32.png",
+		"max_stack_size": 10,
+		"name": "Uncooked Meat",
+		"sprite": "uncooked_meat_32.png",
+		"stack_size": 1,
+		"two_handed": false,
+		"volume": 20,
+		"weight": 0.5
+	}
 ]

--- a/Mods/Dimensionfall/Items/Items.json
+++ b/Mods/Dimensionfall/Items/Items.json
@@ -5,20 +5,6 @@
 		"image": "./Mods/Dimensionfall/Items/plank.png",
 		"max_stack_size": 3,
 		"name": "Plank 2x4",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"mob_loot",
-					"destroyed_furniture_medium",
-					"disassembled_furniture_medium",
-					"debris_urban"
-				],
-				"items": [
-					"cutting_board",
-					"rolling_pin"
-				]
-			}
-		},
 		"sprite": "plank.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -31,21 +17,6 @@
 		"image": "./Mods/Dimensionfall/Items/steel_scrap.png",
 		"max_stack_size": 100,
 		"name": "Steel scrap",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"cabinet_general",
-					"mob_loot",
-					"destroyed_furniture_medium",
-					"disassembled_furniture_medium",
-					"debris_urban"
-				],
-				"items": [
-					"pistol_magazine",
-					"screwdriver"
-				]
-			}
-		},
 		"sprite": "steel_scrap.png",
 		"stack_size": 2,
 		"two_handed": false,
@@ -61,19 +32,6 @@
 		"image": "./Mods/Dimensionfall/Items/9mm.png",
 		"max_stack_size": 100,
 		"name": "bullet 9mm",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"cabinet_general",
-					"mob_loot",
-					"test_items",
-					"M4A1_gun_ammo"
-				],
-				"items": [
-					"pistol_magazine"
-				]
-			}
-		},
 		"sprite": "9mm.png",
 		"stack_size": 20,
 		"two_handed": false,
@@ -118,19 +76,6 @@
 		"image": "./Mods/Dimensionfall/Items/pistol_magazine.png",
 		"max_stack_size": 1,
 		"name": "Pistol magazine",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"cabinet_general",
-					"mob_loot",
-					"test_items",
-					"M4A1_gun_ammo"
-				],
-				"quests": [
-					"starter_tutorial_00"
-				]
-			}
-		},
 		"sprite": "pistol_magazine.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -157,15 +102,6 @@
 		"image": "./Mods/Dimensionfall/Items/pistol_32.png",
 		"max_stack_size": 1,
 		"name": "Pistol 9mm",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"cabinet_general",
-					"test_items",
-					"police_station_locker"
-				]
-			}
-		},
 		"sprite": "pistol_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -192,16 +128,6 @@
 		"image": "./Mods/Dimensionfall/Items/rifle_64_32.png",
 		"max_stack_size": 1,
 		"name": "M4a1 rifle",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"M4A1_gun_ammo"
-				],
-				"quests": [
-					"starter_tutorial_00"
-				]
-			}
-		},
 		"sprite": "rifle_64_32.png",
 		"stack_size": 1,
 		"two_handed": true,
@@ -228,13 +154,6 @@
 		"image": "./Mods/Dimensionfall/Items/chugunov_mpap_32_28.png",
 		"max_stack_size": 1,
 		"name": "Chugunov MPAP",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"police_station_locker"
-				]
-			}
-		},
 		"sprite": "chugunov_mpap_32_28.png",
 		"stack_size": 1,
 		"two_handed": true,
@@ -252,13 +171,6 @@
 		"image": "./Mods/Dimensionfall/Items/chugunov_mpap_magazine_16_32.png",
 		"max_stack_size": 1,
 		"name": "Chuganov MPAP magazine",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"police_station_locker"
-				]
-			}
-		},
 		"sprite": "chugunov_mpap_magazine_16_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -271,18 +183,6 @@
 		"image": "./Mods/Dimensionfall/Items/bottle_empty_32.png",
 		"max_stack_size": 10,
 		"name": "Empty plastic bottle",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"kitchen_cupboard",
-					"urban_litter",
-					"zombie_loot"
-				],
-				"items": [
-					"screwdriver"
-				]
-			}
-		},
 		"sprite": "bottle_empty_32.png",
 		"stack_size": 2,
 		"two_handed": false,
@@ -303,20 +203,6 @@
 		"image": "./Mods/Dimensionfall/Items/bottle_water_32.png",
 		"max_stack_size": 10,
 		"name": "Plastic bottle with water",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"kitchen_cupboard",
-					"cabinet_general",
-					"refridgerator",
-					"vending_machine_drinks",
-					"zombie_loot"
-				],
-				"quests": [
-					"quest_holy_crusade_01"
-				]
-			}
-		},
 		"sprite": "bottle_water_32.png",
 		"stack_size": 2,
 		"two_handed": false,
@@ -337,16 +223,6 @@
 		"image": "./Mods/Dimensionfall/Items/canned_food_32.png",
 		"max_stack_size": 5,
 		"name": "Canned food\t",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"kitchen_cupboard"
-				],
-				"quests": [
-					"quest_holy_crusade_01"
-				]
-			}
-		},
 		"sprite": "canned_food_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -391,13 +267,6 @@
 		"image": "./Mods/Dimensionfall/Items/hammer_32.png",
 		"max_stack_size": 1,
 		"name": "Hammer",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"cabinet_general"
-				]
-			}
-		},
 		"sprite": "hammer_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -429,16 +298,6 @@
 		"image": "./Mods/Dimensionfall/Items/screwdriver_32.png",
 		"max_stack_size": 1,
 		"name": "Screwdriver",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"cabinet_general",
-					"kitchen_cupboard",
-					"electronics_store_small",
-					"electronics_store_mixed"
-				]
-			}
-		},
 		"sprite": "screwdriver_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -481,18 +340,6 @@
 		"image": "./Mods/Dimensionfall/Items/bandage_32.png",
 		"max_stack_size": 20,
 		"name": "Bandage",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"cabinet_general",
-					"kitchen_cupboard",
-					"police_station_locker"
-				],
-				"quests": [
-					"quest_holy_crusade_01"
-				]
-			}
-		},
 		"sprite": "bandage_32.png",
 		"stack_size": 3,
 		"two_handed": false,
@@ -535,16 +382,6 @@
 		"image": "./Mods/Dimensionfall/Items/antibiotics_32.png",
 		"max_stack_size": 5,
 		"name": "Bottle of antibiotics",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"kitchen_cupboard"
-				],
-				"quests": [
-					"quest_holy_crusade_01"
-				]
-			}
-		},
 		"sprite": "antibiotics_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -560,14 +397,6 @@
 		"image": "./Mods/Dimensionfall/Items/jacket_32.png",
 		"max_stack_size": 1,
 		"name": "Jacket",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"clothing_general",
-					"zombie_loot"
-				]
-			}
-		},
 		"sprite": "jacket_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -583,16 +412,6 @@
 		"image": "./Mods/Dimensionfall/Items/boots_32.png",
 		"max_stack_size": 1,
 		"name": "Boots",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"cabinet_general",
-					"clothing_general",
-					"zombie_loot",
-					"police_station_locker"
-				]
-			}
-		},
 		"sprite": "boots_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -617,13 +436,6 @@
 		"image": "./Mods/Dimensionfall/Items/can_oil_32.png",
 		"max_stack_size": 1,
 		"name": "Can of oil",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"cabinet_general"
-				]
-			}
-		},
 		"sprite": "can_oil_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -636,14 +448,6 @@
 		"image": "./Mods/Dimensionfall/Items/battery_powered_radio_32.png",
 		"max_stack_size": 1,
 		"name": "Handheld radio",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"electronics_store_small",
-					"electronics_store_mixed"
-				]
-			}
-		},
 		"sprite": "battery_powered_radio_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -656,19 +460,6 @@
 		"image": "./Mods/Dimensionfall/Items/flashlight_32.png",
 		"max_stack_size": 1,
 		"name": "Flashlight",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"cabinet_general",
-					"electronics_store_small",
-					"electronics_store_mixed",
-					"police_station_locker"
-				],
-				"quests": [
-					"quest_holy_crusade_01"
-				]
-			}
-		},
 		"sprite": "flashlight_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -681,16 +472,6 @@
 		"image": "./Mods/Dimensionfall/Items/can_beer_32.png",
 		"max_stack_size": 5,
 		"name": "Can of beer",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"kitchen_cupboard",
-					"refridgerator",
-					"vending_machine_drinks",
-					"zombie_loot"
-				]
-			}
-		},
 		"sprite": "can_beer_32.png",
 		"stack_size": 2,
 		"two_handed": false,
@@ -703,15 +484,6 @@
 		"image": "./Mods/Dimensionfall/Items/sigarrette_pack_32.png",
 		"max_stack_size": 5,
 		"name": "Pack of sigarrettes",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"vending_machine_snacks",
-					"urban_litter",
-					"zombie_loot"
-				]
-			}
-		},
 		"sprite": "sigarrette_pack_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -727,13 +499,6 @@
 		"image": "./Mods/Dimensionfall/Items/gasmask_32.png",
 		"max_stack_size": 1,
 		"name": "Gas mask",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"police_station_locker"
-				]
-			}
-		},
 		"sprite": "gasmask_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -749,13 +514,6 @@
 		"image": "./Mods/Dimensionfall/Items/vest_ballistic_32.png",
 		"max_stack_size": 1,
 		"name": "Ballistic vest",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"police_station_locker"
-				]
-			}
-		},
 		"sprite": "vest_ballistic_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -768,13 +526,6 @@
 		"image": "./Mods/Dimensionfall/Items/compass_32.png",
 		"max_stack_size": 1,
 		"name": "Compass",
-		"references": {
-			"core": {
-				"quests": [
-					"quest_holy_crusade_01"
-				]
-			}
-		},
 		"sprite": "compass_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -787,16 +538,6 @@
 		"image": "./Mods/Dimensionfall/Items/battery_32.png",
 		"max_stack_size": 20,
 		"name": "Small battery",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"cabinet_general",
-					"electronics_store_small",
-					"electronics_store_mixed",
-					"loot_electronic"
-				]
-			}
-		},
 		"sprite": "battery_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -809,13 +550,6 @@
 		"image": "./Mods/Dimensionfall/Items/solar_panel_32.png",
 		"max_stack_size": 1,
 		"name": "Solar panel",
-		"references": {
-			"core": {
-				"quests": [
-					"quest_radio_signal_01"
-				]
-			}
-		},
 		"sprite": "solar_panel_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -864,13 +598,6 @@
 		"image": "./Mods/Dimensionfall/Items/survival_guide_32.png",
 		"max_stack_size": 5,
 		"name": "Basic survival guide",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"urban_litter"
-				]
-			}
-		},
 		"sprite": "survival_guide_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -883,13 +610,6 @@
 		"image": "./Mods/Dimensionfall/Items/book_novel_32.png",
 		"max_stack_size": 5,
 		"name": "Novel",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"cabinet_general"
-				]
-			}
-		},
 		"sprite": "book_novel_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -932,13 +652,6 @@
 		"image": "./Mods/Dimensionfall/Items/bottle_disinfectant_32.png",
 		"max_stack_size": 5,
 		"name": "Bottle of disinfectant",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"kitchen_cupboard"
-				]
-			}
-		},
 		"sprite": "bottle_disinfectant_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -951,15 +664,6 @@
 		"image": "./Mods/Dimensionfall/Items/radio_two_way_32.png",
 		"max_stack_size": 1,
 		"name": "Two way radio",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"electronics_store_small",
-					"electronics_store_mixed",
-					"police_station_locker"
-				]
-			}
-		},
 		"sprite": "radio_two_way_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -1210,14 +914,6 @@
 		"image": "./Mods/Dimensionfall/Items/toaster_32.png",
 		"max_stack_size": 1,
 		"name": "Toaster",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"electronics_store_medium",
-					"electronics_store_mixed"
-				]
-			}
-		},
 		"sprite": "toaster_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -1230,14 +926,6 @@
 		"image": "./Mods/Dimensionfall/Items/blender_32.png",
 		"max_stack_size": 1,
 		"name": "Blender",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"electronics_store_medium",
-					"electronics_store_mixed"
-				]
-			}
-		},
 		"sprite": "blender_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -1250,14 +938,6 @@
 		"image": "./Mods/Dimensionfall/Items/coffeemaker_32.png",
 		"max_stack_size": 1,
 		"name": "Coffee Maker",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"electronics_store_medium",
-					"electronics_store_mixed"
-				]
-			}
-		},
 		"sprite": "coffeemaker_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -1270,14 +950,6 @@
 		"image": "./Mods/Dimensionfall/Items/microwave_oven_32.png",
 		"max_stack_size": 1,
 		"name": "Microwave Oven",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"electronics_store_medium",
-					"electronics_store_mixed"
-				]
-			}
-		},
 		"sprite": "microwave_oven_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -1302,14 +974,6 @@
 		"image": "./Mods/Dimensionfall/Items/pressure_cooker_32.png",
 		"max_stack_size": 1,
 		"name": "Pressure Cooker",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"electronics_store_medium",
-					"electronics_store_mixed"
-				]
-			}
-		},
 		"sprite": "pressure_cooker_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -1322,14 +986,6 @@
 		"image": "./Mods/Dimensionfall/Items/bread_maker_32.png",
 		"max_stack_size": 1,
 		"name": "Bread Maker",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"electronics_store_medium",
-					"electronics_store_mixed"
-				]
-			}
-		},
 		"sprite": "bread_maker_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -1342,13 +998,6 @@
 		"image": "./Mods/Dimensionfall/Items/nails_32.png",
 		"max_stack_size": 100,
 		"name": "Nails",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"debris_urban"
-				]
-			}
-		},
 		"sprite": "nails_32.png",
 		"stack_size": 10,
 		"two_handed": false,
@@ -1361,14 +1010,6 @@
 		"image": "./Mods/Dimensionfall/Items/log_32.png",
 		"max_stack_size": 3,
 		"name": "Log",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"tree_destroyed",
-					"generic_forest_finds"
-				]
-			}
-		},
 		"sprite": "log_32.png",
 		"stack_size": 1,
 		"two_handed": true,
@@ -1381,13 +1022,6 @@
 		"image": "./Mods/Dimensionfall/Items/screw_32.png",
 		"max_stack_size": 100,
 		"name": "Screw",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"debris_urban"
-				]
-			}
-		},
 		"sprite": "screw_32.png",
 		"stack_size": 10,
 		"two_handed": false,
@@ -1400,14 +1034,6 @@
 		"image": "./Mods/Dimensionfall/Items/branches_32.png",
 		"max_stack_size": 10,
 		"name": "Branch",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"tree_destroyed",
-					"generic_forest_finds"
-				]
-			}
-		},
 		"sprite": "branches_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -1420,15 +1046,6 @@
 		"image": "./Mods/Dimensionfall/Items/leaves_32.png",
 		"max_stack_size": 50,
 		"name": "Leaf",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"tree_destroyed",
-					"generic_field_finds",
-					"generic_forest_finds"
-				]
-			}
-		},
 		"sprite": "leaves_32.png",
 		"stack_size": 5,
 		"two_handed": false,
@@ -1441,13 +1058,6 @@
 		"image": "./Mods/Dimensionfall/Items/pine_branch_32.png",
 		"max_stack_size": 10,
 		"name": "Pine Branch",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"generic_forest_finds"
-				]
-			}
-		},
 		"sprite": "pine_branch_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -1496,15 +1106,6 @@
 		"image": "./Mods/Dimensionfall/Items/plant_remnants_32.png",
 		"max_stack_size": 50,
 		"name": "Plant Remnants",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"tree_destroyed",
-					"generic_field_finds",
-					"generic_forest_finds"
-				]
-			}
-		},
 		"sprite": "plant_remnants_32.png",
 		"stack_size": 5,
 		"two_handed": false,
@@ -1517,16 +1118,6 @@
 		"image": "./Mods/Dimensionfall/Items/electrical_components_32.png",
 		"max_stack_size": 20,
 		"name": "Electrical Components",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"electronics_store_small",
-					"electronics_store_mixed",
-					"electronics_damaged",
-					"loot_electronic"
-				]
-			}
-		},
 		"sprite": "electrical_components_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -1539,16 +1130,6 @@
 		"image": "./Mods/Dimensionfall/Items/plastic_parts_32.png",
 		"max_stack_size": 50,
 		"name": "Plastic Parts",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"debris_urban",
-					"urban_litter",
-					"electronics_damaged",
-					"loot_electronic"
-				]
-			}
-		},
 		"sprite": "plastic_parts_32.png",
 		"stack_size": 10,
 		"two_handed": false,
@@ -1561,13 +1142,6 @@
 		"image": "./Mods/Dimensionfall/Items/ceramic_fragments_32.png",
 		"max_stack_size": 30,
 		"name": "Ceramic Fragments",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"debris_urban"
-				]
-			}
-		},
 		"sprite": "ceramic_fragments_32.png",
 		"stack_size": 5,
 		"two_handed": false,
@@ -1580,16 +1154,6 @@
 		"image": "./Mods/Dimensionfall/Items/metal_parts_32.png",
 		"max_stack_size": 50,
 		"name": "Metal Parts",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"debris_urban",
-					"urban_litter",
-					"electronics_damaged",
-					"loot_electronic"
-				]
-			}
-		},
 		"sprite": "metal_parts_32.png",
 		"stack_size": 10,
 		"two_handed": false,
@@ -1622,13 +1186,6 @@
 		"image": "./Mods/Dimensionfall/Items/tofu_32.png",
 		"max_stack_size": 5,
 		"name": "Tofu",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"refridgerator"
-				]
-			}
-		},
 		"sprite": "tofu_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -1653,13 +1210,6 @@
 		"image": "./Mods/Dimensionfall/Items/bottle_yogurt_32.png",
 		"max_stack_size": 10,
 		"name": "Bottle of Yogurt",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"refridgerator"
-				]
-			}
-		},
 		"sprite": "bottle_yogurt_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -1750,13 +1300,6 @@
 		"image": "./Mods/Dimensionfall/Items/insulin_32.png",
 		"max_stack_size": 5,
 		"name": "Insulin",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"zombie_loot"
-				]
-			}
-		},
 		"sprite": "insulin_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -1799,13 +1342,6 @@
 		"image": "./Mods/Dimensionfall/Items/epipen_32.png",
 		"max_stack_size": 5,
 		"name": "EpiPen",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"zombie_loot"
-				]
-			}
-		},
 		"sprite": "epipen_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -1826,13 +1362,6 @@
 		"image": "./Mods/Dimensionfall/Items/bag_bacon_32.png",
 		"max_stack_size": 10,
 		"name": "Bag of Bacon",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"refridgerator"
-				]
-			}
-		},
 		"sprite": "bag_bacon_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -1885,13 +1414,6 @@
 		"image": "./Mods/Dimensionfall/Items/syringe_32.png",
 		"max_stack_size": 20,
 		"name": "Syringe",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"zombie_loot"
-				]
-			}
-		},
 		"sprite": "syringe_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -1912,13 +1434,6 @@
 		"image": "./Mods/Dimensionfall/Items/slice_of_pizza_32.png",
 		"max_stack_size": 10,
 		"name": "Slice of Pizza",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"refridgerator"
-				]
-			}
-		},
 		"sprite": "slice_of_pizza_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -1939,13 +1454,6 @@
 		"image": "./Mods/Dimensionfall/Items/vacuum_sealed_fish_32.png",
 		"max_stack_size": 10,
 		"name": "Vacuum Sealed Fish",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"refridgerator"
-				]
-			}
-		},
 		"sprite": "vacuum_sealed_fish_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -1970,13 +1478,6 @@
 		"image": "./Mods/Dimensionfall/Items/tomato_32.png",
 		"max_stack_size": 20,
 		"name": "Tomato",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"refridgerator"
-				]
-			}
-		},
 		"sprite": "tomato_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2001,13 +1502,6 @@
 		"image": "./Mods/Dimensionfall/Items/lettuce_32.png",
 		"max_stack_size": 10,
 		"name": "Lettuce",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"refridgerator"
-				]
-			}
-		},
 		"sprite": "lettuce_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2040,14 +1534,6 @@
 		"image": "./Mods/Dimensionfall/Items/chocolate_32.png",
 		"max_stack_size": 10,
 		"name": "Chocolate",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"vending_machine_snacks",
-					"zombie_loot"
-				]
-			}
-		},
 		"sprite": "chocolate_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2140,13 +1626,6 @@
 		"image": "./Mods/Dimensionfall/Items/stale_bread_32.png",
 		"max_stack_size": 5,
 		"name": "Stale Bread",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"urban_litter"
-				]
-			}
-		},
 		"sprite": "stale_bread_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2189,17 +1668,6 @@
 		"image": "./Mods/Dimensionfall/Items/painkiller_32.png",
 		"max_stack_size": 20,
 		"name": "Painkiller",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"first_aid",
-					"zombie_loot"
-				],
-				"quests": [
-					"quest_holy_crusade_01"
-				]
-			}
-		},
 		"sprite": "painkiller_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2248,13 +1716,6 @@
 		"image": "./Mods/Dimensionfall/Items/apple_32.png",
 		"max_stack_size": 20,
 		"name": "Apple",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"refridgerator"
-				]
-			}
-		},
 		"sprite": "apple_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2295,13 +1756,6 @@
 		"image": "./Mods/Dimensionfall/Items/carrot_32.png",
 		"max_stack_size": 20,
 		"name": "Carrot",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"refridgerator"
-				]
-			}
-		},
 		"sprite": "carrot_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2326,13 +1780,6 @@
 		"image": "./Mods/Dimensionfall/Items/eggs_32.png",
 		"max_stack_size": 5,
 		"name": "Eggs",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"refridgerator"
-				]
-			}
-		},
 		"sprite": "eggs_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2353,13 +1800,6 @@
 		"image": "./Mods/Dimensionfall/Items/butter_32.png",
 		"max_stack_size": 10,
 		"name": "Butter",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"refridgerator"
-				]
-			}
-		},
 		"sprite": "butter_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2380,15 +1820,6 @@
 		"image": "./Mods/Dimensionfall/Items/can_energydrink_32.png",
 		"max_stack_size": 20,
 		"name": "Energy Drink",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"refridgerator",
-					"vending_machine_drinks",
-					"zombie_loot"
-				]
-			}
-		},
 		"sprite": "can_energydrink_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2409,15 +1840,6 @@
 		"image": "./Mods/Dimensionfall/Items/can_soda_32.png",
 		"max_stack_size": 20,
 		"name": "Soda",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"refridgerator",
-					"vending_machine_drinks",
-					"zombie_loot"
-				]
-			}
-		},
 		"sprite": "can_soda_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2438,13 +1860,6 @@
 		"image": "./Mods/Dimensionfall/Items/cheese_32.png",
 		"max_stack_size": 10,
 		"name": "Cheese",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"refridgerator"
-				]
-			}
-		},
 		"sprite": "cheese_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2460,14 +1875,6 @@
 		"image": "./Mods/Dimensionfall/Items/t_shirt_32.png",
 		"max_stack_size": 1,
 		"name": "T-shirt",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"clothing_general",
-					"zombie_loot"
-				]
-			}
-		},
 		"sprite": "t_shirt_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2489,14 +1896,6 @@
 		"image": "./Mods/Dimensionfall/Items/jeans_32.png",
 		"max_stack_size": 1,
 		"name": "Jeans",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"clothing_general",
-					"zombie_loot"
-				]
-			}
-		},
 		"sprite": "jeans_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2584,14 +1983,6 @@
 		"image": "./Mods/Dimensionfall/Items/baseball_cap_32.png",
 		"max_stack_size": 1,
 		"name": "Baseball Cap",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"clothing_general",
-					"zombie_loot"
-				]
-			}
-		},
 		"sprite": "baseball_cap_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2607,14 +1998,6 @@
 		"image": "./Mods/Dimensionfall/Items/sweater_32.png",
 		"max_stack_size": 1,
 		"name": "Sweater",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"clothing_general",
-					"zombie_loot"
-				]
-			}
-		},
 		"sprite": "sweater_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2630,14 +2013,6 @@
 		"image": "./Mods/Dimensionfall/Items/scarf_32.png",
 		"max_stack_size": 1,
 		"name": "Scarf",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"clothing_general",
-					"zombie_loot"
-				]
-			}
-		},
 		"sprite": "scarf_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2653,15 +2028,6 @@
 		"image": "./Mods/Dimensionfall/Items/leather_gloves_32.png",
 		"max_stack_size": 1,
 		"name": "Leather Gloves",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"clothing_general",
-					"zombie_loot",
-					"police_station_locker"
-				]
-			}
-		},
 		"sprite": "leather_gloves_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2677,13 +2043,6 @@
 		"image": "./Mods/Dimensionfall/Items/shorts_32.png",
 		"max_stack_size": 1,
 		"name": "Shorts",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"zombie_loot"
-				]
-			}
-		},
 		"sprite": "shorts_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2714,13 +2073,6 @@
 		"image": "./Mods/Dimensionfall/Items/socks_32.png",
 		"max_stack_size": 1,
 		"name": "Socks",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"zombie_loot"
-				]
-			}
-		},
 		"sprite": "socks_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2829,13 +2181,6 @@
 		"image": "./Mods/Dimensionfall/Items/stick_small_32.png",
 		"max_stack_size": 5,
 		"name": "Small Stick",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"generic_forest_finds"
-				]
-			}
-		},
 		"sprite": "stick_small_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2848,13 +2193,6 @@
 		"image": "./Mods/Dimensionfall/Items/rock_large_32.png",
 		"max_stack_size": 1,
 		"name": "Large Rock",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"debris_rock"
-				]
-			}
-		},
 		"sprite": "rock_large_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2867,13 +2205,6 @@
 		"image": "./Mods/Dimensionfall/Items/wild_herbs_32.png",
 		"max_stack_size": 10,
 		"name": "Wild Herbs",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"generic_forest_finds"
-				]
-			}
-		},
 		"sprite": "wild_herbs_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2898,16 +2229,6 @@
 		"image": "./Mods/Dimensionfall/Items/berries_wild_32.png",
 		"max_stack_size": 100,
 		"name": "Wild Berries",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"generic_forest_finds"
-				],
-				"quests": [
-					"starter_tutorial_00"
-				]
-			}
-		},
 		"sprite": "berries_wild_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2928,13 +2249,6 @@
 		"image": "./Mods/Dimensionfall/Items/mushroom_forest_32.png",
 		"max_stack_size": 10,
 		"name": "Forest Mushrooms",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"generic_forest_finds"
-				]
-			}
-		},
 		"sprite": "mushroom_forest_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2947,13 +2261,6 @@
 		"image": "./Mods/Dimensionfall/Items/pinecone_32.png",
 		"max_stack_size": 10,
 		"name": "Pinecone",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"generic_forest_finds"
-				]
-			}
-		},
 		"sprite": "pinecone_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2978,13 +2285,6 @@
 		"image": "./Mods/Dimensionfall/Items/egg_bird_32.png",
 		"max_stack_size": 10,
 		"name": "Bird Egg",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"generic_forest_finds"
-				]
-			}
-		},
 		"sprite": "egg_bird_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -2997,13 +2297,6 @@
 		"image": "./Mods/Dimensionfall/Items/flower_wild_32.png",
 		"max_stack_size": 10,
 		"name": "Wild Flower",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"generic_field_finds"
-				]
-			}
-		},
 		"sprite": "flower_wild_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -3016,13 +2309,6 @@
 		"image": "./Mods/Dimensionfall/Items/acorn_32.png",
 		"max_stack_size": 100,
 		"name": "Acorn",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"generic_forest_finds"
-				]
-			}
-		},
 		"sprite": "acorn_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -3035,16 +2321,6 @@
 		"image": "./Mods/Dimensionfall/Items/pebble_32.png",
 		"max_stack_size": 100,
 		"name": "Pebble",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"generic_field_finds",
-					"generic_forest_finds",
-					"debris_rock",
-					"urban_litter"
-				]
-			}
-		},
 		"sprite": "pebble_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -3069,14 +2345,6 @@
 		"image": "./Mods/Dimensionfall/Items/gravel_32.png",
 		"max_stack_size": 100,
 		"name": "Gravel",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"debris_rock",
-					"debris_urban"
-				]
-			}
-		},
 		"sprite": "gravel_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -3089,15 +2357,6 @@
 		"image": "./Mods/Dimensionfall/Items/rock_medium_32.png",
 		"max_stack_size": 10,
 		"name": "Medium Rock",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"generic_field_finds",
-					"debris_rock",
-					"debris_urban"
-				]
-			}
-		},
 		"sprite": "rock_medium_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -3110,15 +2369,6 @@
 		"image": "./Mods/Dimensionfall/Items/rock_small_32.png",
 		"max_stack_size": 20,
 		"name": "Small Rock",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"generic_field_finds",
-					"generic_forest_finds",
-					"debris_rock"
-				]
-			}
-		},
 		"sprite": "rock_small_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -3139,14 +2389,6 @@
 		"image": "./Mods/Dimensionfall/Items/stick_32.png",
 		"max_stack_size": 3,
 		"name": "Stick",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"generic_forest_finds",
-					"destroyed_furniture_medium"
-				]
-			}
-		},
 		"sprite": "stick_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -3167,21 +2409,6 @@
 		"image": "./Mods/Dimensionfall/Items/stick_long_32.png",
 		"max_stack_size": 2,
 		"name": "Long Stick",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"tree_destroyed",
-					"generic_forest_finds",
-					"test_items"
-				],
-				"items": [
-					"stone_spear"
-				],
-				"quests": [
-					"starter_tutorial_00"
-				]
-			}
-		},
 		"sprite": "stick_long_32.png",
 		"stack_size": 1,
 		"two_handed": true,
@@ -3194,20 +2421,6 @@
 		"image": "./Mods/Dimensionfall/Items/rock_sharp_32.png",
 		"max_stack_size": 5,
 		"name": "Sharp Stone",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"generic_field_finds",
-					"test_items"
-				],
-				"items": [
-					"stone_spear"
-				],
-				"quests": [
-					"starter_tutorial_00"
-				]
-			}
-		},
 		"sprite": "rock_sharp_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -3251,13 +2464,6 @@
 		"image": "./Mods/Dimensionfall/Items/spear_stone_32.png",
 		"max_stack_size": 1,
 		"name": "Stone Spear",
-		"references": {
-			"core": {
-				"quests": [
-					"starter_tutorial_00"
-				]
-			}
-		},
 		"sprite": "spear_stone_32.png",
 		"stack_size": 1,
 		"two_handed": true,
@@ -3279,14 +2485,6 @@
 		"image": "./Mods/Dimensionfall/Items/waistbag_32.png",
 		"max_stack_size": 1,
 		"name": "Waist Bag",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"clothing_general",
-					"zombie_loot"
-				]
-			}
-		},
 		"sprite": "waistbag_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -3308,14 +2506,6 @@
 		"image": "./Mods/Dimensionfall/Items/mailbag_32.png",
 		"max_stack_size": 1,
 		"name": "Mail Bag",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"clothing_general",
-					"zombie_loot"
-				]
-			}
-		},
 		"sprite": "mailbag_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -3337,14 +2527,6 @@
 		"image": "./Mods/Dimensionfall/Items/backpack_32.png",
 		"max_stack_size": 1,
 		"name": "Backpack",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"clothing_general",
-					"zombie_loot"
-				]
-			}
-		},
 		"sprite": "backpack_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -3381,13 +2563,6 @@
 		"image": "./Mods/Dimensionfall/Items/concrete_slab_damaged_32.png",
 		"max_stack_size": 1,
 		"name": "Damaged Concrete Slab",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"debris_urban"
-				]
-			}
-		},
 		"sprite": "concrete_slab_damaged_32.png",
 		"stack_size": 1,
 		"two_handed": true,
@@ -3400,14 +2575,6 @@
 		"image": "./Mods/Dimensionfall/Items/glass_shards_32.png",
 		"max_stack_size": 100,
 		"name": "Glass Shards",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"debris_urban",
-					"urban_litter"
-				]
-			}
-		},
 		"sprite": "glass_shards_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -3420,13 +2587,6 @@
 		"image": "./Mods/Dimensionfall/Items/rusted_metal_sheets_32.png",
 		"max_stack_size": 20,
 		"name": "Rusted Metal Sheets",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"debris_urban"
-				]
-			}
-		},
 		"sprite": "rusted_metal_sheets_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -3449,17 +2609,6 @@
 		"image": "./Mods/Dimensionfall/Items/antidote_32.png",
 		"max_stack_size": 5,
 		"name": "Bottle of antidote",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"test_items",
-					"kitchen_cupboard"
-				],
-				"quests": [
-					"quest_holy_crusade_01"
-				]
-			}
-		},
 		"sprite": "antidote_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -3472,16 +2621,6 @@
 		"image": "./Mods/Dimensionfall/Items/transmitter_broken_32.png",
 		"max_stack_size": 1,
 		"name": "Damaged transmitter",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"electronics_damaged"
-				],
-				"quests": [
-					"quest_radio_signal_01"
-				]
-			}
-		},
 		"sprite": "transmitter_broken_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -3494,17 +2633,6 @@
 		"image": "./Mods/Dimensionfall/Items/cirquit_board_32.png",
 		"max_stack_size": 5,
 		"name": "Circuit Board",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"loot_electronic",
-					"electronics_store_small"
-				],
-				"quests": [
-					"quest_radio_signal_01"
-				]
-			}
-		},
 		"sprite": "cirquit_board_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -3552,19 +2680,6 @@
 		"image": "./Mods/Dimensionfall/Items/transmitter_32.png",
 		"max_stack_size": 1,
 		"name": "Transmitter",
-		"references": {
-			"core": {
-				"items": [
-					"damaged_transmitter",
-					"electrical_components",
-					"plastic_parts",
-					"circuit_board"
-				],
-				"quests": [
-					"quest_radio_signal_01"
-				]
-			}
-		},
 		"sprite": "transmitter_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -3589,13 +2704,6 @@
 		"image": "./Mods/Dimensionfall/Items/wallet_32.png",
 		"max_stack_size": 3,
 		"name": "Wallet",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"zombie_loot"
-				]
-			}
-		},
 		"sprite": "wallet_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -3611,13 +2719,6 @@
 		"image": "./Mods/Dimensionfall/Items/watch_32.png",
 		"max_stack_size": 3,
 		"name": "Wallet",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"zombie_loot"
-				]
-			}
-		},
 		"sprite": "watch_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -3646,13 +2747,6 @@
 		"image": "./Mods/Dimensionfall/Items/rotten_flesh_chunk_32.png",
 		"max_stack_size": 10,
 		"name": "Chunk of Rotten Flesh",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"zombie_loot"
-				]
-			}
-		},
 		"sprite": "rotten_flesh_chunk_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -3665,13 +2759,6 @@
 		"image": "./Mods/Dimensionfall/Items/zombie_bone_32.png",
 		"max_stack_size": 10,
 		"name": "Zombie Bone",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"zombie_loot"
-				]
-			}
-		},
 		"sprite": "zombie_bone_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -3700,13 +2787,6 @@
 		"image": "./Mods/Dimensionfall/Items/zombie_eye_32.png",
 		"max_stack_size": 10,
 		"name": "Zombie Eye",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"zombie_loot"
-				]
-			}
-		},
 		"sprite": "zombie_eye_32.png",
 		"stack_size": 1,
 		"two_handed": false,
@@ -3735,13 +2815,6 @@
 		"image": "./Mods/Dimensionfall/Items/zombie_organ_32.png",
 		"max_stack_size": 3,
 		"name": "Decayed Organ",
-		"references": {
-			"core": {
-				"itemgroups": [
-					"zombie_loot"
-				]
-			}
-		},
 		"sprite": "zombie_organ_32.png",
 		"stack_size": 1,
 		"two_handed": false,

--- a/Mods/Dimensionfall/Items/references.json
+++ b/Mods/Dimensionfall/Items/references.json
@@ -105,6 +105,9 @@
 			"kitchen_cupboard",
 			"urban_litter",
 			"zombie_loot"
+		],
+		"items": [
+			"screwdriver"
 		]
 	},
 	"bottle_plastic_water": {
@@ -232,6 +235,9 @@
 			"electronics_store_small",
 			"loot_electronic"
 		],
+		"items": [
+			"transmitter"
+		],
 		"quests": [
 			"quest_radio_signal_01"
 		]
@@ -256,6 +262,9 @@
 		"itemgroups": [
 			"electronics_damaged"
 		],
+		"items": [
+			"transmitter"
+		],
 		"quests": [
 			"quest_radio_signal_01"
 		]
@@ -271,6 +280,9 @@
 			"electronics_store_mixed",
 			"electronics_damaged",
 			"loot_electronic"
+		],
+		"items": [
+			"transmitter"
 		]
 	},
 	"epipen": {
@@ -396,6 +408,9 @@
 			"generic_forest_finds",
 			"tree_forage"
 		],
+		"items": [
+			"stone_spear"
+		],
 		"quests": [
 			"starter_tutorial_00"
 		]
@@ -498,6 +513,10 @@
 			"destroyed_furniture_medium",
 			"disassembled_furniture_medium",
 			"debris_urban"
+		],
+		"items": [
+			"cutting_board",
+			"rolling_pin"
 		]
 	},
 	"plant_remnants": {
@@ -513,6 +532,9 @@
 			"urban_litter",
 			"debris_urban",
 			"loot_electronic"
+		],
+		"items": [
+			"transmitter"
 		]
 	},
 	"pressure_cooker": {
@@ -577,6 +599,9 @@
 			"test_items",
 			"generic_field_finds"
 		],
+		"items": [
+			"stone_spear"
+		],
 		"quests": [
 			"starter_tutorial_00"
 		]
@@ -630,7 +655,8 @@
 			"loot_electronic"
 		],
 		"items": [
-			"pistol_magazine"
+			"pistol_magazine",
+			"screwdriver"
 		]
 	},
 	"stick": {

--- a/Mods/Dimensionfall/Items/references.json
+++ b/Mods/Dimensionfall/Items/references.json
@@ -150,6 +150,9 @@
 			"M4A1_gun_ammo",
 			"test_items",
 			"police_station_locker"
+		],
+		"items": [
+			"pistol_magazine"
 		]
 	},
 	"butter": {
@@ -625,6 +628,9 @@
 			"disassembled_furniture_medium",
 			"debris_urban",
 			"loot_electronic"
+		],
+		"items": [
+			"pistol_magazine"
 		]
 	},
 	"stick": {

--- a/Mods/Dimensionfall/Items/references.json
+++ b/Mods/Dimensionfall/Items/references.json
@@ -9,14 +9,45 @@
 			"refridgerator"
 		]
 	},
+	"bandage_basic": {
+		"itemgroups": [
+			"kitchen_cupboard"
+		]
+	},
+	"bottle_antibiotics": {
+		"itemgroups": [
+			"kitchen_cupboard"
+		]
+	},
+	"bottle_antidote": {
+		"itemgroups": [
+			"kitchen_cupboard"
+		]
+	},
+	"bottle_disinfectant": {
+		"itemgroups": [
+			"kitchen_cupboard"
+		]
+	},
+	"bottle_plastic_empty": {
+		"itemgroups": [
+			"kitchen_cupboard"
+		]
+	},
 	"bottle_plastic_water": {
 		"itemgroups": [
-			"refridgerator"
+			"refridgerator",
+			"kitchen_cupboard"
 		]
 	},
 	"bottle_yogurt": {
 		"itemgroups": [
 			"refridgerator"
+		]
+	},
+	"bullet_9mm": {
+		"itemgroups": [
+			"mob_loot"
 		]
 	},
 	"butter": {
@@ -26,7 +57,8 @@
 	},
 	"can_beer": {
 		"itemgroups": [
-			"refridgerator"
+			"refridgerator",
+			"kitchen_cupboard"
 		]
 	},
 	"can_energydrink": {
@@ -37,6 +69,11 @@
 	"can_soda": {
 		"itemgroups": [
 			"refridgerator"
+		]
+	},
+	"canned_food": {
+		"itemgroups": [
+			"kitchen_cupboard"
 		]
 	},
 	"carrot": {
@@ -64,9 +101,29 @@
 			"refridgerator"
 		]
 	},
+	"pistol_magazine": {
+		"itemgroups": [
+			"mob_loot"
+		]
+	},
+	"plank_2x4": {
+		"itemgroups": [
+			"mob_loot"
+		]
+	},
+	"screwdriver": {
+		"itemgroups": [
+			"kitchen_cupboard"
+		]
+	},
 	"slice_of_pizza": {
 		"itemgroups": [
 			"refridgerator"
+		]
+	},
+	"steel_scrap": {
+		"itemgroups": [
+			"mob_loot"
 		]
 	},
 	"tofu": {

--- a/Mods/Dimensionfall/Items/references.json
+++ b/Mods/Dimensionfall/Items/references.json
@@ -1,7 +1,19 @@
 {
+	"acorn": {
+		"itemgroups": [
+			"generic_forest_finds"
+		]
+	},
 	"apple": {
 		"itemgroups": [
-			"refridgerator"
+			"refridgerator",
+			"starting_items"
+		]
+	},
+	"backpack": {
+		"itemgroups": [
+			"clothing_general",
+			"zombie_loot"
 		]
 	},
 	"bag_bacon": {
@@ -11,33 +23,86 @@
 	},
 	"bandage_basic": {
 		"itemgroups": [
-			"kitchen_cupboard"
+			"kitchen_cupboard",
+			"cabinet_general",
+			"starting_items",
+			"police_station_locker",
+			"first_aid"
+		]
+	},
+	"battery_small": {
+		"itemgroups": [
+			"cabinet_general",
+			"electronics_store_small",
+			"electronics_store_mixed",
+			"loot_electronic"
+		]
+	},
+	"berries_wild": {
+		"itemgroups": [
+			"generic_forest_finds"
+		]
+	},
+	"bird_egg": {
+		"itemgroups": [
+			"generic_forest_finds"
+		]
+	},
+	"blender": {
+		"itemgroups": [
+			"electronics_store_medium",
+			"electronics_store_mixed"
+		]
+	},
+	"book_novel": {
+		"itemgroups": [
+			"cabinet_general"
+		]
+	},
+	"boots": {
+		"itemgroups": [
+			"cabinet_general",
+			"clothing_general",
+			"starting_items",
+			"zombie_loot",
+			"police_station_locker"
 		]
 	},
 	"bottle_antibiotics": {
 		"itemgroups": [
-			"kitchen_cupboard"
+			"kitchen_cupboard",
+			"starting_items",
+			"first_aid"
 		]
 	},
 	"bottle_antidote": {
 		"itemgroups": [
-			"kitchen_cupboard"
+			"kitchen_cupboard",
+			"test_items",
+			"first_aid"
 		]
 	},
 	"bottle_disinfectant": {
 		"itemgroups": [
-			"kitchen_cupboard"
+			"kitchen_cupboard",
+			"first_aid"
 		]
 	},
 	"bottle_plastic_empty": {
 		"itemgroups": [
-			"kitchen_cupboard"
+			"kitchen_cupboard",
+			"urban_litter",
+			"zombie_loot"
 		]
 	},
 	"bottle_plastic_water": {
 		"itemgroups": [
 			"refridgerator",
-			"kitchen_cupboard"
+			"kitchen_cupboard",
+			"cabinet_general",
+			"vending_machine_drinks",
+			"starting_items",
+			"zombie_loot"
 		]
 	},
 	"bottle_yogurt": {
@@ -45,9 +110,31 @@
 			"refridgerator"
 		]
 	},
+	"branch": {
+		"itemgroups": [
+			"tree_destroyed",
+			"generic_forest_finds",
+			"tree_forage"
+		]
+	},
+	"bread": {
+		"itemgroups": [
+			"starting_items"
+		]
+	},
+	"bread_maker": {
+		"itemgroups": [
+			"electronics_store_medium",
+			"electronics_store_mixed"
+		]
+	},
 	"bullet_9mm": {
 		"itemgroups": [
-			"mob_loot"
+			"mob_loot",
+			"cabinet_general",
+			"M4A1_gun_ammo",
+			"test_items",
+			"police_station_locker"
 		]
 	},
 	"butter": {
@@ -58,17 +145,29 @@
 	"can_beer": {
 		"itemgroups": [
 			"refridgerator",
-			"kitchen_cupboard"
+			"kitchen_cupboard",
+			"vending_machine_drinks",
+			"zombie_loot"
 		]
 	},
 	"can_energydrink": {
 		"itemgroups": [
-			"refridgerator"
+			"refridgerator",
+			"vending_machine_drinks",
+			"zombie_loot"
+		]
+	},
+	"can_oil": {
+		"itemgroups": [
+			"cabinet_general"
 		]
 	},
 	"can_soda": {
 		"itemgroups": [
-			"refridgerator"
+			"refridgerator",
+			"vending_machine_drinks",
+			"starting_items",
+			"zombie_loot"
 		]
 	},
 	"canned_food": {
@@ -81,9 +180,52 @@
 			"refridgerator"
 		]
 	},
+	"ceramic_fragments": {
+		"itemgroups": [
+			"debris_urban"
+		]
+	},
 	"cheese": {
 		"itemgroups": [
 			"refridgerator"
+		]
+	},
+	"chocolate": {
+		"itemgroups": [
+			"vending_machine_snacks",
+			"zombie_loot"
+		]
+	},
+	"chugunov_mpap": {
+		"itemgroups": [
+			"police_station_locker"
+		]
+	},
+	"chugunov_mpap_magazine": {
+		"itemgroups": [
+			"police_station_locker"
+		]
+	},
+	"circuit_board": {
+		"itemgroups": [
+			"electronics_store_small",
+			"loot_electronic"
+		]
+	},
+	"coffee_maker": {
+		"itemgroups": [
+			"electronics_store_medium",
+			"electronics_store_mixed"
+		]
+	},
+	"damaged_concrete_slab": {
+		"itemgroups": [
+			"debris_urban"
+		]
+	},
+	"damaged_transmitter": {
+		"itemgroups": [
+			"electronics_damaged"
 		]
 	},
 	"eggs": {
@@ -91,9 +233,114 @@
 			"refridgerator"
 		]
 	},
+	"electrical_components": {
+		"itemgroups": [
+			"electronics_store_small",
+			"electronics_store_mixed",
+			"electronics_damaged",
+			"loot_electronic"
+		]
+	},
+	"epipen": {
+		"itemgroups": [
+			"zombie_loot"
+		]
+	},
+	"flashlight_basic": {
+		"itemgroups": [
+			"cabinet_general",
+			"electronics_store_small",
+			"electronics_store_mixed",
+			"police_station_locker"
+		]
+	},
+	"flower_wild": {
+		"itemgroups": [
+			"generic_field_finds"
+		]
+	},
+	"gas_mask": {
+		"itemgroups": [
+			"police_station_locker"
+		]
+	},
+	"glass_shards": {
+		"itemgroups": [
+			"urban_litter",
+			"debris_urban"
+		]
+	},
+	"gloves_leather": {
+		"itemgroups": [
+			"clothing_general",
+			"starting_items",
+			"zombie_loot",
+			"police_station_locker"
+		]
+	},
+	"gravel": {
+		"itemgroups": [
+			"debris_urban",
+			"debris_rock"
+		]
+	},
+	"guide_survival_basic": {
+		"itemgroups": [
+			"urban_litter"
+		]
+	},
+	"hammer": {
+		"itemgroups": [
+			"cabinet_general"
+		]
+	},
+	"hat_baseball": {
+		"itemgroups": [
+			"clothing_general",
+			"starting_items",
+			"zombie_loot"
+		]
+	},
+	"herbs_wild": {
+		"itemgroups": [
+			"generic_forest_finds"
+		]
+	},
+	"insulin": {
+		"itemgroups": [
+			"zombie_loot"
+		]
+	},
+	"jacket": {
+		"itemgroups": [
+			"clothing_general",
+			"starting_items",
+			"zombie_loot"
+		]
+	},
+	"jeans": {
+		"itemgroups": [
+			"clothing_general",
+			"starting_items",
+			"zombie_loot"
+		]
+	},
 	"kiwi": {
 		"itemgroups": [
 			"refridgerator"
+		]
+	},
+	"large_rock": {
+		"itemgroups": [
+			"debris_rock"
+		]
+	},
+	"leaf": {
+		"itemgroups": [
+			"tree_destroyed",
+			"generic_forest_finds",
+			"generic_field_finds",
+			"tree_forage"
 		]
 	},
 	"lettuce": {
@@ -101,19 +348,193 @@
 			"refridgerator"
 		]
 	},
+	"log": {
+		"itemgroups": [
+			"tree_destroyed",
+			"generic_forest_finds"
+		]
+	},
+	"long_stick": {
+		"itemgroups": [
+			"tree_destroyed",
+			"test_items",
+			"generic_forest_finds",
+			"tree_forage"
+		]
+	},
+	"mailbag": {
+		"itemgroups": [
+			"clothing_general",
+			"starting_items",
+			"zombie_loot"
+		]
+	},
+	"medium_rock": {
+		"itemgroups": [
+			"generic_field_finds",
+			"debris_urban",
+			"debris_rock"
+		]
+	},
+	"metal_parts": {
+		"itemgroups": [
+			"electronics_damaged",
+			"urban_litter",
+			"debris_urban",
+			"loot_electronic"
+		]
+	},
+	"microwave_oven": {
+		"itemgroups": [
+			"electronics_store_medium",
+			"electronics_store_mixed"
+		]
+	},
+	"mushrooms_forest": {
+		"itemgroups": [
+			"generic_forest_finds"
+		]
+	},
+	"nails": {
+		"itemgroups": [
+			"debris_urban"
+		]
+	},
+	"pack_sigarrettes": {
+		"itemgroups": [
+			"vending_machine_snacks",
+			"urban_litter",
+			"zombie_loot"
+		]
+	},
+	"painkiller": {
+		"itemgroups": [
+			"zombie_loot",
+			"first_aid"
+		]
+	},
+	"pebble": {
+		"itemgroups": [
+			"generic_forest_finds",
+			"generic_field_finds",
+			"urban_litter",
+			"debris_rock"
+		]
+	},
+	"pine_branch": {
+		"itemgroups": [
+			"generic_forest_finds",
+			"tree_forage"
+		]
+	},
+	"pinecone": {
+		"itemgroups": [
+			"generic_forest_finds"
+		]
+	},
+	"pistol_9mm": {
+		"itemgroups": [
+			"cabinet_general",
+			"test_items",
+			"police_station_locker"
+		]
+	},
 	"pistol_magazine": {
 		"itemgroups": [
-			"mob_loot"
+			"mob_loot",
+			"cabinet_general",
+			"M4A1_gun_ammo",
+			"test_items",
+			"police_station_locker"
 		]
 	},
 	"plank_2x4": {
 		"itemgroups": [
-			"mob_loot"
+			"mob_loot",
+			"destroyed_furniture_medium",
+			"disassembled_furniture_medium",
+			"debris_urban"
+		]
+	},
+	"plant_remnants": {
+		"itemgroups": [
+			"tree_destroyed",
+			"generic_forest_finds",
+			"generic_field_finds"
+		]
+	},
+	"plastic_parts": {
+		"itemgroups": [
+			"electronics_damaged",
+			"urban_litter",
+			"debris_urban",
+			"loot_electronic"
+		]
+	},
+	"pressure_cooker": {
+		"itemgroups": [
+			"electronics_store_medium",
+			"electronics_store_mixed"
+		]
+	},
+	"radio_handheld": {
+		"itemgroups": [
+			"electronics_store_small",
+			"electronics_store_mixed"
+		]
+	},
+	"radio_two_way": {
+		"itemgroups": [
+			"electronics_store_small",
+			"electronics_store_mixed",
+			"police_station_locker"
+		]
+	},
+	"rifle_m4a1": {
+		"itemgroups": [
+			"M4A1_gun_ammo",
+			"police_station_locker"
+		]
+	},
+	"rotten_flesh_chunk": {
+		"itemgroups": [
+			"zombie_loot"
+		]
+	},
+	"rusted_metal_sheets": {
+		"itemgroups": [
+			"debris_urban"
+		]
+	},
+	"scarf": {
+		"itemgroups": [
+			"clothing_general",
+			"zombie_loot"
+		]
+	},
+	"screw": {
+		"itemgroups": [
+			"debris_urban"
 		]
 	},
 	"screwdriver": {
 		"itemgroups": [
-			"kitchen_cupboard"
+			"kitchen_cupboard",
+			"cabinet_general",
+			"electronics_store_small",
+			"electronics_store_mixed"
+		]
+	},
+	"sharp_stone": {
+		"itemgroups": [
+			"test_items",
+			"generic_field_finds"
+		]
+	},
+	"shorts": {
+		"itemgroups": [
+			"clothing_general",
+			"zombie_loot"
 		]
 	},
 	"slice_of_pizza": {
@@ -121,9 +542,61 @@
 			"refridgerator"
 		]
 	},
+	"small_rock": {
+		"itemgroups": [
+			"generic_forest_finds",
+			"generic_field_finds",
+			"debris_rock"
+		]
+	},
+	"small_stick": {
+		"itemgroups": [
+			"generic_forest_finds"
+		]
+	},
+	"socks": {
+		"itemgroups": [
+			"clothing_general",
+			"zombie_loot"
+		]
+	},
+	"stale_bread": {
+		"itemgroups": [
+			"urban_litter"
+		]
+	},
 	"steel_scrap": {
 		"itemgroups": [
-			"mob_loot"
+			"mob_loot",
+			"cabinet_general",
+			"destroyed_furniture_medium",
+			"disassembled_furniture_medium",
+			"debris_urban",
+			"loot_electronic"
+		]
+	},
+	"stick": {
+		"itemgroups": [
+			"destroyed_furniture_medium",
+			"generic_forest_finds",
+			"tree_forage"
+		]
+	},
+	"sweater": {
+		"itemgroups": [
+			"clothing_general",
+			"zombie_loot"
+		]
+	},
+	"syringe": {
+		"itemgroups": [
+			"zombie_loot"
+		]
+	},
+	"toaster": {
+		"itemgroups": [
+			"electronics_store_medium",
+			"electronics_store_mixed"
 		]
 	},
 	"tofu": {
@@ -136,6 +609,12 @@
 			"refridgerator"
 		]
 	},
+	"tshirt": {
+		"itemgroups": [
+			"clothing_general",
+			"zombie_loot"
+		]
+	},
 	"uncooked_meat": {
 		"itemgroups": [
 			"refridgerator"
@@ -144,6 +623,42 @@
 	"vacuum_sealed_fish": {
 		"itemgroups": [
 			"refridgerator"
+		]
+	},
+	"vest_ballistic": {
+		"itemgroups": [
+			"police_station_locker"
+		]
+	},
+	"waistbag": {
+		"itemgroups": [
+			"clothing_general",
+			"zombie_loot"
+		]
+	},
+	"wallet": {
+		"itemgroups": [
+			"zombie_loot"
+		]
+	},
+	"wrist_watch": {
+		"itemgroups": [
+			"zombie_loot"
+		]
+	},
+	"zombie_bone": {
+		"itemgroups": [
+			"zombie_loot"
+		]
+	},
+	"zombie_eye": {
+		"itemgroups": [
+			"zombie_loot"
+		]
+	},
+	"zombie_organ": {
+		"itemgroups": [
+			"zombie_loot"
 		]
 	}
 }

--- a/Mods/Dimensionfall/Items/references.json
+++ b/Mods/Dimensionfall/Items/references.json
@@ -28,6 +28,9 @@
 			"starting_items",
 			"police_station_locker",
 			"first_aid"
+		],
+		"quests": [
+			"quest_holy_crusade_01"
 		]
 	},
 	"battery_small": {
@@ -41,6 +44,9 @@
 	"berries_wild": {
 		"itemgroups": [
 			"generic_forest_finds"
+		],
+		"quests": [
+			"starter_tutorial_00"
 		]
 	},
 	"bird_egg": {
@@ -73,6 +79,9 @@
 			"kitchen_cupboard",
 			"starting_items",
 			"first_aid"
+		],
+		"quests": [
+			"quest_holy_crusade_01"
 		]
 	},
 	"bottle_antidote": {
@@ -80,6 +89,9 @@
 			"kitchen_cupboard",
 			"test_items",
 			"first_aid"
+		],
+		"quests": [
+			"quest_holy_crusade_01"
 		]
 	},
 	"bottle_disinfectant": {
@@ -103,6 +115,9 @@
 			"vending_machine_drinks",
 			"starting_items",
 			"zombie_loot"
+		],
+		"quests": [
+			"quest_holy_crusade_01"
 		]
 	},
 	"bottle_yogurt": {
@@ -173,6 +188,9 @@
 	"canned_food": {
 		"itemgroups": [
 			"kitchen_cupboard"
+		],
+		"quests": [
+			"quest_holy_crusade_01"
 		]
 	},
 	"carrot": {
@@ -210,12 +228,20 @@
 		"itemgroups": [
 			"electronics_store_small",
 			"loot_electronic"
+		],
+		"quests": [
+			"quest_radio_signal_01"
 		]
 	},
 	"coffee_maker": {
 		"itemgroups": [
 			"electronics_store_medium",
 			"electronics_store_mixed"
+		]
+	},
+	"compass": {
+		"quests": [
+			"quest_holy_crusade_01"
 		]
 	},
 	"damaged_concrete_slab": {
@@ -226,6 +252,9 @@
 	"damaged_transmitter": {
 		"itemgroups": [
 			"electronics_damaged"
+		],
+		"quests": [
+			"quest_radio_signal_01"
 		]
 	},
 	"eggs": {
@@ -252,6 +281,9 @@
 			"electronics_store_small",
 			"electronics_store_mixed",
 			"police_station_locker"
+		],
+		"quests": [
+			"quest_holy_crusade_01"
 		]
 	},
 	"flower_wild": {
@@ -360,6 +392,9 @@
 			"test_items",
 			"generic_forest_finds",
 			"tree_forage"
+		],
+		"quests": [
+			"starter_tutorial_00"
 		]
 	},
 	"mailbag": {
@@ -411,6 +446,9 @@
 		"itemgroups": [
 			"zombie_loot",
 			"first_aid"
+		],
+		"quests": [
+			"quest_holy_crusade_01"
 		]
 	},
 	"pebble": {
@@ -446,6 +484,9 @@
 			"M4A1_gun_ammo",
 			"test_items",
 			"police_station_locker"
+		],
+		"quests": [
+			"starter_tutorial_00"
 		]
 	},
 	"plank_2x4": {
@@ -494,6 +535,9 @@
 		"itemgroups": [
 			"M4A1_gun_ammo",
 			"police_station_locker"
+		],
+		"quests": [
+			"starter_tutorial_00"
 		]
 	},
 	"rotten_flesh_chunk": {
@@ -529,6 +573,9 @@
 		"itemgroups": [
 			"test_items",
 			"generic_field_finds"
+		],
+		"quests": [
+			"starter_tutorial_00"
 		]
 	},
 	"shorts": {
@@ -560,6 +607,11 @@
 			"zombie_loot"
 		]
 	},
+	"solar_panel": {
+		"quests": [
+			"quest_radio_signal_01"
+		]
+	},
 	"stale_bread": {
 		"itemgroups": [
 			"urban_litter"
@@ -580,6 +632,11 @@
 			"destroyed_furniture_medium",
 			"generic_forest_finds",
 			"tree_forage"
+		]
+	},
+	"stone_spear": {
+		"quests": [
+			"starter_tutorial_00"
 		]
 	},
 	"sweater": {
@@ -607,6 +664,11 @@
 	"tomato": {
 		"itemgroups": [
 			"refridgerator"
+		]
+	},
+	"transmitter": {
+		"quests": [
+			"quest_radio_signal_01"
 		]
 	},
 	"tshirt": {

--- a/Mods/Dimensionfall/Maps/references.json
+++ b/Mods/Dimensionfall/Maps/references.json
@@ -35,6 +35,9 @@
 	"abandoned_building": {
 		"overmapareas": [
 			"city"
+		],
+		"quests": [
+			"quest_radio_signal_01"
 		]
 	},
 	"city_square": {
@@ -108,6 +111,9 @@
 	"radio_tower": {
 		"overmapareas": [
 			"city"
+		],
+		"quests": [
+			"quest_radio_signal_01"
 		]
 	},
 	"skyscraper": {

--- a/Mods/Dimensionfall/Mobgroups/references.json
+++ b/Mods/Dimensionfall/Mobgroups/references.json
@@ -1,0 +1,8 @@
+{
+	"basic_zombies": {
+		"quests": [
+			"quest_holy_crusade_01",
+			"starter_tutorial_00"
+		]
+	}
+}

--- a/Mods/Dimensionfall/Mobs/references.json
+++ b/Mods/Dimensionfall/Mobs/references.json
@@ -113,6 +113,9 @@
 		],
 		"mobgroups": [
 			"security_robots"
+		],
+		"quests": [
+			"quest_radio_signal_01"
 		]
 	},
 	"heavy_zombie": {

--- a/Mods/Dimensionfall/PlayerAttributes/references.json
+++ b/Mods/Dimensionfall/PlayerAttributes/references.json
@@ -1,3 +1,113 @@
 {
-
+	"food": {
+		"items": [
+			"condensed_milk",
+			"jar_pickles",
+			"bottle_yogurt",
+			"tofu",
+			"lettuce",
+			"tomato",
+			"vacuum_sealed_fish",
+			"slice_of_pizza",
+			"bread",
+			"bag_bacon",
+			"orange",
+			"stale_bread",
+			"bottle_ketchup",
+			"jar_mustard",
+			"jar_olives",
+			"chocolate",
+			"cheese",
+			"butter",
+			"eggs",
+			"carrot",
+			"potato",
+			"apple",
+			"mushrooms_forest",
+			"berries_wild",
+			"bird_egg",
+			"uncooked_meat",
+			"kiwi",
+			"zombie_organ",
+			"zombie_eye",
+			"rotten_flesh_chunk"
+		]
+	},
+	"head_health": {
+		"items": [
+			"bottle_disinfectant",
+			"epipen",
+			"insulin",
+			"painkiller"
+		]
+	},
+	"left_arm_health": {
+		"items": [
+			"bottle_disinfectant",
+			"epipen",
+			"insulin",
+			"painkiller"
+		]
+	},
+	"left_leg_health": {
+		"items": [
+			"bottle_disinfectant",
+			"epipen",
+			"insulin",
+			"painkiller"
+		]
+	},
+	"poison": {
+		"items": [
+			"bottle_antidote",
+			"zombie_organ",
+			"zombie_eye",
+			"rotten_flesh_chunk"
+		]
+	},
+	"right_arm_health": {
+		"items": [
+			"bottle_disinfectant",
+			"epipen",
+			"insulin",
+			"painkiller"
+		]
+	},
+	"right_leg_health": {
+		"items": [
+			"bottle_disinfectant",
+			"epipen",
+			"insulin",
+			"painkiller"
+		]
+	},
+	"torso_health": {
+		"items": [
+			"bottle_disinfectant",
+			"epipen",
+			"insulin",
+			"painkiller"
+		]
+	},
+	"water": {
+		"items": [
+			"condensed_milk",
+			"jar_pickles",
+			"bottle_yogurt",
+			"lettuce",
+			"tomato",
+			"wine_bottle",
+			"orange",
+			"can_soda",
+			"can_energydrink",
+			"eggs",
+			"apple",
+			"berries_wild",
+			"bird_egg",
+			"kiwi",
+			"zombie_organ",
+			"zombie_eye",
+			"rotten_flesh_chunk"
+		]
+	}
 }

--- a/Mods/Dimensionfall/Skills/references.json
+++ b/Mods/Dimensionfall/Skills/references.json
@@ -1,0 +1,22 @@
+{
+	"fabrication": {
+		"items": [
+			"pistol_magazine"
+		]
+	},
+	"handguns": {
+		"items": [
+			"pistol_9mm"
+		]
+	},
+	"rifle": {
+		"items": [
+			"rifle_m4a1"
+		]
+	},
+	"smg": {
+		"items": [
+			"chugunov_mpap"
+		]
+	}
+}

--- a/Mods/Dimensionfall/Skills/references.json
+++ b/Mods/Dimensionfall/Skills/references.json
@@ -1,7 +1,27 @@
 {
+	"bashing": {
+		"items": [
+			"long_stick",
+			"stick"
+		]
+	},
+	"cutting": {
+		"items": [
+			"machete",
+			"stone_spear"
+		]
+	},
+	"electronics": {
+		"items": [
+			"transmitter"
+		]
+	},
 	"fabrication": {
 		"items": [
-			"pistol_magazine"
+			"pistol_magazine",
+			"cutting_board",
+			"rolling_pin",
+			"stone_spear"
 		]
 	},
 	"handguns": {

--- a/Scripts/Gamedata/DItem.gd
+++ b/Scripts/Gamedata/DItem.gd
@@ -17,7 +17,6 @@ var image: String
 var stack_size: int
 var max_stack_size: int
 var two_handed: bool
-var references: Dictionary = {}
 var parent: DItems
 
 # Other properties per type
@@ -391,7 +390,6 @@ func _init(data: Dictionary, myparent: DItems):
 	stack_size = data.get("stack_size", 1)
 	max_stack_size = data.get("max_stack_size", 1)
 	two_handed = data.get("two_handed", false)
-	references = data.get("references", {})
 
 	# Initialize Craft and Magazine subclasses if they exist in data
 	if data.has("Craft"):
@@ -449,8 +447,6 @@ func get_data() -> Dictionary:
 		"max_stack_size": max_stack_size,
 		"two_handed": two_handed
 	}
-	if not references.is_empty():
-		data["references"] = references
 
 	# Add Craft and Magazine data if they exist
 	if craft:
@@ -683,20 +679,6 @@ func delete():
 	# Remove the reference of this item from each skill
 	for skill_id in skill_ids.keys():
 		Gamedata.mods.remove_reference(DMod.ContentType.SKILLS, skill_id, DMod.ContentType.ITEMS, id)
-
-
-# Executes a callable function on each reference of the given type
-# module = name of the mod. for example "core"
-# type = the type of reference we want to handle. For example "itemgroup"
-# callable = a function to execute on each reference ID
-# We will check if data has the [module] and [type] properties and execute the callable on each found ID
-func execute_callable_on_references_of_type(module: String, type: String, callable: Callable):
-	# Check if it contains the specified 'module' and 'type'
-	if references.has(module) and references[module].has(type):
-		# If the type exists, execute the callable on each ID found under this type
-		for ref_id in references[module][type]:
-			callable.call(ref_id)
-
 
 
 # Function to remove all instances of a skill from the item

--- a/Scripts/Gamedata/DItems.gd
+++ b/Scripts/Gamedata/DItems.gd
@@ -23,6 +23,16 @@ func _init(new_mod_id: String) -> void:
 	spritePath = "./Mods/" + mod_id + "/Items/"
 	load_sprites()
 	load_items_from_disk()
+	load_references()
+
+
+# Load references from references.json
+func load_references() -> void:
+	var path = dataPath + "references.json"
+	if FileAccess.file_exists(path):
+		references = Helper.json_helper.load_json_dictionary_file(path)
+	else:
+		references = {}  # Initialize an empty references dictionary if the file doesn't exist
 
 
 # Load all itemdata from disk into memory

--- a/Scripts/ItemEditor.gd
+++ b/Scripts/ItemEditor.gd
@@ -87,7 +87,8 @@ func load_item_data() -> void:
 				 # Set button_pressed to true if contentData has the property
 				child.button_pressed = true 
 	refresh_tab_visibility()
-	references_editor.reference_data = ditem.references
+	# TODO: Update the reference editor to use the DMods references
+	references_editor.reference_data = {}
 
 
 #The editor is closed, destroy the instance

--- a/Scripts/ItemMedicalEditor.gd
+++ b/Scripts/ItemMedicalEditor.gd
@@ -88,7 +88,7 @@ func _get_attributes_from_ui() -> Array:
 
 # Add a new attribute entry to the attributes_container
 func _add_attribute_entry(attribute: Dictionary) -> void:
-	var dattribute: DPlayerAttribute = ditem.parent.playerattributes.by_id(attribute.id)
+	var dattribute: DPlayerAttribute = Gamedata.mods.by_id(ditem.parent.mod_id).playerattributes.by_id(attribute.id)
 	var sprite: Texture = dattribute.sprite
 	var attribute_name = attribute.id
 	var amount = attribute.amount
@@ -156,7 +156,7 @@ func _can_drop_attribute_data(_newpos, data) -> bool:
 		return false
 
 	# Fetch attribute by ID from the Gamedata to ensure it exists and is valid
-	if not ditem.parent.playerattributes.has_id(data["id"]):
+	if not Gamedata.mods.by_id(ditem.parent.mod_id).playerattributes.has_id(data["id"]):
 		return false
 
 	# Check if the attribute ID already exists in the attributes grid
@@ -184,7 +184,7 @@ func _handle_attribute_drop(dropped_data, _newpos) -> void:
 	# dropped_data is a Dictionary that includes an 'id'
 	if dropped_data and "id" in dropped_data:
 		var attribute_id = dropped_data["id"]
-		if not ditem.parent.playerattributes.has_id(attribute_id):
+		if not Gamedata.mods.by_id(ditem.parent.mod_id).playerattributes.has_id(attribute_id):
 			print_debug("No attribute data found for ID: " + attribute_id)
 			return
 		

--- a/Scripts/ItemMedicalEditor.gd
+++ b/Scripts/ItemMedicalEditor.gd
@@ -88,7 +88,7 @@ func _get_attributes_from_ui() -> Array:
 
 # Add a new attribute entry to the attributes_container
 func _add_attribute_entry(attribute: Dictionary) -> void:
-	var dattribute: DPlayerAttribute = Gamedata.mods.by_id("Core").playerattributes.by_id(attribute.id)
+	var dattribute: DPlayerAttribute = ditem.parent.playerattributes.by_id(attribute.id)
 	var sprite: Texture = dattribute.sprite
 	var attribute_name = attribute.id
 	var amount = attribute.amount
@@ -156,7 +156,7 @@ func _can_drop_attribute_data(_newpos, data) -> bool:
 		return false
 
 	# Fetch attribute by ID from the Gamedata to ensure it exists and is valid
-	if not Gamedata.mods.by_id("Core").playerattributes.has_id(data["id"]):
+	if not ditem.parent.playerattributes.has_id(data["id"]):
 		return false
 
 	# Check if the attribute ID already exists in the attributes grid
@@ -184,7 +184,7 @@ func _handle_attribute_drop(dropped_data, _newpos) -> void:
 	# dropped_data is a Dictionary that includes an 'id'
 	if dropped_data and "id" in dropped_data:
 		var attribute_id = dropped_data["id"]
-		if not Gamedata.mods.by_id("Core").playerattributes.has_id(attribute_id):
+		if not ditem.parent.playerattributes.has_id(attribute_id):
 			print_debug("No attribute data found for ID: " + attribute_id)
 			return
 		


### PR DESCRIPTION
The item references were never loaded from disk, so they were not persistent.

This pr fixes that and updates the item's references. Also removes some hardcoded lines that try to access the core mod.