### PR TITLE
Allow tacticalmapeditor to select mods

### DIFF
--- a/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/Scripts/EntitiesContainer.gd
+++ b/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/Scripts/EntitiesContainer.gd
@@ -2,8 +2,11 @@ extends VBoxContainer
 
 @export var scrolling_Flow_Container: PackedScene = null
 @export var tileBrush: PackedScene = null
+@export var select_mod_option_button: OptionButton = null
+
 
 var instanced_brushes: Array[Node] = []
+var selected_mod: String = "Core"
 
 signal tile_brush_selection_change(tilebrush: Control)
 var selected_brush: Control:
@@ -12,12 +15,20 @@ var selected_brush: Control:
 		tile_brush_selection_change.emit(selected_brush)
 
 func _ready():
+	# Load the saved selected mod or default to "Core"
+	selected_mod = load_selected_mod()
+
+	# Populate the selectmods OptionButton
+	populate_select_mods()
+
+	# Select the saved mod or default to the first option
+	select_mod_from_saved_or_default()
 	loadMaps()
 
 
 # loop over Gamedata.mods.by_id("Core").maps and creates tilebrushes for each map sprite in the list. 
 func loadMaps():
-	var mapsList: Dictionary = Gamedata.mods.by_id("Dimensionfall").maps.get_all()
+	var mapsList: Dictionary = Gamedata.mods.by_id(selected_mod).maps.get_all()
 	var newTilesList: Control = scrolling_Flow_Container.instantiate()
 	newTilesList.header = "maps"
 	add_child(newTilesList)
@@ -52,3 +63,65 @@ func tilebrush_clicked(tilebrush: Control) -> void:
 func deselect_all_brushes():
 	for child in instanced_brushes:
 		child.set_selected(false)
+
+
+func _on_select_mod_option_button_item_selected(index: int) -> void:
+	selected_mod = select_mod_option_button.get_item_text(index)
+	save_selected_mod()  # Save the newly selected mod
+
+	# Refresh the UI with the new selection
+	Helper.free_all_children(self)
+	instanced_brushes.clear()
+	loadMaps()
+
+# Save the selected mod into the settings.cfg
+func save_selected_mod():
+	var config = ConfigFile.new()
+	var path = "user://settings.cfg"
+
+	# Load existing settings
+	var err = config.load(path)
+	if err != OK and err != ERR_FILE_NOT_FOUND:
+		print("Failed to load settings for saving:", err)
+		return
+
+	# Save the selected mod
+	config.set_value("mapeditor", "selected_mod", selected_mod)
+	if config.save(path) != OK:
+		print("Failed to save selected mod.")
+
+# Load the selected mod from settings.cfg or default to "Core"
+func load_selected_mod() -> String:
+	var config = ConfigFile.new()
+	var path = "user://settings.cfg"
+
+	# Load the config file
+	var err = config.load(path)
+	if err == OK:
+		# Return the saved mod or default to "Core"
+		return config.get_value("mapeditor", "selected_mod", "Core")
+	else:
+		print("Failed to load selected mod. Defaulting to 'Core':", err)
+		return "Core"
+
+
+func select_mod_from_saved_or_default():
+	var mod_index = -1
+	for i in range(select_mod_option_button.get_item_count()):
+		if select_mod_option_button.get_item_text(i) == selected_mod:
+			mod_index = i
+			break
+
+	# If the mod is found, select it; otherwise, default to the first mod
+	if mod_index >= 0:
+		select_mod_option_button.select(mod_index)
+	else:
+		selected_mod = "Core"  # Fallback to "Core"
+		select_mod_option_button.select(0)
+
+
+# Populate available mods in the OptionButton
+func populate_select_mods() -> void:
+	select_mod_option_button.clear()
+	for mod_id in Gamedata.mods.get_all_mod_ids():
+		select_mod_option_button.add_item(mod_id)

--- a/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/TacticalMapEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/TacticalMapEditor.tscn
@@ -154,17 +154,31 @@ tileScene = ExtResource("8_pt28t")
 mapEditor = NodePath("../../../../../..")
 buttonRotateRight = NodePath("../../../../Toolbar/RotateRight")
 
-[node name="EntitiesContainer" type="VBoxContainer" parent="HSplitContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="HSplitContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.2
+
+[node name="SelectModOptionButton" type="OptionButton" parent="HSplitContainer/VBoxContainer"]
+layout_mode = 2
+selected = 0
+item_count = 1
+popup/item_0/text = "Core"
+
+[node name="EntitiesContainer" type="VBoxContainer" parent="HSplitContainer/VBoxContainer" node_paths=PackedStringArray("select_mod_option_button")]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
 size_flags_stretch_ratio = 0.2
 script = ExtResource("9_u8o0i")
 scrolling_Flow_Container = ExtResource("10_lnsqy")
 tileBrush = ExtResource("11_bh5ke")
+select_mod_option_button = NodePath("../SelectModOptionButton")
 
 [connection signal="button_up" from="HSplitContainer/MapeditorContainer/Toolbar/CloseButton" to="." method="_on_close_button_button_up"]
 [connection signal="button_up" from="HSplitContainer/MapeditorContainer/Toolbar/SaveButton" to="HSplitContainer/MapeditorContainer/HBoxContainer/MapScrollWindow/PanWindow/TileGrid" method="save_map_json_file"]
 [connection signal="value_changed" from="HSplitContainer/MapeditorContainer/Toolbar/MapWidth" to="." method="_on_map_width_value_changed"]
 [connection signal="value_changed" from="HSplitContainer/MapeditorContainer/Toolbar/MapHeight" to="." method="_on_map_height_value_changed"]
 [connection signal="pressed" from="HSplitContainer/MapeditorContainer/Toolbar/RotateRight" to="HSplitContainer/MapeditorContainer/HBoxContainer/MapScrollWindow/PanWindow/TileGrid" method="_on_rotate_right_pressed"]
-[connection signal="tile_brush_selection_change" from="HSplitContainer/EntitiesContainer" to="HSplitContainer/MapeditorContainer/HBoxContainer/MapScrollWindow/PanWindow/TileGrid" method="_on_entities_container_tile_brush_selection_change"]
+[connection signal="item_selected" from="HSplitContainer/VBoxContainer/SelectModOptionButton" to="HSplitContainer/VBoxContainer/EntitiesContainer" method="_on_select_mod_option_button_item_selected"]
+[connection signal="tile_brush_selection_change" from="HSplitContainer/VBoxContainer/EntitiesContainer" to="HSplitContainer/MapeditorContainer/HBoxContainer/MapScrollWindow/PanWindow/TileGrid" method="_on_entities_container_tile_brush_selection_change"]


### PR DESCRIPTION
Fixes #594 

The tacticalmap can now be edited using the maps from the mod you select. The selection is saved and loaded, so you  don't have to select the mod every time.