### PR TITLE
Allow placing furniture trough the building menu

### DIFF
--- a/Defaults/Blocks/Materials/construction_ghost_material.tres
+++ b/Defaults/Blocks/Materials/construction_ghost_material.tres
@@ -1,6 +1,6 @@
 [gd_resource type="StandardMaterial3D" load_steps=2 format=3 uid="uid://ot2fpooebty0"]
 
-[ext_resource type="Texture2D" uid="uid://bpjkd6sssic7b" path="res://Mods/Core/Tiles/2.png" id="1_2cd6c"]
+[ext_resource type="Texture2D" uid="uid://bpjkd6sssic7b" path="res://Mods/Dimensionfall/Tiles/2.png" id="1_2cd6c"]
 
 [resource]
 albedo_color = Color(0, 0.768627, 0.768627, 0.545098)

--- a/Scenes/UI/BuildingMenu.tscn
+++ b/Scenes/UI/BuildingMenu.tscn
@@ -1,0 +1,13 @@
+[gd_scene load_steps=2 format=3 uid="uid://clpbtb0qfrk5j"]
+
+[ext_resource type="Script" path="res://Scripts/BuildingMenu.gd" id="1_wcwjs"]
+
+[node name="BuildingMenu" type="GridContainer"]
+offset_right = 186.0
+offset_bottom = 33.0
+columns = 4
+script = ExtResource("1_wcwjs")
+
+[node name="Concrete" type="Button" parent="."]
+layout_mode = 2
+text = "Concrete (2x plank)"

--- a/Scenes/UI/BuildingMenu.tscn
+++ b/Scenes/UI/BuildingMenu.tscn
@@ -2,14 +2,17 @@
 
 [ext_resource type="Script" path="res://Scripts/BuildingMenu.gd" id="1_wcwjs"]
 
-[node name="BuildingMenu" type="GridContainer"]
+[node name="BuildingMenu" type="GridContainer" node_paths=PackedStringArray("construction_option_button")]
 offset_right = 186.0
 offset_bottom = 33.0
 columns = 4
 script = ExtResource("1_wcwjs")
+construction_option_button = NodePath("ConstructionOptionButton")
 
-[node name="Concrete" type="OptionButton" parent="."]
+[node name="ConstructionOptionButton" type="OptionButton" parent="."]
 layout_mode = 2
 selected = 0
 item_count = 1
 popup/item_0/text = "concrete_wall"
+
+[connection signal="item_selected" from="ConstructionOptionButton" to="." method="_on_construction_option_button_item_selected"]

--- a/Scenes/UI/BuildingMenu.tscn
+++ b/Scenes/UI/BuildingMenu.tscn
@@ -8,6 +8,8 @@ offset_bottom = 33.0
 columns = 4
 script = ExtResource("1_wcwjs")
 
-[node name="Concrete" type="Button" parent="."]
+[node name="Concrete" type="OptionButton" parent="."]
 layout_mode = 2
-text = "Concrete (2x plank)"
+selected = 0
+item_count = 1
+popup/item_0/text = "concrete_wall"

--- a/Scripts/BuildManager.gd
+++ b/Scripts/BuildManager.gd
@@ -33,7 +33,7 @@ func cancel_building():
 func _on_hud_construction_chosen(type: String, choice: String):
 	construction_type = type
 	construction_choice = choice
-	update_construction_ghost_material()  # Update the ghost material based on the new selection
+	update_construction_ghost()  # Update the ghost based on the new selection
 	start_building()
 
 
@@ -91,29 +91,36 @@ func _on_build_menu_visibility_change(buildmenu):
 	# Update construction ghost visibility based on build menu visibility
 	set_building_state(buildmenu.is_visible())
 
-func set_building_state(visible: bool):
-	construction_ghost.visible = visible
-	is_building = visible
-	if not visible:
+func set_building_state(isvisible: bool):
+	construction_ghost.visible = isvisible
+	is_building = isvisible
+	if not isvisible:
 		General.is_allowed_to_shoot = true
 
 
 # Updates the material of the construction ghost based on the construction type and choice
-func update_construction_ghost_material():
-	if construction_type == "block":
-		# Reset to the default material for blocks
-		construction_ghost.reset_material_to_default()
-	elif construction_type == "furniture":
+func update_construction_ghost():
+	construction_ghost.reset_to_default() # Resets size, rotation, material, offset
+	if construction_type == "furniture":
 		# Get the RFurniture instance by its ID
 		var rfurniture: RFurniture = Runtimedata.furnitures.by_id(construction_choice)
 		if rfurniture:
 			# Retrieve the sprite material and set it to the construction ghost
 			var furniture_sprite_material = Runtimedata.furnitures.get_shader_material_by_id(construction_choice)
 			construction_ghost.set_material(furniture_sprite_material)
+			construction_ghost.set_mesh_size(calculate_furniture_size(rfurniture))
 		else:
 			print_debug("RFurniture with ID ", construction_choice, " not found. Resetting material.")
-			construction_ghost.reset_material_to_default()
 	else:
 		# Handle unknown construction types by resetting to the default material
 		print_debug("Unknown construction type: ", construction_type, ". Resetting material.")
