### PR TITLE
Wearableslots

### DIFF
--- a/Mods/Dimensionfall/Itemgroups/Itemgroups.json
+++ b/Mods/Dimensionfall/Itemgroups/Itemgroups.json
@@ -1572,36 +1572,6 @@
 		"id": "starting_items",
 		"items": [
 			{
-				"id": "boots",
-				"max": 1,
-				"min": 1,
-				"probability": 100
-			},
-			{
-				"id": "gloves_leather",
-				"max": 1,
-				"min": 1,
-				"probability": 100
-			},
-			{
-				"id": "hat_baseball",
-				"max": 1,
-				"min": 1,
-				"probability": 100
-			},
-			{
-				"id": "jeans",
-				"max": 1,
-				"min": 1,
-				"probability": 100
-			},
-			{
-				"id": "mailbag",
-				"max": 1,
-				"min": 1,
-				"probability": 100
-			},
-			{
 				"id": "bottle_plastic_water",
 				"max": 1,
 				"min": 1,
@@ -1633,12 +1603,6 @@
 			},
 			{
 				"id": "bottle_antibiotics",
-				"max": 1,
-				"min": 1,
-				"probability": 100
-			},
-			{
-				"id": "jacket",
 				"max": 1,
 				"min": 1,
 				"probability": 100

--- a/Mods/Dimensionfall/Items/references.json
+++ b/Mods/Dimensionfall/Items/references.json
@@ -69,7 +69,6 @@
 		"itemgroups": [
 			"cabinet_general",
 			"clothing_general",
-			"starting_items",
 			"zombie_loot",
 			"police_station_locker"
 		]
@@ -325,7 +324,6 @@
 	"gloves_leather": {
 		"itemgroups": [
 			"clothing_general",
-			"starting_items",
 			"zombie_loot",
 			"police_station_locker"
 		]
@@ -349,7 +347,6 @@
 	"hat_baseball": {
 		"itemgroups": [
 			"clothing_general",
-			"starting_items",
 			"zombie_loot"
 		]
 	},
@@ -366,14 +363,12 @@
 	"jacket": {
 		"itemgroups": [
 			"clothing_general",
-			"starting_items",
 			"zombie_loot"
 		]
 	},
 	"jeans": {
 		"itemgroups": [
 			"clothing_general",
-			"starting_items",
 			"zombie_loot"
 		]
 	},
@@ -423,7 +418,6 @@
 	"mailbag": {
 		"itemgroups": [
 			"clothing_general",
-			"starting_items",
 			"zombie_loot"
 		]
 	},

--- a/Mods/Dimensionfall/Wearableslots/Wearableslots.json
+++ b/Mods/Dimensionfall/Wearableslots/Wearableslots.json
@@ -3,36 +3,42 @@
 		"description": "Holds equipment on your torso",
 		"id": "torso",
 		"name": "Torso",
-		"sprite": "wearableslot_torso_32.png"
+		"sprite": "wearableslot_torso_32.png",
+		"starting_item": "jacket"
 	},
 	{
 		"description": "Holds equipment on your legs",
 		"id": "legs",
 		"name": "Legs",
-		"sprite": "wearableslot_legs_32.png"
+		"sprite": "wearableslot_legs_32.png",
+		"starting_item": "jeans"
 	},
 	{
 		"description": "Holds equipment on your feet",
 		"id": "feet",
 		"name": "Feet",
-		"sprite": "wearableslot_feet_32.png"
+		"sprite": "wearableslot_feet_32.png",
+		"starting_item": "boots"
 	},
 	{
 		"description": "Holds equipment on your hands",
 		"id": "hands",
 		"name": "Hands",
-		"sprite": "wearableslot_hands_32.png"
+		"sprite": "wearableslot_hands_32.png",
+		"starting_item": "gloves_leather"
 	},
 	{
 		"description": "Holds equipment on your head",
 		"id": "head",
 		"name": "Head",
-		"sprite": "wearableslot_head_32.png"
+		"sprite": "wearableslot_head_32.png",
+		"starting_item": "hat_baseball"
 	},
 	{
 		"description": "Holds equipment on your back",
 		"id": "back",
 		"name": "Back",
-		"sprite": "wearableslot_back_32.png"
+		"sprite": "wearableslot_back_32.png",
+		"starting_item": "mailbag"
 	}
 ]

--- a/Scenes/ContentManager/Custom_Editors/Scripts/WearableslotEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/WearableslotEditor.gd
@@ -11,6 +11,8 @@ extends Control
 @export var NameTextEdit: TextEdit = null
 @export var DescriptionTextEdit: TextEdit = null
 @export var slotSelector: Popup = null
+@export var starting_item_text_edit: HBoxContainer = null
+
 
 # This signal will be emitted when the user presses the save button
 # This signal should alert Gamedata that the slot data array should be saved to disk
@@ -40,6 +42,7 @@ func load_slot_data() -> void:
 		NameTextEdit.text = dwearableslot.name
 	if DescriptionTextEdit != null:
 		DescriptionTextEdit.text = dwearableslot.description
+	starting_item_text_edit.set_text(dwearableslot.starting_item)
 
 # The editor is closed, destroy the instance
 # TODO: Check for unsaved changes
@@ -55,6 +58,8 @@ func _on_save_button_button_up() -> void:
 	dwearableslot.name = NameTextEdit.text
 	dwearableslot.description = DescriptionTextEdit.text
 	dwearableslot.sprite = slotImageDisplay.texture
+	dwearableslot.starting_item = starting_item_text_edit.get_text()
+	
 	dwearableslot.save_to_disk()
 	data_changed.emit()
 	olddata = DWearableSlot.new(dwearableslot.get_data().duplicate(true), null)

--- a/Scenes/ContentManager/Custom_Editors/Scripts/WearableslotEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/WearableslotEditor.gd
@@ -31,6 +31,9 @@ var dwearableslot: DWearableSlot = null:
 		olddata = DWearableSlot.new(dwearableslot.get_data().duplicate(true), null)
 
 
+func _ready():
+	set_drop_functions()
+
 # This function updates the form based on the DWearableSlot that has been loaded
 func load_slot_data() -> void:
 	if slotImageDisplay != null and dwearableslot.spriteid:
@@ -74,3 +77,45 @@ func _on_sprite_selector_sprite_selected_ok(clicked_sprite) -> void:
 	var slotTexture: Resource = clicked_sprite.get_texture()
 	slotImageDisplay.texture = slotTexture
 	PathTextLabel.text = slotTexture.resource_path.get_file()
+
+
+# Set the drop funcitons on the required item and item progression controls
+# This enables them to receive drop data
+func set_drop_functions():
+	starting_item_text_edit.drop_function = item_drop
+	starting_item_text_edit.can_drop_function = can_item_drop
+
+
+# Called when the user has successfully dropped data onto the starting_item_text_edit
+# We have to check the dropped_data for the id property
+func item_drop(dropped_data: Dictionary) -> void:
+	# Assuming dropped_data is a Dictionary that includes an 'id'
+	if dropped_data and "id" in dropped_data:
+		var item_id = dropped_data["id"]
+		if not Gamedata.mods.by_id(dropped_data["mod_id"]).items.has_id(item_id):
+			print_debug("No item data found for ID: " + item_id)
+			return
+		starting_item_text_edit.set_text(item_id)
+	else:
+		print_debug("Dropped data does not contain an 'id' key.")
+
+
+func can_item_drop(dropped_data: Dictionary):
+	# Check if the data dictionary has the 'id' property
+	if not dropped_data or not dropped_data.has("id"):
+		return false
+	
+	var ditems: DItems = Gamedata.mods.by_id(dropped_data["mod_id"]).items
+	# Fetch item data by ID from the Gamedata to ensure it exists and is valid
+	if not ditems.has_id(dropped_data["id"]):
+		return false
+
+	var ditem: DItem = ditems.by_id(dropped_data["id"])
+	if not ditem.wearable:
+		return false
+	
+	# The item has to fit in this slot
+	if not ditem.wearable.slot == dwearableslot.id:
+		return false
+	# If all checks pass, return true
+	return true

--- a/Scenes/ContentManager/Custom_Editors/WearableslotEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/WearableslotEditor.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=4 format=3 uid="uid://767oi7u7wkm5"]
+[gd_scene load_steps=5 format=3 uid="uid://767oi7u7wkm5"]
 
 [ext_resource type="Script" path="res://Scenes/ContentManager/Custom_Editors/Scripts/WearableslotEditor.gd" id="1_j4ii6"]
 [ext_resource type="Texture2D" uid="uid://c8ragmxitca47" path="res://Scenes/ContentManager/Mapeditor/Images/emptyTile.png" id="2_8f3xi"]