-		construction_ghost.reset_material_to_default()
+
+
+# Function to calculate the size of the furniture
+func calculate_furniture_size(rfurniture: RFurniture) -> Vector2:
+	var sprite_texture = rfurniture.sprite
+	if sprite_texture:
+		var sprite_width = sprite_texture.get_width() / 100.0 # Convert pixels to meters
+		var sprite_depth = sprite_texture.get_height() / 100.0 # Convert pixels to meters
+		return Vector2(sprite_width, sprite_depth)  # Use height from support shape
+	return Vector2(0.5, 0.5)  # Default size if texture is not set

--- a/Scripts/BuildManager.gd
+++ b/Scripts/BuildManager.gd
@@ -77,8 +77,22 @@ func on_construction_clicked(construction_data: Dictionary):
 			myrotation = 270
 		elif myrotation == 270:
 			myrotation = 90
-		chunk.spawn_furniture({"json": {"id": construction_choice, "rotation": myrotation}, "pos": construction_data.pos})
-		print_debug("Furniture construction chosen. Type: ", construction_type, ", Choice: ", construction_choice, ", construction_data.pos: ", str(construction_data.pos))
+
+		# Translate the position to negate the chunk's `mypos`
+		construction_data.pos -= chunk.mypos
+
+		# Spawn the furniture with the adjusted position
+		chunk.spawn_furniture({
+			"json": {"id": construction_choice, "rotation": myrotation},
+			"pos": construction_data.pos
+		})
+
+		print_debug(
+			"Furniture construction chosen. Type: ", construction_type,
+			", Choice: ", construction_choice,
+			", Adjusted construction_data.pos: ", str(construction_data.pos)
+		)
+
 
 	# Handle unknown construction types
 	else:
@@ -115,6 +129,8 @@ func update_construction_ghost():
 			var furniture_sprite_material = Runtimedata.furnitures.get_shader_material_by_id(construction_choice)
 			construction_ghost.set_material(furniture_sprite_material)
 			construction_ghost.set_mesh_size(calculate_furniture_size(rfurniture))
+			if not rfurniture.edgesnapping == "None":
+				construction_ghost.set_position_offset(rfurniture.edgesnapping)
 		else:
 			print_debug("RFurniture with ID ", construction_choice, " not found. Resetting material.")
 	else:

--- a/Scripts/BuildManager.gd
+++ b/Scripts/BuildManager.gd
@@ -50,6 +50,10 @@ func on_construction_clicked(construction_data: Dictionary):
 		print_debug("Construction type or choice is not set. Aborting.")
 		return
 
+	var chunk: Chunk = LevelGenerator.get_chunk_from_position(construction_data.pos)
+	if not chunk:
+		return
+
 	# Handle block construction
 	if construction_type == "block":
 		var numberofplanks: int = ItemManager.get_accessibleitem_amount("plank_2x4")
@@ -60,14 +64,13 @@ func on_construction_clicked(construction_data: Dictionary):
 		if not ItemManager.remove_resource("plank_2x4", 2, ItemManager.allAccessibleItems):
 			return
 
-		var chunk: Chunk = LevelGenerator.get_chunk_from_position(construction_data.pos)
-		if chunk:
-			var local_position = calculate_local_position(construction_data.pos, chunk.position)
-			chunk.add_block("concrete_00", local_position)
-			print_debug("Block placed at local position: ", local_position, " in chunk at ", chunk.position, " with type ", construction_data.id)
+		var local_position = calculate_local_position(construction_data.pos, chunk.position)
+		chunk.add_block("concrete_00", local_position)
+		print_debug("Block placed at local position: ", local_position, " in chunk at ", chunk.position, " with type ", construction_data.id)
 
 	# Handle furniture construction
 	elif construction_type == "furniture":
+		chunk.spawn_furniture({"json": {"id": construction_choice, "rotation": 0}, "pos": construction_data.pos})
 		print_debug("Furniture construction chosen. Type: ", construction_type, ", Choice: ", construction_choice)
 
 	# Handle unknown construction types

--- a/Scripts/BuildManager.gd
+++ b/Scripts/BuildManager.gd
@@ -70,8 +70,9 @@ func on_construction_clicked(construction_data: Dictionary):
 
 	# Handle furniture construction
 	elif construction_type == "furniture":
+		construction_data.pos.y -= 1
 		chunk.spawn_furniture({"json": {"id": construction_choice, "rotation": 0}, "pos": construction_data.pos})
-		print_debug("Furniture construction chosen. Type: ", construction_type, ", Choice: ", construction_choice)
+		print_debug("Furniture construction chosen. Type: ", construction_type, ", Choice: ", construction_choice, ", construction_data.pos: ", str(construction_data.pos))
 
 	# Handle unknown construction types
 	else:
@@ -104,10 +105,10 @@ func update_construction_ghost_material():
 		construction_ghost.reset_material_to_default()
 	elif construction_type == "furniture":
 		# Get the RFurniture instance by its ID
-		var rfurniture: RFurniture = Runtimedata.rfurnitures.by_id(construction_choice)
+		var rfurniture: RFurniture = Runtimedata.furnitures.by_id(construction_choice)
 		if rfurniture:
 			# Retrieve the sprite material and set it to the construction ghost
-			var furniture_sprite_material = rfurniture.sprite
+			var furniture_sprite_material = Runtimedata.furnitures.get_shader_material_by_id(construction_choice)
 			construction_ghost.set_material(furniture_sprite_material)
 		else:
 			print_debug("RFurniture with ID ", construction_choice, " not found. Resetting material.")

--- a/Scripts/BuildManager.gd
+++ b/Scripts/BuildManager.gd
@@ -43,18 +43,34 @@ func start_building():
 # Connects from the ConstructionGhost.gd script. 
 # Example construction data: {"pos": global_transform.origin}
 func on_construction_clicked(construction_data: Dictionary):
-	var numberofplanks: int = ItemManager.get_accessibleitem_amount("plank_2x4")
-	if numberofplanks < 2:
-		print_debug("tried to construct, but not enough planks")
+	# Ensure construction_type and construction_choice are set
+	if construction_type == "" or construction_choice == "":
+		print_debug("Construction type or choice is not set. Aborting.")
 		return
+
+	# Handle block construction
+	if construction_type == "block":
+		var numberofplanks: int = ItemManager.get_accessibleitem_amount("plank_2x4")
+		if numberofplanks < 2:
+			print_debug("Tried to construct, but not enough planks")
+			return
 		
-	if not ItemManager.remove_resource("plank_2x4",2, ItemManager.allAccessibleItems):
-		return
-	var chunk: Chunk = LevelGenerator.get_chunk_from_position(construction_data.pos)
-	if chunk:
-		var local_position = calculate_local_position(construction_data.pos, chunk.position)
-		chunk.add_block("concrete_00", local_position)
-		print_debug("Block placed at local position: ", local_position, " in chunk at ", chunk.position, " with type ", construction_data.id)
+		if not ItemManager.remove_resource("plank_2x4", 2, ItemManager.allAccessibleItems):
+			return
+
+		var chunk: Chunk = LevelGenerator.get_chunk_from_position(construction_data.pos)
+		if chunk:
+			var local_position = calculate_local_position(construction_data.pos, chunk.position)
+			chunk.add_block("concrete_00", local_position)
+			print_debug("Block placed at local position: ", local_position, " in chunk at ", chunk.position, " with type ", construction_data.id)
+
+	# Handle furniture construction
+	elif construction_type == "furniture":
+		print_debug("Furniture construction chosen. Type: ", construction_type, ", Choice: ", construction_choice)
+
+	# Handle unknown construction types
+	else:
+		print_debug("Unknown construction type: ", construction_type)
 
 
 func calculate_local_position(global_pos: Vector3, chunk_pos: Vector3) -> Vector3:

--- a/Scripts/BuildManager.gd
+++ b/Scripts/BuildManager.gd
@@ -71,7 +71,13 @@ func on_construction_clicked(construction_data: Dictionary):
 	# Handle furniture construction
 	elif construction_type == "furniture":
 		construction_data.pos.y -= 1
-		chunk.spawn_furniture({"json": {"id": construction_choice, "rotation": 0}, "pos": construction_data.pos})
+		# Because Godot can be strange with rotation sometimes we have to translate the rotation
+		var myrotation = construction_data.rotation
+		if myrotation == 90:
+			myrotation = 270
+		elif myrotation == 270:
+			myrotation = 90
+		chunk.spawn_furniture({"json": {"id": construction_choice, "rotation": myrotation}, "pos": construction_data.pos})
 		print_debug("Furniture construction chosen. Type: ", construction_type, ", Choice: ", construction_choice, ", construction_data.pos: ", str(construction_data.pos))
 
 	# Handle unknown construction types

--- a/Scripts/BuildManager.gd
+++ b/Scripts/BuildManager.gd
@@ -33,7 +33,9 @@ func cancel_building():
 func _on_hud_construction_chosen(type: String, choice: String):
 	construction_type = type
 	construction_choice = choice
+	update_construction_ghost_material()  # Update the ghost material based on the new selection
 	start_building()
+
 
 func start_building():
 	is_building = true
@@ -90,3 +92,24 @@ func set_building_state(visible: bool):
 	is_building = visible
 	if not visible:
 		General.is_allowed_to_shoot = true
+
+
+# Updates the material of the construction ghost based on the construction type and choice
+func update_construction_ghost_material():
+	if construction_type == "block":
+		# Reset to the default material for blocks
+		construction_ghost.reset_material_to_default()
+	elif construction_type == "furniture":
+		# Get the RFurniture instance by its ID
+		var rfurniture: RFurniture = Runtimedata.rfurnitures.by_id(construction_choice)
+		if rfurniture:
+			# Retrieve the sprite material and set it to the construction ghost
+			var furniture_sprite_material = rfurniture.sprite
+			construction_ghost.set_material(furniture_sprite_material)
+		else:
+			print_debug("RFurniture with ID ", construction_choice, " not found. Resetting material.")
+			construction_ghost.reset_material_to_default()
+	else:
+		# Handle unknown construction types by resetting to the default material
+		print_debug("Unknown construction type: ", construction_type, ". Resetting material.")
+		construction_ghost.reset_material_to_default()

--- a/Scripts/BuildingMenu.gd
+++ b/Scripts/BuildingMenu.gd
@@ -1,0 +1,11 @@
+extends GridContainer
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(_delta: float) -> void:
+	pass

--- a/Scripts/BuildingMenu.gd
+++ b/Scripts/BuildingMenu.gd
@@ -4,8 +4,6 @@ extends GridContainer
 var is_building_menu_open = false
 @export var construction_option_button: OptionButton = null
 