+[ext_resource type="PackedScene" uid="uid://dsax7il2yggw8" path="res://Scenes/ContentManager/Custom_Widgets/DropEnabledTextEdit.tscn" id="3_14upu"]
 [ext_resource type="PackedScene" uid="uid://d1h1rpwt8f807" path="res://Scenes/ContentManager/Custom_Widgets/Sprite_Selector_Popup.tscn" id="3_qjob6"]
 
-[node name="WearableEditor" type="Control" node_paths=PackedStringArray("slotImageDisplay", "IDTextLabel", "PathTextLabel", "NameTextEdit", "DescriptionTextEdit", "slotSelector")]
+[node name="WearableEditor" type="Control" node_paths=PackedStringArray("slotImageDisplay", "IDTextLabel", "PathTextLabel", "NameTextEdit", "DescriptionTextEdit", "slotSelector", "starting_item_text_edit")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -18,6 +19,7 @@ PathTextLabel = NodePath("VBoxContainer/FormGrid/PathTextLabel")
 NameTextEdit = NodePath("VBoxContainer/FormGrid/NameTextEdit")
 DescriptionTextEdit = NodePath("VBoxContainer/FormGrid/DescriptionTextEdit")
 slotSelector = NodePath("Sprite_selector")
+starting_item_text_edit = NodePath("VBoxContainer/FormGrid/StartingItemDropEnabledTextEdit")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 1
@@ -100,6 +102,16 @@ size_flags_stretch_ratio = 0.9
 focus_previous = NodePath("../NameTextEdit")
 placeholder_text = "Holds equipment on your torso"
 wrap_mode = 1
+
+[node name="StartingItemLabel" type="Label" parent="VBoxContainer/FormGrid"]
+layout_mode = 2
+text = "Starting item"
+
+[node name="StartingItemDropEnabledTextEdit" parent="VBoxContainer/FormGrid" instance=ExtResource("3_14upu")]
+layout_mode = 2
+size_flags_vertical = 1
+tooltip_text = "Drag an item from the item list to the left to select it as a starting item for this slot. The player will start the game with that item in the slot."
+myplaceholdertext = "Drop a starting item for this slot here"
 
 [node name="Sprite_selector" parent="." instance=ExtResource("3_qjob6")]
 visible = false

--- a/Scenes/ContentManager/Custom_Editors/WearableslotEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/WearableslotEditor.tscn
@@ -110,8 +110,10 @@ text = "Starting item"
 [node name="StartingItemDropEnabledTextEdit" parent="VBoxContainer/FormGrid" instance=ExtResource("3_14upu")]
 layout_mode = 2
 size_flags_vertical = 1
-tooltip_text = "Drag an item from the item list to the left to select it as a starting item for this slot. The player will start the game with that item in the slot."
-myplaceholdertext = "Drop a starting item for this slot here"
+tooltip_text = "Drag an item from the item list to the left to select it as a starting item 
+for this slot. The player will start the game with that item in the slot. The 
+item has to be \"wearable\" and have this slot configured as the fitting slot."
+myplaceholdertext = "Drop a starting item for this slot here. It has to fit the slot."
 
 [node name="Sprite_selector" parent="." instance=ExtResource("3_qjob6")]
 visible = false

--- a/Scripts/CtrlInventoryStackedCustom.gd
+++ b/Scripts/CtrlInventoryStackedCustom.gd
@@ -398,6 +398,8 @@ func _populate_inventory_list():
 
 
 func _update_bars(changedItem: InventoryItem, action: String):
+	if not myInventory:
+		return
 	var total_weight = 0
 	var total_volume = 0
 	for item in myInventory.get_children():

--- a/Scripts/Gamedata/DItem.gd
+++ b/Scripts/Gamedata/DItem.gd
@@ -633,6 +633,7 @@ func delete():
 		mod.items.remove_item_from_all_recipes(id)
 		mod.quests.remove_item_from_all_quests(id)
 		mod.furnitures.remove_item_from_all_furniture(id)
+		mod.wearableslots.remove_item_from_all_wearableslot(id)
 	
 	if food and not food.attributes.is_empty():
 		for food_attribute in food.attributes:

--- a/Scripts/Gamedata/DWearableSlot.gd
+++ b/Scripts/Gamedata/DWearableSlot.gd
@@ -7,6 +7,7 @@ extends RefCounted
 #		"description": "Holds equipment on your torso",
 #		"id": "torso",
 #		"name": "Torso",
+#       "starting_item": "boots_fancy",
 #		"references": {
 #			"core": {
 #				"items": [
@@ -25,6 +26,7 @@ var name: String
 var description: String
 var spriteid: String
 var sprite: Texture
+var starting_item: String
 var parent: DWearableSlots
 
 # Constructor to initialize quest properties from a dictionary
@@ -35,6 +37,7 @@ func _init(data: Dictionary, myparent: DWearableSlots):
 	name = data.get("name", "")
 	description = data.get("description", "")
 	spriteid = data.get("sprite", "")
+	starting_item = data.get("starting_item", "")
 
 # Get data function to return a dictionary with all properties
 func get_data() -> Dictionary:
@@ -44,6 +47,8 @@ func get_data() -> Dictionary:
 		"description": description,
 		"sprite": spriteid
 	}