-signal construction_chosen(type: String, choice: String)
-
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	pass # Replace with function body.
@@ -34,6 +32,6 @@ func _on_construction_option_button_item_selected(_index: int) -> void:
 
 	# Determine the type and emit the signal
 	if selected_text == "concrete_wall":
-		construction_chosen.emit("block", "concrete_wall")
+		Helper.signal_broker.construction_chosen.emit("block", "concrete_wall")
 	else:
-		construction_chosen.emit("furniture", selected_text)
+		Helper.signal_broker.construction_chosen.emit("furniture", selected_text)

--- a/Scripts/BuildingMenu.gd
+++ b/Scripts/BuildingMenu.gd
@@ -6,7 +6,7 @@ var is_building_menu_open = false
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	pass # Replace with function body.
+	populate_optionbutton()
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.

--- a/Scripts/BuildingMenu.gd
+++ b/Scripts/BuildingMenu.gd
@@ -1,6 +1,9 @@
 extends GridContainer
 
 
+var is_building_menu_open = false
+signal construction_chosen
+
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	pass # Replace with function body.
@@ -9,3 +12,7 @@ func _ready() -> void:
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(_delta: float) -> void:
 	pass
+
+
+func _on_concrete_button_down():
+	construction_chosen.emit("concrete_wall")

--- a/Scripts/BuildingMenu.gd
+++ b/Scripts/BuildingMenu.gd
@@ -2,7 +2,9 @@ extends GridContainer
 
 
 var is_building_menu_open = false
-signal construction_chosen
+@export var construction_option_button: OptionButton = null
+
+signal construction_chosen(type: String, choice: String)
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
@@ -14,5 +16,24 @@ func _process(_delta: float) -> void:
 	pass
 
 
-func _on_concrete_button_down():
-	construction_chosen.emit("concrete_wall")
+func populate_optionbutton():
+	# Clear the existing options while preserving the first option
+	construction_option_button.clear()
+	construction_option_button.add_item("concrete_wall", 0)  # First option remains concrete_wall
+
+	# Get constructable furnitures and add their IDs to the option button
+	var rfurnitures: Array[RFurniture] = Runtimedata.furnitures.get_constructable_furnitures()
+	for rfurniture in rfurnitures:
+		construction_option_button.add_item(rfurniture.id)
+
+
+func _on_construction_option_button_item_selected(_index: int) -> void:
+	# Get the selected option from the OptionButton
+	var selected_value = construction_option_button.get_selected_id()
+	var selected_text = construction_option_button.get_item_text(selected_value)
+
+	# Determine the type and emit the signal
+	if selected_text == "concrete_wall":
+		construction_chosen.emit("block", "concrete_wall")
+	else:
+		construction_chosen.emit("furniture", selected_text)

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -170,7 +170,6 @@ func process_level_data() -> Dictionary:
 	return processed_leveldata
 
 
-
 # Creates a dictionary of all block positions with a local x,y and z position
 # This function works with new mapdata
 func create_block_position_dictionary_new_arraymesh() -> Dictionary:
@@ -1393,3 +1392,12 @@ func rotate_level_clockwise(level_data: Array) -> Array:
 				new_level_data[new_index]["furniture"]["rotation"] = (furniture_rotation + 90) % 360
 
 	return new_level_data
+
+
+# Spawns a furniture onto the chunk. 
+# furniture_data example: {"json": {"id": "kitchen_cupboard", "rotation": 0}, "pos": Vector3(12,2,189)}
+func spawn_furniture(furniture_data: Dictionary):
+	if not furniture_data.has("json") or not furniture_data.has("pos"):
+		print_debug("Invalid data structure. Expected keys: 'json', 'pos'.")
+		return
+	furniture_static_spawner.spawn_furniture(furniture_data)

--- a/Scripts/ConstructionGhost.gd
+++ b/Scripts/ConstructionGhost.gd
@@ -1,9 +1,13 @@
 extends MeshInstance3D
 
+# This script belongs to the ConstructionGhost node in the level_generation.tscn scene
+# This script controls the constructionghost for the player so it will aid him in constructing something
+
 # Reference to the player node
 @export var player: Node3D
 @export var sceneCam: Camera3D
 @export var buildmanager: Node3D
+const CONSTRUCTION_GHOST_MATERIAL: Material = preload("res://Defaults/Blocks/Materials/construction_ghost_material.tres")
 
 # Settings
 var grid_size = 1.0
@@ -65,3 +69,13 @@ func _input(event):
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
 		construction_data = {"pos": global_transform.origin}
 		construction_clicked.emit(construction_data)
+
+
+# Sets the material of the ConstructionGhost
+func set_material(new_material: Material) -> void:
+	if mesh:
+		mesh.surface_set_material(0, new_material)  # Assuming the ghost mesh has a single surface
+
+# Resets the material to the default CONSTRUCTION_GHOST_MATERIAL
+func reset_material_to_default() -> void:
+	set_material(CONSTRUCTION_GHOST_MATERIAL)

--- a/Scripts/ConstructionGhost.gd
+++ b/Scripts/ConstructionGhost.gd
@@ -20,6 +20,7 @@ var construction_data: Dictionary
 # Offset for the ConstructionGhost's position
 var position_offset: Vector3 = Vector3.ZERO
 var has_obstacle: bool = false # Tracks whether there is an obstacle