+	if starting_item:
+		data["starting_item"] = starting_item
 	return data
 
 # Method to save any changes to the wearable slot back to disk

--- a/Scripts/Gamedata/DWearableSlots.gd
+++ b/Scripts/Gamedata/DWearableSlots.gd
@@ -98,7 +98,6 @@ func append_new(newwearableslot: DWearableSlot) -> void:
 	save_wearableslots_to_disk()
 
 
-
 func delete_by_id(wearableslotid: String) -> void:
 	wearableslotdict[wearableslotid].delete()
 	wearableslotdict.erase(wearableslotid)
@@ -124,37 +123,14 @@ func sprite_by_file(spritefile: String) -> Texture:
 	return sprites[spritefile]
 
 
-# Removes the reference from the selected wearableslot
-func remove_reference(wearableslotid: String, module: String, type: String, refid: String):
-	var mywearableslot: DWearableSlot = wearableslotdict[wearableslotid]
-	mywearableslot.remove_reference(module, type, refid)
+# Removes the reference of the selected wearableslot
+func remove_reference(wearableslot_id: String):
+	references.erase(wearableslot_id)
+	Gamedata.mods.save_references(self)
 
 
-# Adds a reference to the references list
-# For example, add "grass_field" to references.Core.maps
-# wearableslotid: The id of the wearableslot to add the reference to
-# module: the mod that the entity belongs to, for example "Core"
-# type: The type of entity, for example "maps"
-# refid: The id of the entity to reference, for example "grass_field"
-func add_reference(wearableslotid: String, module: String, type: String, refid: String):
-	var mywearableslot: DWearableSlot = wearableslotdict[wearableslotid]
-	mywearableslot.add_reference(module, type, refid)
-
-
-# Helper function to update references if they have changed.
-# old: an entity id that is present in the old data
-# new: an entity id that is present in the new data
-# refid: The entity that's referenced in old and/or new
-# type: The type of entity that will be referenced
-# Example usage: update_reference(old_wearableslot, new_wearableslot, "furniture", furniture_id)
-# This example will remove furniture_id from the old_wearableslot's references and
-# add the furniture_id to the new_wearableslot's refrences
-func update_reference(old: String, new: String, type: String, refid: String) -> void:
-	if old == new:
-		return  # No change detected, exit early
-
-	# Remove from old group if necessary
-	if old != "":
-		remove_reference(old, "core", type, refid)
-	if new != "":
-		add_reference(new, "core", type, refid)
+# Remove the provided item from all wearableslot
+# This will erase it from starting_item
+func remove_item_from_all_wearableslot(item_id: String):
+	for wearableslot in wearableslotdict.values():
+		wearableslot.remove_item(item_id)