+var current_rotation: int = 0
 
 signal construction_clicked(data: Dictionary)
 
@@ -72,12 +73,21 @@ func get_mouse_3d_position() -> Vector3:
 
 # Input handling to check for obstacles and other criteria before emitting the signal
 func _input(event):
-	if !visible or has_obstacle:
-		#print_debug("has_obstacle = " + str(has_obstacle))
+	if not visible:
 		return
+
+	# Handle left mouse button click for placing construction
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
-		construction_data = {"pos": global_transform.origin}
+		if has_obstacle:
+			return
+		construction_data = {"pos": global_transform.origin, "rotation": current_rotation}
 		construction_clicked.emit(construction_data)
+	
+	# Handle "r" key press for rotating the construction ghost
+	if event is InputEventKey and event.is_pressed() and event.keycode == KEY_R:
+		# Increment the current rotation by 90 degrees
+		var new_rotation = (current_rotation + 90) % 360
+		set_mesh_rotation(new_rotation)
 
 
 # Sets the material of the ConstructionGhost
@@ -143,7 +153,8 @@ func reset_position_offset_to_default() -> void:
 # Sets the rotation of the ConstructionGhost mesh
 func set_mesh_rotation(myrotation: int) -> void:
 	# Set the rotation offset to the desired value
-	rotation.y = myrotation
+	current_rotation = myrotation
+	rotation_degrees.y = myrotation
 
 # Resets the rotation of the ConstructionGhost mesh to the default (no rotation)
 func reset_rotation_to_default() -> void:

--- a/Scripts/ConstructionGhost.gd
+++ b/Scripts/ConstructionGhost.gd
@@ -14,6 +14,8 @@ var grid_size = 1.0
 var y_offset = 0.0  # Offset relative to the player's position in the Y-axis
 var build_range = 5.0  # Maximum build range from the player
 var construction_data: Dictionary
+# Offset for the ConstructionGhost's position
+var position_offset: Vector3 = Vector3.ZERO
 
 signal construction_clicked(data: Dictionary)
 
@@ -48,8 +50,8 @@ func _process(_delta):
 	var snapped_z = round(mouse_position.z / grid_size) * grid_size
 	var snapped_y = round(mouse_position.y / grid_size) * grid_size
 	
-	# Update the position of the constructionghost
-	global_transform.origin = Vector3(snapped_x, snapped_y, snapped_z)
+	# Update the position of the construction ghost with the offset applied
+	global_transform.origin = Vector3(snapped_x, snapped_y, snapped_z) + position_offset
 
 
 # Calculate the 3D position based on the mouse's 2D position and the player's Y offset
@@ -79,3 +81,64 @@ func set_material(new_material: Material) -> void:
 # Resets the material to the default CONSTRUCTION_GHOST_MATERIAL
 func reset_material_to_default() -> void:
 	set_material(CONSTRUCTION_GHOST_MATERIAL)
+
+
+# Sets the size of the ConstructionGhost mesh, which is a PlaneMesh
+func set_mesh_size(size: Vector2) -> void:
+	if mesh:
+		mesh.set_size = size
+
+# Resets the size of the ConstructionGhost mesh to the default size (Vector2(1, 1))
+func reset_mesh_size_to_default() -> void:
+	set_mesh_size(Vector2(1, 1))
+
+
+# Applies edge snapping and updates the position offset
+func _apply_edge_snapping(direction: String) -> Vector3:
+	# Block size, each block is 1x1 meter
+	var block_size = Vector3(1.0, 1.0, 1.0)
+	var offset = Vector3.ZERO
+
+	# Retrieve the furniture size from the mesh
+	var furniture_size = mesh.size if mesh else Vector3.ONE
+
+	# Adjust offset based on the edge-snapping direction
+	match direction:
+		"North":
+			offset.z -= block_size.z / 2 - furniture_size.z / 2
+		"South":
+			offset.z += block_size.z / 2 - furniture_size.z / 2
+		"East":
+			offset.x += block_size.x / 2 - furniture_size.x / 2
+		"West":
+			offset.x -= block_size.x / 2 - furniture_size.x / 2
+		_:
+			pass  # No adjustment for undefined directions
+
+	return offset
+
+
+# Sets the position offset of the ConstructionGhost
+func set_position_offset(edge_snapping_direction: String = "") -> void:
+	# Reset the position offset
+	position_offset = Vector3.ZERO
+
+	# Apply edge snapping if direction is provided
+	if edge_snapping_direction != "":
+		position_offset += _apply_edge_snapping(edge_snapping_direction)
+
+
+# Resets the position offset of the ConstructionGhost
+func reset_position_offset_to_default() -> void:
+	# Reset the offset to zero (default)
+	position_offset = Vector3.ZERO
+
+# Sets the rotation of the ConstructionGhost mesh
+func set_mesh_rotation(myrotation: int) -> void:
+	# Set the rotation offset to the desired value
+	rotation.y = myrotation
+
+# Resets the rotation of the ConstructionGhost mesh to the default (no rotation)
+func reset_rotation_to_default() -> void:
+	# Reset the rotation to 0
+	set_mesh_rotation(0)

--- a/Scripts/ConstructionGhost.gd
+++ b/Scripts/ConstructionGhost.gd
@@ -56,7 +56,7 @@ func _process(_delta):
 	
 	# Update the position of the construction ghost with the offset applied
 	global_transform.origin = Vector3(snapped_x, snapped_y, snapped_z) + position_offset