--- a/Scripts/Runtimedata/RWearableSlot.gd
+++ b/Scripts/Runtimedata/RWearableSlot.gd
@@ -9,6 +9,7 @@ extends RefCounted
 #     "id": "torso",
 #     "name": "Torso",
 #     "sprite": "wearableslot_torso_32.png",
+#     "starting_item": "boots_fancy",
 #     "references": {
 #         "core": {
 #             "items": [
@@ -26,6 +27,7 @@ var name: String
 var description: String
 var spriteid: String
 var sprite: Texture
+var starting_item: String
 var parent: RWearableSlots  # Reference to the list containing all runtime wearable slots for this mod
 
 # Constructor to initialize wearable slot properties from a dictionary
@@ -43,6 +45,7 @@ func overwrite_from_dwearableslot(dwearableslot: DWearableSlot) -> void:
 	description = dwearableslot.description
 	spriteid = dwearableslot.spriteid
 	sprite = dwearableslot.sprite
+	starting_item = dwearableslot.starting_item
 
 # Get data function to return a dictionary with all properties
 func get_data() -> Dictionary:
@@ -52,4 +55,6 @@ func get_data() -> Dictionary:
 		"description": description,
 		"sprite": spriteid
 	}
+	if starting_item:
+		data["starting_item"] = starting_item
 	return data

--- a/Scripts/item_manager.gd
+++ b/Scripts/item_manager.gd
@@ -167,21 +167,8 @@ func create_starting_items():
 	
 	# Create starting equipment. The items are not added to the playerInventory, 
 	# only to the equipment slots.
-	#player_equipment.EquipmentItemList["feet"] = playerInventory.create_item("boots")
-	#player_equipment.EquipmentItemList["hands"] = playerInventory.create_item("gloves_leather")
-	#player_equipment.EquipmentItemList["head"] = playerInventory.create_item("hat_baseball")
-	#player_equipment.EquipmentItemList["legs"] = playerInventory.create_item("jeans")
-	#player_equipment.EquipmentItemList["torso"] = playerInventory.create_item("jacket")
-	#player_equipment.EquipmentItemList["back"] = playerInventory.create_item("mailbag")
-#
-	#if playerInventory.get_children() == []:
-		#playerInventory.create_and_add_item("bottle_plastic_water")
-		#playerInventory.create_and_add_item("bread")
-		#playerInventory.create_and_add_item("apple")
-		#playerInventory.create_and_add_item("can_soda")
-		#playerInventory.create_and_add_item("bandage_basic")
-		#playerInventory.create_and_add_item("bottle_antibiotics")
-
+	for wearableslot: RWearableSlot in Runtimedata.wearableslots.get_all().values():
+		player_equipment.EquipmentItemList[wearableslot.id] = playerInventory.create_item(wearableslot.starting_item)
 
 
 # The actual reloading is executed on the item


### PR DESCRIPTION
Fixes #572 

You can specify a starting item to a wearableslot and when the game starts, the item will be inside the wearableslot, worn by the player. Only items that fit the slot may be added. 

In the future we'll either override this with some scenario settings or replace it all together..