-	construction_ghost_area_3d.global_transform.origin = Vector3(snapped_x, snapped_y, snapped_z)
+	construction_ghost_area_3d.global_transform.origin = Vector3(snapped_x, snapped_y+0.5, snapped_z)
 
 
 # Calculate the 3D position based on the mouse's 2D position and the player's Y offset
@@ -73,6 +73,7 @@ func get_mouse_3d_position() -> Vector3:
 # Input handling to check for obstacles and other criteria before emitting the signal
 func _input(event):
 	if !visible or has_obstacle:
+		#print_debug("has_obstacle = " + str(has_obstacle))
 		return
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
 		construction_data = {"pos": global_transform.origin}

--- a/Scripts/ConstructionGhost.gd
+++ b/Scripts/ConstructionGhost.gd
@@ -63,5 +63,5 @@ func _input(event):
 	if !visible:
 		return
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
-		construction_data = {"pos": global_transform.origin, "id": "concrete_00"}
+		construction_data = {"pos": global_transform.origin}
 		construction_clicked.emit(construction_data)

--- a/Scripts/ConstructionGhost.gd
+++ b/Scripts/ConstructionGhost.gd
@@ -93,7 +93,7 @@ func reset_material_to_default() -> void:
 # Sets the size of the ConstructionGhost mesh, which is a PlaneMesh
 func set_mesh_size(size: Vector2) -> void:
 	if mesh:
-		mesh.set_size = size
+		mesh.set_size(size)
 
 # Resets the size of the ConstructionGhost mesh to the default size (Vector2(1, 1))
 func reset_mesh_size_to_default() -> void:
@@ -163,3 +163,9 @@ func _on_construction_ghost_area_3d_body_exited(body: Node3D) -> void:
 	if construction_ghost_area_3d.get_overlapping_bodies().size() == 0:
 		has_obstacle = false
 		print_debug("Obstacle cleared: ", body.name)
+
+func reset_to_default():
+	reset_rotation_to_default()
+	reset_position_offset_to_default()
+	reset_mesh_size_to_default()
+	reset_material_to_default()

--- a/Scripts/EscapeMenu.gd
+++ b/Scripts/EscapeMenu.gd
@@ -18,8 +18,6 @@ extends Control
 @export var quest_window: Control = null
 
 
-
-
 # A boolean variable used in an "if" statement to check if the game is paused or not.
 var game_paused: bool = false
 

--- a/Scripts/FurnitureStaticSpawner.gd
+++ b/Scripts/FurnitureStaticSpawner.gd
@@ -29,6 +29,7 @@ func _ready():
 
 
 # Function to spawn a FurnitureStaticSrv at a given position with given furniture data
+# furniture_data example: {"json": {"id": "kitchen_cupboard", "rotation": 0}, "pos": Vector3(12,2,189)}
 func spawn_furniture(furniture_data: Dictionary) -> void:
 	# Get the position using the helper function
 	var myposition: Vector3

--- a/Scripts/Helper/signal_broker.gd
+++ b/Scripts/Helper/signal_broker.gd
@@ -16,6 +16,11 @@ signal inventory_window_visibility_changed(inventoryWindow: Control)
 # Nodes can use this signal to interrupt actions
 signal build_window_visibility_changed(buildWindow: Control)
 
+# Emitted when the user selects an option in the BuildingMenu.tscn scene
+# type: One of "block" or "furniture". Choice: can be "concrete_wall" or some furniture id
+@warning_ignore("unused_signal")
+signal construction_chosen(type: String, choice: String)
+
 # Signalled when an items were used
 # It can be one or more items. It's up to the receiver to figure it out
 @warning_ignore("unused_signal")

--- a/Scripts/Runtimedata/RFurniture.gd
+++ b/Scripts/Runtimedata/RFurniture.gd
@@ -268,5 +268,5 @@ func get_crafting_items() -> Array:
 	return crafting.get_items() if crafting else []
 
 # Returns the list of items from construction
-func get_construction_items() -> Array:
-	return construction.get_items() if construction else []
+func get_construction_items() -> Dictionary:
+	return construction.get_items() if construction else {}

--- a/Scripts/Runtimedata/RFurnitures.gd
+++ b/Scripts/Runtimedata/RFurnitures.gd
@@ -127,3 +127,15 @@ func _on_game_ended():
 
 func is_moveable(id: String) -> bool:
 	return by_id(id).moveable
+
+
+# Returns a list of all RFurniture instances that have construction items
+func get_constructable_furnitures() -> Array[RFurniture]:
+	var constructable_furnitures: Array[RFurniture] = []
+	
+	for furniture in furnituredict.values():
+		# Check if the furniture has construction items
+		if not furniture.get_construction_items().is_empty():
+			constructable_furnitures.append(furniture)
+	
+	return constructable_furnitures

--- a/Scripts/hud.gd
+++ b/Scripts/hud.gd
@@ -29,14 +29,8 @@ var progress_bar_timer_max_time : float
 
 var is_progress_bar_well_progressing_i_guess = false
 
-signal construction_chosen
-
-
 
 @export var item_protoset : ItemProtoset
-
-func test():
-	print("TESTING 123 123!")
 	
 func _process(_delta):
 	if is_progress_bar_well_progressing_i_guess:
@@ -90,10 +84,6 @@ func _input(event):
 
 func _on_player_update_stamina_hud(stamina):
 	get_node(stamina_HUD).text = str(round(stamina)) + "%"
-
-
-func _on_concrete_button_down():
-	construction_chosen.emit("concrete_wall")
 
 
 func start_progress_bar(time : float):

--- a/hud.tscn
+++ b/hud.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=19 format=3 uid="uid://clhj525tmme3k"]
+[gd_scene load_steps=20 format=3 uid="uid://clhj525tmme3k"]
 
 [ext_resource type="FontFile" uid="uid://chm7lbcdeyo0h" path="res://Roboto-Bold.ttf" id="1_pxloi"]
 [ext_resource type="Script" path="res://Scripts/hud.gd" id="1_s3xoj"]
@@ -8,6 +8,7 @@
 [ext_resource type="Texture2D" uid="uid://dcgwgmsmi7mjn" path="res://Textures/bar_border.png" id="3_y43f5"]
 [ext_resource type="PackedScene" uid="uid://b6ooia1084wfx" path="res://Scenes/UI/AttributesWindow.tscn" id="6_6e87o"]
 [ext_resource type="PackedScene" uid="uid://drjw0yaxf8x1p" path="res://Scenes/UI/QuestTrackerUI.tscn" id="7_bbed4"]
+[ext_resource type="PackedScene" uid="uid://clpbtb0qfrk5j" path="res://Scenes/UI/BuildingMenu.tscn" id="9_v36fg"]
 [ext_resource type="PackedScene" uid="uid://sewnt37ji4s1" path="res://Scenes/UI/FurnitureWindow.tscn" id="11_40vt2"]
 [ext_resource type="PackedScene" uid="uid://bxyvtsslfr7kt" path="res://Scenes/UI/CraftingMenu.tscn" id="13_wjtvq"]
 [ext_resource type="PackedScene" uid="uid://cgxw4cu430nst" path="res://Scenes/UI/CharacterWindow.tscn" id="17_2f357"]
@@ -155,15 +156,8 @@ theme_override_font_sizes/font_size = 49
 text = "11:20"
 vertical_alignment = 1
 
-[node name="BuildingMenu" type="GridContainer" parent="."]
+[node name="BuildingMenu" parent="." instance=ExtResource("9_v36fg")]
 visible = false
-offset_right = 186.0
-offset_bottom = 33.0
-columns = 4
-
-[node name="Concrete" type="Button" parent="BuildingMenu"]
-layout_mode = 2
-text = "Concrete (2x plank)"
 
 [node name="CraftingMenu" parent="." instance=ExtResource("13_wjtvq")]
 visible = false
@@ -221,4 +215,3 @@ visible = false
 [connection signal="timeout" from="ProgressBar/ProgressBarTimer" to="." method="_on_progress_bar_timer_timeout"]
 [connection signal="mouse_entered" from="OutsideOfHUD" to="OutsideOfHUD" method="_on_mouse_entered"]
 [connection signal="mouse_exited" from="OutsideOfHUD" to="OutsideOfHUD" method="_on_mouse_exited"]
-[connection signal="button_down" from="BuildingMenu/Concrete" to="." method="_on_concrete_button_down"]

--- a/level_generation.tscn
+++ b/level_generation.tscn
@@ -267,4 +267,3 @@ transform = Transform3D(-0.946576, 0, -0.32248, 0, 1, 0, 0.32248, 0, -0.946576, 
 [connection signal="area_exited" from="TacticalMap/Entities/Player/ItemDetector" to="TacticalMap/Entities/Player/ItemDetector" method="_on_area_exited"]
 [connection signal="body_shape_entered" from="TacticalMap/Entities/Player/ItemDetector" to="TacticalMap/Entities/Player/ItemDetector" method="_on_body_shape_entered"]
 [connection signal="body_shape_exited" from="TacticalMap/Entities/Player/ItemDetector" to="TacticalMap/Entities/Player/ItemDetector" method="_on_body_shape_exited"]
-[connection signal="construction_chosen" from="HUD" to="TacticalMap/BuildManager" method="_on_hud_construction_chosen"]

--- a/level_generation.tscn
+++ b/level_generation.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=34 format=3 uid="uid://drl78uuphij1l"]
+[gd_scene load_steps=35 format=3 uid="uid://drl78uuphij1l"]
 
 [ext_resource type="Script" path="res://LevelGenerator.gd" id="1_i8qa4"]
 [ext_resource type="Script" path="res://LevelManager.gd" id="2_gm6x7"]
@@ -34,6 +34,8 @@ reflected_light_source = 1
 [sub_resource type="PlaneMesh" id="PlaneMesh_usfn3"]
 material = ExtResource("4_ujcgp")
 size = Vector2(1, 1)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_qial8"]
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_7gsdb"]
 albedo_color = Color(0, 1, 0, 1)
@@ -94,7 +96,7 @@ construction_ghost = NodePath("ConstructionGhost")
 LevelGenerator = NodePath("../LevelGenerator")
 hud = NodePath("../../HUD")
 
-[node name="ConstructionGhost" type="MeshInstance3D" parent="TacticalMap/BuildManager" node_paths=PackedStringArray("player", "sceneCam", "buildmanager")]
+[node name="ConstructionGhost" type="MeshInstance3D" parent="TacticalMap/BuildManager" node_paths=PackedStringArray("player", "sceneCam", "buildmanager", "construction_ghost_area_3d", "construction_ghost_collision_shape_3d")]
 editor_description = "Visualizes the construction of blocks and slopes for the player"
 visible = false
 cast_shadow = 0
@@ -103,6 +105,14 @@ script = ExtResource("5_iwiv4")
 player = NodePath("../../Entities/Player")
 sceneCam = NodePath("../../Entities/Player/Camera3D")
 buildmanager = NodePath("..")
+construction_ghost_area_3d = NodePath("../ConstructionGhostArea3D")
+construction_ghost_collision_shape_3d = NodePath("../ConstructionGhostArea3D/ConstructionGhostCollisionShape3D")
+
+[node name="ConstructionGhostArea3D" type="Area3D" parent="TacticalMap/BuildManager"]
+collision_mask = 255
+
+[node name="ConstructionGhostCollisionShape3D" type="CollisionShape3D" parent="TacticalMap/BuildManager/ConstructionGhostArea3D"]
+shape = SubResource("BoxShape3D_qial8")
 
 [node name="Entities" type="Node3D" parent="TacticalMap"]
 
@@ -260,6 +270,8 @@ bus = &"Music"
 [node name="TestCamera" type="Camera3D" parent="."]
 transform = Transform3D(-0.946576, 0, -0.32248, 0, 1, 0, 0.32248, 0, -0.946576, -20.8475, 0.21176, -31.9964)
 
+[connection signal="body_entered" from="TacticalMap/BuildManager/ConstructionGhostArea3D" to="TacticalMap/BuildManager/ConstructionGhost" method="_on_construction_ghost_area_3d_body_entered"]
+[connection signal="body_exited" from="TacticalMap/BuildManager/ConstructionGhostArea3D" to="TacticalMap/BuildManager/ConstructionGhost" method="_on_construction_ghost_area_3d_body_exited"]
 [connection signal="update_stamina_HUD" from="TacticalMap/Entities/Player" to="HUD" method="_on_player_update_stamina_hud"]
 [connection signal="ammo_changed" from="TacticalMap/Entities/Player/Sprite3D2/EquippedRight" to="HUD" method="_on_shooting_ammo_changed"]
 [connection signal="ammo_changed" from="TacticalMap/Entities/Player/Sprite3D2/EquippedLeft" to="HUD" method="_on_shooting_ammo_changed"]

--- a/level_generation.tscn
+++ b/level_generation.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=33 format=3 uid="uid://drl78uuphij1l"]
+[gd_scene load_steps=34 format=3 uid="uid://drl78uuphij1l"]
 
 [ext_resource type="Script" path="res://LevelGenerator.gd" id="1_i8qa4"]
 [ext_resource type="Script" path="res://LevelManager.gd" id="2_gm6x7"]
 [ext_resource type="PackedScene" path="res://day_night.tscn" id="3_0lu7f"]
+[ext_resource type="Material" uid="uid://ot2fpooebty0" path="res://Defaults/Blocks/Materials/construction_ghost_material.tres" id="4_ujcgp"]
 [ext_resource type="Script" path="res://Scripts/ConstructionGhost.gd" id="5_iwiv4"]
 [ext_resource type="Script" path="res://Scripts/BuildManager.gd" id="6_y7rk5"]
 [ext_resource type="Texture2D" uid="uid://d33h00t0fl7x" path="res://Defaults/Player/VestDude01.png" id="7_jr4x1"]
@@ -31,6 +32,7 @@ ambient_light_energy = 0.0
 reflected_light_source = 1
 
 [sub_resource type="PlaneMesh" id="PlaneMesh_usfn3"]
+material = ExtResource("4_ujcgp")
 size = Vector2(1, 1)
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_7gsdb"]

--- a/level_generation.tscn
+++ b/level_generation.tscn
@@ -109,7 +109,7 @@ construction_ghost_area_3d = NodePath("../ConstructionGhostArea3D")
 construction_ghost_collision_shape_3d = NodePath("../ConstructionGhostArea3D/ConstructionGhostCollisionShape3D")
 
 [node name="ConstructionGhostArea3D" type="Area3D" parent="TacticalMap/BuildManager"]
-collision_mask = 255
+collision_mask = 191
 
 [node name="ConstructionGhostCollisionShape3D" type="CollisionShape3D" parent="TacticalMap/BuildManager/ConstructionGhostArea3D"]
 shape = SubResource("BoxShape3D_qial8")
@@ -205,6 +205,7 @@ reload_audio_player = NodePath("../../Shooting/ReloadAudio")
 
 [node name="MeleeRange" type="Area3D" parent="TacticalMap/Entities/Player/Sprite3D2"]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, -0.277026)
+collision_layer = 0
 collision_mask = 14
 
 [node name="MeleeCollisionShape3D" type="CollisionShape3D" parent="TacticalMap/Entities/Player/Sprite3D2/MeleeRange"]


### PR DESCRIPTION
Fixes #598

The building menu (b) now allows you to select furniture, not just `concrete wall`. In order to have furniture show up in the menu, you have to configure a list of items required for the furniture to be constructed. These items will not be used during placement right now, but will be in the future.