### PR TITLE
Allow furniture to set a random item sprite when it's a container

### DIFF
--- a/Defaults/Blocks/Materials/construction_ghost_material.tres
+++ b/Defaults/Blocks/Materials/construction_ghost_material.tres
@@ -1,6 +1,6 @@
 [gd_resource type="StandardMaterial3D" load_steps=2 format=3 uid="uid://ot2fpooebty0"]
 
-[ext_resource type="Texture2D" uid="uid://bpjkd6sssic7b" path="res://Mods/Core/Tiles/2.png" id="1_2cd6c"]
+[ext_resource type="Texture2D" uid="uid://bpjkd6sssic7b" path="res://Mods/Dimensionfall/Tiles/2.png" id="1_2cd6c"]
 
 [resource]
 albedo_color = Color(0, 0.768627, 0.768627, 0.545098)

--- a/Mods/Dimensionfall/Furniture/Furniture.json
+++ b/Mods/Dimensionfall/Furniture/Furniture.json
@@ -36,8 +36,7 @@
 	{
 		"Function": {
 			"container_group": "kitchen_cupboard",
-			"is_container": true,
-			"random_container_sprite": false
+			"is_container": true
 		},
 		"categories": [
 			"Urban",
@@ -111,7 +110,7 @@
 			"container_group": "tree_forage",
 			"container_regeneration_time": 10,
 			"is_container": true,
-			"random_container_sprite": false
+			"random_container_sprite": true
 		},
 		"categories": [
 			"Nature"
@@ -139,7 +138,7 @@
 			"container_group": "tree_forage",
 			"container_regeneration_time": 10,
 			"is_container": true,
-			"random_container_sprite": false
+			"random_container_sprite": true
 		},
 		"categories": [
 			"Nature"
@@ -231,8 +230,7 @@
 	{
 		"Function": {
 			"container_group": "cabinet_general",
-			"is_container": true,
-			"random_container_sprite": false
+			"is_container": true
 		},
 		"categories": [
 			"Urban",
@@ -284,8 +282,7 @@
 	{
 		"Function": {
 			"container_group": "refridgerator",
-			"is_container": true,
-			"random_container_sprite": false
+			"is_container": true
 		},
 		"categories": [
 			"Urban",
@@ -388,8 +385,7 @@
 	{
 		"Function": {
 			"container_group": "clothing_general",
-			"is_container": true,
-			"random_container_sprite": false
+			"is_container": true
 		},
 		"categories": [
 			"Urban",
@@ -640,8 +636,7 @@
 	},
 	{
 		"Function": {
-			"is_container": true,
-			"random_container_sprite": false
+			"is_container": true
 		},
 		"categories": [
 			"Urban",
@@ -661,8 +656,7 @@
 	{
 		"Function": {
 			"container_group": "refridgerator",
-			"is_container": true,
-			"random_container_sprite": false
+			"is_container": true
 		},
 		"categories": [
 			"Urban",
@@ -689,8 +683,7 @@
 	{
 		"Function": {
 			"container_group": "vending_machine_drinks",
-			"is_container": true,
-			"random_container_sprite": false
+			"is_container": true
 		},
 		"categories": [
 			"Urban",
@@ -717,8 +710,7 @@
 	{
 		"Function": {
 			"container_group": "clothing_general",
-			"is_container": true,
-			"random_container_sprite": false
+			"is_container": true
 		},
 		"categories": [
 			"Urban",
@@ -737,8 +729,7 @@
 	},
 	{
 		"Function": {
-			"is_container": true,
-			"random_container_sprite": false
+			"is_container": true
 		},
 		"categories": [
 			"Urban",
@@ -790,8 +781,7 @@
 	},
 	{
 		"Function": {
-			"is_container": true,
-			"random_container_sprite": false
+			"is_container": true
 		},
 		"categories": [
 			"Urban",
@@ -811,8 +801,7 @@
 	{
 		"Function": {
 			"container_group": "cabinet_general",
-			"is_container": true,
-			"random_container_sprite": false
+			"is_container": true
 		},
 		"categories": [
 			"Urban",
@@ -861,8 +850,7 @@
 	},
 	{
 		"Function": {
-			"is_container": true,
-			"random_container_sprite": false
+			"is_container": true
 		},
 		"categories": [
 			"Urban",
@@ -963,8 +951,7 @@
 	},
 	{
 		"Function": {
-			"is_container": true,
-			"random_container_sprite": false
+			"is_container": true
 		},
 		"categories": [
 			"Urban",
@@ -991,8 +978,7 @@
 	},
 	{
 		"Function": {
-			"is_container": true,
-			"random_container_sprite": false
+			"is_container": true
 		},
 		"categories": [
 			"Urban",
@@ -1066,8 +1052,7 @@
 	{
 		"Function": {
 			"container_group": "tree_forage",
-			"is_container": true,
-			"random_container_sprite": false
+			"is_container": true
 		},
 		"categories": [
 			"Survival",
@@ -1092,8 +1077,7 @@
 	},
 	{
 		"Function": {
-			"is_container": true,
-			"random_container_sprite": false
+			"is_container": true
 		},
 		"categories": [
 			"Survival",

--- a/Mods/Dimensionfall/Furniture/Furniture.json
+++ b/Mods/Dimensionfall/Furniture/Furniture.json
@@ -36,7 +36,8 @@
 	{
 		"Function": {
 			"container_group": "kitchen_cupboard",
-			"is_container": true
+			"is_container": true,
+			"random_container_sprite": false
 		},
 		"categories": [
 			"Urban",
@@ -81,7 +82,8 @@
 		"Function": {
 			"container_group": "tree_forage",
 			"container_regeneration_time": 10,
-			"is_container": true
+			"is_container": true,
+			"random_container_sprite": true
 		},
 		"categories": [
 			"Nature"
@@ -108,7 +110,8 @@
 		"Function": {
 			"container_group": "tree_forage",
 			"container_regeneration_time": 10,
-			"is_container": true
+			"is_container": true,
+			"random_container_sprite": false
 		},
 		"categories": [
 			"Nature"
@@ -135,7 +138,8 @@
 		"Function": {
 			"container_group": "tree_forage",
 			"container_regeneration_time": 10,
-			"is_container": true
+			"is_container": true,
+			"random_container_sprite": false
 		},
 		"categories": [
 			"Nature"
@@ -227,7 +231,8 @@
 	{
 		"Function": {
 			"container_group": "cabinet_general",
-			"is_container": true
+			"is_container": true,
+			"random_container_sprite": false
 		},
 		"categories": [
 			"Urban",
@@ -279,7 +284,8 @@
 	{
 		"Function": {
 			"container_group": "refridgerator",
-			"is_container": true
+			"is_container": true,
+			"random_container_sprite": false
 		},
 		"categories": [
 			"Urban",
@@ -382,7 +388,8 @@
 	{
 		"Function": {
 			"container_group": "clothing_general",
-			"is_container": true
+			"is_container": true,
+			"random_container_sprite": false
 		},
 		"categories": [
 			"Urban",
@@ -633,7 +640,8 @@
 	},
 	{
 		"Function": {
-			"is_container": true
+			"is_container": true,
+			"random_container_sprite": false
 		},
 		"categories": [
 			"Urban",
@@ -653,7 +661,8 @@
 	{
 		"Function": {
 			"container_group": "refridgerator",
-			"is_container": true
+			"is_container": true,
+			"random_container_sprite": false
 		},
 		"categories": [
 			"Urban",
@@ -680,7 +689,8 @@
 	{
 		"Function": {
 			"container_group": "vending_machine_drinks",
-			"is_container": true
+			"is_container": true,
+			"random_container_sprite": false
 		},
 		"categories": [
 			"Urban",
@@ -707,7 +717,8 @@
 	{
 		"Function": {
 			"container_group": "clothing_general",
-			"is_container": true
+			"is_container": true,
+			"random_container_sprite": false
 		},
 		"categories": [
 			"Urban",
@@ -726,7 +737,8 @@
 	},
 	{
 		"Function": {
-			"is_container": true
+			"is_container": true,
+			"random_container_sprite": false
 		},
 		"categories": [
 			"Urban",
@@ -778,7 +790,8 @@
 	},
 	{
 		"Function": {
-			"is_container": true
+			"is_container": true,
+			"random_container_sprite": false
 		},
 		"categories": [
 			"Urban",
@@ -798,7 +811,8 @@
 	{
 		"Function": {
 			"container_group": "cabinet_general",
-			"is_container": true
+			"is_container": true,
+			"random_container_sprite": false
 		},
 		"categories": [
 			"Urban",
@@ -847,7 +861,8 @@
 	},
 	{
 		"Function": {
-			"is_container": true
+			"is_container": true,
+			"random_container_sprite": false
 		},
 		"categories": [
 			"Urban",
@@ -948,7 +963,8 @@
 	},
 	{
 		"Function": {
-			"is_container": true
+			"is_container": true,
+			"random_container_sprite": false
 		},
 		"categories": [
 			"Urban",
@@ -975,7 +991,8 @@
 	},
 	{
 		"Function": {
-			"is_container": true
+			"is_container": true,
+			"random_container_sprite": false
 		},
 		"categories": [
 			"Urban",
@@ -1049,7 +1066,8 @@
 	{
 		"Function": {
 			"container_group": "tree_forage",
-			"is_container": true
+			"is_container": true,
+			"random_container_sprite": false
 		},
 		"categories": [
 			"Survival",
@@ -1074,7 +1092,8 @@
 	},
 	{
 		"Function": {
-			"is_container": true
+			"is_container": true,
+			"random_container_sprite": false
 		},
 		"categories": [
 			"Survival",

--- a/Mods/Dimensionfall/Mobgroups/references.json
+++ b/Mods/Dimensionfall/Mobgroups/references.json
@@ -1,5 +1,8 @@
 {
 	"basic_zombies": {
+		"maps": [
+			"urbanroad"
+		],
 		"quests": [
 			"quest_holy_crusade_01",
 			"starter_tutorial_00"

--- a/Scenes/ContentManager/Custom_Editors/FurnitureEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/FurnitureEditor.tscn
@@ -11,7 +11,7 @@
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ujqyk"]
 
-[node name="FurnitureEditor" type="Control" node_paths=PackedStringArray("tab_container", "furniture_image_display", "id_label", "name_edit", "description_edit", "categories_list", "furniture_selector", "image_name_label", "moveable_checkbox", "weight_label", "weight_spinbox", "edge_snapping_option", "door_option", "container_checkbox", "container_text_edit", "regeneration_label", "regeneration_spin_box", "destroy_container", "can_destroy_checkbox", "destruction_text_edit", "destruction_image_display", "destruction_sprite_label", "disassembly_container", "can_disassemble_checkbox", "disassembly_text_edit", "disassembly_image_display", "disassembly_sprite_label", "support_shape_option_button", "width_scale_label", "depth_scale_label", "radius_scale_label", "width_scale_spin_box", "depth_scale_spin_box", "radius_scale_spin_box", "heigth_spin_box", "color_picker", "sprite_texture_rect", "transparent_check_box", "crafting_items_container", "construction_items_container")]
+[node name="FurnitureEditor" type="Control" node_paths=PackedStringArray("tab_container", "furniture_image_display", "id_label", "name_edit", "description_edit", "categories_list", "furniture_selector", "image_name_label", "moveable_checkbox", "weight_label", "weight_spinbox", "edge_snapping_option", "door_option", "container_checkbox", "container_text_edit", "regeneration_label", "regeneration_spin_box", "random_container_sprite_check_box", "destroy_container", "can_destroy_checkbox", "destruction_text_edit", "destruction_image_display", "destruction_sprite_label", "disassembly_container", "can_disassemble_checkbox", "disassembly_text_edit", "disassembly_image_display", "disassembly_sprite_label", "support_shape_option_button", "width_scale_label", "depth_scale_label", "radius_scale_label", "width_scale_spin_box", "depth_scale_spin_box", "radius_scale_spin_box", "heigth_spin_box", "color_picker", "sprite_texture_rect", "transparent_check_box", "crafting_items_container", "construction_items_container")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -36,6 +36,7 @@ container_checkbox = NodePath("VBoxContainer/TabContainer/General/FunctionContro
 container_text_edit = NodePath("VBoxContainer/TabContainer/General/FunctionControlContainer/ContainerTextEdit")
 regeneration_label = NodePath("VBoxContainer/TabContainer/General/FunctionControlContainer/RegenerationLabel")
 regeneration_spin_box = NodePath("VBoxContainer/TabContainer/General/FunctionControlContainer/RegenerationSpinBox")
+random_container_sprite_check_box = NodePath("VBoxContainer/TabContainer/General/FunctionControlContainer/RandomContainerSpriteCheckBox")
 destroy_container = NodePath("VBoxContainer/TabContainer/General/DestructionHBoxContainer")
 can_destroy_checkbox = NodePath("VBoxContainer/TabContainer/General/DestructionHBoxContainer/CanDestroyCheckBox")
 destruction_text_edit = NodePath("VBoxContainer/TabContainer/General/DestructionHBoxContainer/DestructionTextEdit")
@@ -343,6 +344,14 @@ contents of the itemgroup when it is
 spawned. If container is not checked on, it
 will not act as a container."
 myplaceholdertext = "Drag an itemgroup from the left to here"
+
+[node name="RandomContainerSpriteCheckBox" type="CheckBox" parent="VBoxContainer/TabContainer/General/FunctionControlContainer"]
+layout_mode = 2
+tooltip_text = "Determines the initial sprite for the container.
+On: Will pick a random item from the itemgroup and display the item's sprite as the container sprite
+Off: Uses the default container sprite.
+Recommendation: Off for inorganic furniture like cupboards. On for organic furniture like trees."
+text = "Random sprite"
 
 [node name="RegenerationLabel" type="Label" parent="VBoxContainer/TabContainer/General/FunctionControlContainer"]
 layout_mode = 2

--- a/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
@@ -23,6 +23,8 @@ extends Control
 @export var container_text_edit: HBoxContainer = null # Might contain the id of a loot group
 @export var regeneration_label: Label = null
 @export var regeneration_spin_box: SpinBox = null # The time in days before regeneration
+@export var random_container_sprite_check_box: CheckBox = null
+
 
 @export var destroy_container: HBoxContainer = null # contains destroy controls
 @export var can_destroy_checkbox: CheckBox = null # If the furniture can be destroyed or not
@@ -145,10 +147,15 @@ func load_furniture_data():
 			regeneration_spin_box.value = dfurniture.function.container_regeneration_time
 		else:
 			regeneration_spin_box.value = -1.0  # Default to -1.0 if no regeneration time is set
+
+		# Load the random container sprite checkbox value
+		random_container_sprite_check_box.button_pressed = dfurniture.function.random_container_sprite
 	else:
 		container_checkbox.button_pressed = false  # Uncheck the container checkbox
 		container_text_edit.mytextedit.clear()  # Clear the text edit as no container data is present
 		regeneration_spin_box.value = -1.0  # Reset regeneration spin box
+		random_container_sprite_check_box.button_pressed = false  # Reset the checkbox
+
 
 	# Call the function to load the support shape data
 	load_support_shape_option()
@@ -283,11 +290,16 @@ func handle_container_option():
 		dfurniture.function.container_group = container_text_edit.get_text()
 		# Save the regeneration time
 		dfurniture.function.container_regeneration_time = regeneration_spin_box.value
+		# Save the random container sprite checkbox value
+		dfurniture.function.random_container_sprite = random_container_sprite_check_box.button_pressed
 	else:
 		dfurniture.function.is_container = false
 		dfurniture.function.container_group = ""
 		# Reset the regeneration time
 		dfurniture.function.container_regeneration_time = -1
+		# Reset the random container sprite checkbox value
+		dfurniture.function.random_container_sprite = false
+
 
 
 func handle_destruction_option():

--- a/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
@@ -87,6 +87,7 @@ func _ready():
 	# Connect the toggle signal to the function
 	moveable_checkbox.toggled.connect(_on_moveable_checkbox_toggled)
 	crafting_items_container.set_drag_forwarding(Callable(), _can_item_drop, _item_drop)
+	container_text_edit.text_changed.connect(_on_container_text_edit_text_changed)
 
 
 func load_furniture_data():
@@ -155,7 +156,7 @@ func load_furniture_data():
 		container_text_edit.mytextedit.clear()  # Clear the text edit as no container data is present
 		regeneration_spin_box.value = -1.0  # Reset regeneration spin box
 		random_container_sprite_check_box.button_pressed = false  # Reset the checkbox
-
+	update_container_controls_visibility()
 
 	# Call the function to load the support shape data
 	load_support_shape_option()
@@ -708,3 +709,16 @@ func _extract_items_from_container(container: GridContainer) -> Array:
 		if child is Label:
 			items.append(child.text)
 	return items
+
+
+func update_container_controls_visibility():
+	# Check if container_text_edit has a value
+	var has_value = container_text_edit.get_text() != ""
+	
+	# Toggle visibility based on value
+	regeneration_label.visible = has_value
+	regeneration_spin_box.visible = has_value
+	random_container_sprite_check_box.visible = has_value
+
+func _on_container_text_edit_text_changed(_new_text: String):
+	update_container_controls_visibility()

--- a/Scenes/ContentManager/Custom_Widgets/Scripts/DropEnabledTextEdit.gd
+++ b/Scenes/ContentManager/Custom_Widgets/Scripts/DropEnabledTextEdit.gd
@@ -46,6 +46,8 @@ var is_disabled: bool = false  # Tracks whether the widget is disabled
 @export var myplaceholdertext: String = "drop your data here"
 @export var button: Button = null
 
+signal text_changed(new_text: String)
+
 
 func _ready():
 	mytextedit.placeholder_text = myplaceholdertext
@@ -74,10 +76,12 @@ func _handle_item_drop(dropped_data, _newpos) -> void:
 
 func _on_button_button_up():
 	mytextedit.clear()
+	text_changed.emit("")
 
 
 func set_text(newtext: String):
 	mytextedit.text = newtext
+	text_changed.emit(newtext)
 
 
 func get_text():

--- a/Scenes/UI/BuildingMenu.tscn
+++ b/Scenes/UI/BuildingMenu.tscn
@@ -1,0 +1,13 @@
+[gd_scene load_steps=2 format=3 uid="uid://clpbtb0qfrk5j"]
+
+[ext_resource type="Script" path="res://Scripts/BuildingMenu.gd" id="1_wcwjs"]
+
+[node name="BuildingMenu" type="GridContainer"]
+offset_right = 186.0
+offset_bottom = 33.0
+columns = 4
+script = ExtResource("1_wcwjs")
+
+[node name="Concrete" type="Button" parent="."]
+layout_mode = 2
+text = "Concrete (2x plank)"

--- a/Scenes/UI/BuildingMenu.tscn
+++ b/Scenes/UI/BuildingMenu.tscn
@@ -2,14 +2,17 @@
 
 [ext_resource type="Script" path="res://Scripts/BuildingMenu.gd" id="1_wcwjs"]
 
-[node name="BuildingMenu" type="GridContainer"]
+[node name="BuildingMenu" type="GridContainer" node_paths=PackedStringArray("construction_option_button")]
 offset_right = 186.0
 offset_bottom = 33.0
 columns = 4
 script = ExtResource("1_wcwjs")
+construction_option_button = NodePath("ConstructionOptionButton")
 
-[node name="Concrete" type="OptionButton" parent="."]
+[node name="ConstructionOptionButton" type="OptionButton" parent="."]
 layout_mode = 2
 selected = 0
 item_count = 1
 popup/item_0/text = "concrete_wall"
+
+[connection signal="item_selected" from="ConstructionOptionButton" to="." method="_on_construction_option_button_item_selected"]

--- a/Scenes/UI/BuildingMenu.tscn
+++ b/Scenes/UI/BuildingMenu.tscn
@@ -8,6 +8,8 @@ offset_bottom = 33.0
 columns = 4
 script = ExtResource("1_wcwjs")
 
-[node name="Concrete" type="Button" parent="."]
+[node name="Concrete" type="OptionButton" parent="."]
 layout_mode = 2
-text = "Concrete (2x plank)"
+selected = 0
+item_count = 1
+popup/item_0/text = "concrete_wall"

--- a/Scripts/BuildManager.gd
+++ b/Scripts/BuildManager.gd
@@ -33,7 +33,7 @@ func cancel_building():
 func _on_hud_construction_chosen(type: String, choice: String):
 	construction_type = type
 	construction_choice = choice
-	update_construction_ghost_material()  # Update the ghost material based on the new selection
+	update_construction_ghost()  # Update the ghost based on the new selection
 	start_building()
 
 
@@ -91,29 +91,36 @@ func _on_build_menu_visibility_change(buildmenu):
 	# Update construction ghost visibility based on build menu visibility
 	set_building_state(buildmenu.is_visible())
 
-func set_building_state(visible: bool):
-	construction_ghost.visible = visible
-	is_building = visible
-	if not visible:
+func set_building_state(isvisible: bool):
+	construction_ghost.visible = isvisible
+	is_building = isvisible
+	if not isvisible:
 		General.is_allowed_to_shoot = true
 
 
 # Updates the material of the construction ghost based on the construction type and choice
-func update_construction_ghost_material():
-	if construction_type == "block":
-		# Reset to the default material for blocks
-		construction_ghost.reset_material_to_default()
-	elif construction_type == "furniture":
+func update_construction_ghost():
+	construction_ghost.reset_to_default() # Resets size, rotation, material, offset
+	if construction_type == "furniture":
 		# Get the RFurniture instance by its ID
 		var rfurniture: RFurniture = Runtimedata.furnitures.by_id(construction_choice)
 		if rfurniture:
 			# Retrieve the sprite material and set it to the construction ghost
 			var furniture_sprite_material = Runtimedata.furnitures.get_shader_material_by_id(construction_choice)
 			construction_ghost.set_material(furniture_sprite_material)
+			construction_ghost.set_mesh_size(calculate_furniture_size(rfurniture))
 		else:
 			print_debug("RFurniture with ID ", construction_choice, " not found. Resetting material.")
-			construction_ghost.reset_material_to_default()
 	else:
 		# Handle unknown construction types by resetting to the default material
 		print_debug("Unknown construction type: ", construction_type, ". Resetting material.")
-		construction_ghost.reset_material_to_default()
+
+
+# Function to calculate the size of the furniture
+func calculate_furniture_size(rfurniture: RFurniture) -> Vector2:
+	var sprite_texture = rfurniture.sprite
+	if sprite_texture:
+		var sprite_width = sprite_texture.get_width() / 100.0 # Convert pixels to meters
+		var sprite_depth = sprite_texture.get_height() / 100.0 # Convert pixels to meters
+		return Vector2(sprite_width, sprite_depth)  # Use height from support shape
+	return Vector2(0.5, 0.5)  # Default size if texture is not set

--- a/Scripts/BuildManager.gd
+++ b/Scripts/BuildManager.gd
@@ -77,8 +77,22 @@ func on_construction_clicked(construction_data: Dictionary):
 			myrotation = 270
 		elif myrotation == 270:
 			myrotation = 90
-		chunk.spawn_furniture({"json": {"id": construction_choice, "rotation": myrotation}, "pos": construction_data.pos})
-		print_debug("Furniture construction chosen. Type: ", construction_type, ", Choice: ", construction_choice, ", construction_data.pos: ", str(construction_data.pos))
+
+		# Translate the position to negate the chunk's `mypos`
+		construction_data.pos -= chunk.mypos
+
+		# Spawn the furniture with the adjusted position
+		chunk.spawn_furniture({
+			"json": {"id": construction_choice, "rotation": myrotation},
+			"pos": construction_data.pos
+		})
+
+		print_debug(
+			"Furniture construction chosen. Type: ", construction_type,
+			", Choice: ", construction_choice,
+			", Adjusted construction_data.pos: ", str(construction_data.pos)
+		)
+
 
 	# Handle unknown construction types
 	else:
@@ -115,6 +129,8 @@ func update_construction_ghost():
 			var furniture_sprite_material = Runtimedata.furnitures.get_shader_material_by_id(construction_choice)
 			construction_ghost.set_material(furniture_sprite_material)
 			construction_ghost.set_mesh_size(calculate_furniture_size(rfurniture))
+			if not rfurniture.edgesnapping == "None":
+				construction_ghost.set_position_offset(rfurniture.edgesnapping)
 		else:
 			print_debug("RFurniture with ID ", construction_choice, " not found. Resetting material.")
 	else:

--- a/Scripts/BuildManager.gd
+++ b/Scripts/BuildManager.gd
@@ -50,6 +50,10 @@ func on_construction_clicked(construction_data: Dictionary):
 		print_debug("Construction type or choice is not set. Aborting.")
 		return
 
+	var chunk: Chunk = LevelGenerator.get_chunk_from_position(construction_data.pos)
+	if not chunk:
+		return
+
 	# Handle block construction
 	if construction_type == "block":
 		var numberofplanks: int = ItemManager.get_accessibleitem_amount("plank_2x4")
@@ -60,14 +64,13 @@ func on_construction_clicked(construction_data: Dictionary):
 		if not ItemManager.remove_resource("plank_2x4", 2, ItemManager.allAccessibleItems):
 			return
 
-		var chunk: Chunk = LevelGenerator.get_chunk_from_position(construction_data.pos)
-		if chunk:
-			var local_position = calculate_local_position(construction_data.pos, chunk.position)
-			chunk.add_block("concrete_00", local_position)
-			print_debug("Block placed at local position: ", local_position, " in chunk at ", chunk.position, " with type ", construction_data.id)
+		var local_position = calculate_local_position(construction_data.pos, chunk.position)
+		chunk.add_block("concrete_00", local_position)
+		print_debug("Block placed at local position: ", local_position, " in chunk at ", chunk.position, " with type ", construction_data.id)
 
 	# Handle furniture construction
 	elif construction_type == "furniture":
+		chunk.spawn_furniture({"json": {"id": construction_choice, "rotation": 0}, "pos": construction_data.pos})
 		print_debug("Furniture construction chosen. Type: ", construction_type, ", Choice: ", construction_choice)
 
 	# Handle unknown construction types

--- a/Scripts/BuildManager.gd
+++ b/Scripts/BuildManager.gd
@@ -70,8 +70,9 @@ func on_construction_clicked(construction_data: Dictionary):
 
 	# Handle furniture construction
 	elif construction_type == "furniture":
+		construction_data.pos.y -= 1
 		chunk.spawn_furniture({"json": {"id": construction_choice, "rotation": 0}, "pos": construction_data.pos})
-		print_debug("Furniture construction chosen. Type: ", construction_type, ", Choice: ", construction_choice)
+		print_debug("Furniture construction chosen. Type: ", construction_type, ", Choice: ", construction_choice, ", construction_data.pos: ", str(construction_data.pos))
 
 	# Handle unknown construction types
 	else:
@@ -104,10 +105,10 @@ func update_construction_ghost_material():
 		construction_ghost.reset_material_to_default()
 	elif construction_type == "furniture":
 		# Get the RFurniture instance by its ID
-		var rfurniture: RFurniture = Runtimedata.rfurnitures.by_id(construction_choice)
+		var rfurniture: RFurniture = Runtimedata.furnitures.by_id(construction_choice)
 		if rfurniture:
 			# Retrieve the sprite material and set it to the construction ghost
-			var furniture_sprite_material = rfurniture.sprite
+			var furniture_sprite_material = Runtimedata.furnitures.get_shader_material_by_id(construction_choice)
 			construction_ghost.set_material(furniture_sprite_material)
 		else:
 			print_debug("RFurniture with ID ", construction_choice, " not found. Resetting material.")

--- a/Scripts/BuildManager.gd
+++ b/Scripts/BuildManager.gd
@@ -43,18 +43,34 @@ func start_building():
 # Connects from the ConstructionGhost.gd script. 
 # Example construction data: {"pos": global_transform.origin}
 func on_construction_clicked(construction_data: Dictionary):
-	var numberofplanks: int = ItemManager.get_accessibleitem_amount("plank_2x4")
-	if numberofplanks < 2:
-		print_debug("tried to construct, but not enough planks")
+	# Ensure construction_type and construction_choice are set
+	if construction_type == "" or construction_choice == "":
+		print_debug("Construction type or choice is not set. Aborting.")
 		return
+
+	# Handle block construction
+	if construction_type == "block":
+		var numberofplanks: int = ItemManager.get_accessibleitem_amount("plank_2x4")
+		if numberofplanks < 2:
+			print_debug("Tried to construct, but not enough planks")
+			return
 		
-	if not ItemManager.remove_resource("plank_2x4",2, ItemManager.allAccessibleItems):
-		return
-	var chunk: Chunk = LevelGenerator.get_chunk_from_position(construction_data.pos)
-	if chunk:
-		var local_position = calculate_local_position(construction_data.pos, chunk.position)
-		chunk.add_block("concrete_00", local_position)
-		print_debug("Block placed at local position: ", local_position, " in chunk at ", chunk.position, " with type ", construction_data.id)
+		if not ItemManager.remove_resource("plank_2x4", 2, ItemManager.allAccessibleItems):
+			return
+
+		var chunk: Chunk = LevelGenerator.get_chunk_from_position(construction_data.pos)
+		if chunk:
+			var local_position = calculate_local_position(construction_data.pos, chunk.position)
+			chunk.add_block("concrete_00", local_position)
+			print_debug("Block placed at local position: ", local_position, " in chunk at ", chunk.position, " with type ", construction_data.id)
+
+	# Handle furniture construction
+	elif construction_type == "furniture":
+		print_debug("Furniture construction chosen. Type: ", construction_type, ", Choice: ", construction_choice)
+
+	# Handle unknown construction types
+	else:
+		print_debug("Unknown construction type: ", construction_type)
 
 
 func calculate_local_position(global_pos: Vector3, chunk_pos: Vector3) -> Vector3:

--- a/Scripts/BuildManager.gd
+++ b/Scripts/BuildManager.gd
@@ -71,7 +71,13 @@ func on_construction_clicked(construction_data: Dictionary):
 	# Handle furniture construction
 	elif construction_type == "furniture":
 		construction_data.pos.y -= 1
-		chunk.spawn_furniture({"json": {"id": construction_choice, "rotation": 0}, "pos": construction_data.pos})
+		# Because Godot can be strange with rotation sometimes we have to translate the rotation
+		var myrotation = construction_data.rotation
+		if myrotation == 90:
+			myrotation = 270
+		elif myrotation == 270:
+			myrotation = 90
+		chunk.spawn_furniture({"json": {"id": construction_choice, "rotation": myrotation}, "pos": construction_data.pos})
 		print_debug("Furniture construction chosen. Type: ", construction_type, ", Choice: ", construction_choice, ", construction_data.pos: ", str(construction_data.pos))
 
 	# Handle unknown construction types

--- a/Scripts/BuildManager.gd
+++ b/Scripts/BuildManager.gd
@@ -33,7 +33,9 @@ func cancel_building():
 func _on_hud_construction_chosen(type: String, choice: String):
 	construction_type = type
 	construction_choice = choice
+	update_construction_ghost_material()  # Update the ghost material based on the new selection
 	start_building()
+
 
 func start_building():
 	is_building = true
@@ -90,3 +92,24 @@ func set_building_state(visible: bool):
 	is_building = visible
 	if not visible:
 		General.is_allowed_to_shoot = true
+
+
+# Updates the material of the construction ghost based on the construction type and choice
+func update_construction_ghost_material():
+	if construction_type == "block":
+		# Reset to the default material for blocks
+		construction_ghost.reset_material_to_default()
+	elif construction_type == "furniture":
+		# Get the RFurniture instance by its ID
+		var rfurniture: RFurniture = Runtimedata.rfurnitures.by_id(construction_choice)
+		if rfurniture:
+			# Retrieve the sprite material and set it to the construction ghost
+			var furniture_sprite_material = rfurniture.sprite
+			construction_ghost.set_material(furniture_sprite_material)
+		else:
+			print_debug("RFurniture with ID ", construction_choice, " not found. Resetting material.")
+			construction_ghost.reset_material_to_default()
+	else:
+		# Handle unknown construction types by resetting to the default material
+		print_debug("Unknown construction type: ", construction_type, ". Resetting material.")
+		construction_ghost.reset_material_to_default()

--- a/Scripts/BuildingMenu.gd
+++ b/Scripts/BuildingMenu.gd
@@ -1,0 +1,11 @@
+extends GridContainer
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(_delta: float) -> void:
+	pass

--- a/Scripts/BuildingMenu.gd
+++ b/Scripts/BuildingMenu.gd
@@ -4,8 +4,6 @@ extends GridContainer
 var is_building_menu_open = false
 @export var construction_option_button: OptionButton = null
 
-signal construction_chosen(type: String, choice: String)
-
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	pass # Replace with function body.
@@ -34,6 +32,6 @@ func _on_construction_option_button_item_selected(_index: int) -> void:
 
 	# Determine the type and emit the signal
 	if selected_text == "concrete_wall":
-		construction_chosen.emit("block", "concrete_wall")
+		Helper.signal_broker.construction_chosen.emit("block", "concrete_wall")
 	else:
-		construction_chosen.emit("furniture", selected_text)
+		Helper.signal_broker.construction_chosen.emit("furniture", selected_text)

--- a/Scripts/BuildingMenu.gd
+++ b/Scripts/BuildingMenu.gd
@@ -6,7 +6,7 @@ var is_building_menu_open = false
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	pass # Replace with function body.
+	populate_optionbutton()
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.

--- a/Scripts/BuildingMenu.gd
+++ b/Scripts/BuildingMenu.gd
@@ -1,6 +1,9 @@
 extends GridContainer
 
 
+var is_building_menu_open = false
+signal construction_chosen
+
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	pass # Replace with function body.
@@ -9,3 +12,7 @@ func _ready() -> void:
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(_delta: float) -> void:
 	pass
+
+
+func _on_concrete_button_down():
+	construction_chosen.emit("concrete_wall")

--- a/Scripts/BuildingMenu.gd
+++ b/Scripts/BuildingMenu.gd
@@ -2,7 +2,9 @@ extends GridContainer
 
 
 var is_building_menu_open = false
-signal construction_chosen
+@export var construction_option_button: OptionButton = null
+
+signal construction_chosen(type: String, choice: String)
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
@@ -14,5 +16,24 @@ func _process(_delta: float) -> void:
 	pass
 
 
-func _on_concrete_button_down():
-	construction_chosen.emit("concrete_wall")
+func populate_optionbutton():
+	# Clear the existing options while preserving the first option
+	construction_option_button.clear()
+	construction_option_button.add_item("concrete_wall", 0)  # First option remains concrete_wall
+
+	# Get constructable furnitures and add their IDs to the option button
+	var rfurnitures: Array[RFurniture] = Runtimedata.furnitures.get_constructable_furnitures()
+	for rfurniture in rfurnitures:
+		construction_option_button.add_item(rfurniture.id)
+
+
+func _on_construction_option_button_item_selected(_index: int) -> void:
+	# Get the selected option from the OptionButton
+	var selected_value = construction_option_button.get_selected_id()
+	var selected_text = construction_option_button.get_item_text(selected_value)
+
+	# Determine the type and emit the signal
+	if selected_text == "concrete_wall":
+		construction_chosen.emit("block", "concrete_wall")
+	else:
+		construction_chosen.emit("furniture", selected_text)

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -170,7 +170,6 @@ func process_level_data() -> Dictionary:
 	return processed_leveldata
 
 
-
 # Creates a dictionary of all block positions with a local x,y and z position
 # This function works with new mapdata
 func create_block_position_dictionary_new_arraymesh() -> Dictionary:
@@ -1393,3 +1392,12 @@ func rotate_level_clockwise(level_data: Array) -> Array:
 				new_level_data[new_index]["furniture"]["rotation"] = (furniture_rotation + 90) % 360
 
 	return new_level_data
+
+
+# Spawns a furniture onto the chunk. 
+# furniture_data example: {"json": {"id": "kitchen_cupboard", "rotation": 0}, "pos": Vector3(12,2,189)}
+func spawn_furniture(furniture_data: Dictionary):
+	if not furniture_data.has("json") or not furniture_data.has("pos"):
+		print_debug("Invalid data structure. Expected keys: 'json', 'pos'.")
+		return
+	furniture_static_spawner.spawn_furniture(furniture_data)

--- a/Scripts/ConstructionGhost.gd
+++ b/Scripts/ConstructionGhost.gd
@@ -1,9 +1,13 @@
 extends MeshInstance3D
 
+# This script belongs to the ConstructionGhost node in the level_generation.tscn scene
+# This script controls the constructionghost for the player so it will aid him in constructing something
+
 # Reference to the player node
 @export var player: Node3D
 @export var sceneCam: Camera3D
 @export var buildmanager: Node3D
+const CONSTRUCTION_GHOST_MATERIAL: Material = preload("res://Defaults/Blocks/Materials/construction_ghost_material.tres")
 
 # Settings
 var grid_size = 1.0
@@ -65,3 +69,13 @@ func _input(event):
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
 		construction_data = {"pos": global_transform.origin}
 		construction_clicked.emit(construction_data)
+
+
+# Sets the material of the ConstructionGhost
+func set_material(new_material: Material) -> void:
+	if mesh:
+		mesh.surface_set_material(0, new_material)  # Assuming the ghost mesh has a single surface
+
+# Resets the material to the default CONSTRUCTION_GHOST_MATERIAL
+func reset_material_to_default() -> void:
+	set_material(CONSTRUCTION_GHOST_MATERIAL)

--- a/Scripts/ConstructionGhost.gd
+++ b/Scripts/ConstructionGhost.gd
@@ -20,6 +20,7 @@ var construction_data: Dictionary
 # Offset for the ConstructionGhost's position
 var position_offset: Vector3 = Vector3.ZERO
 var has_obstacle: bool = false # Tracks whether there is an obstacle
+var current_rotation: int = 0
 
 signal construction_clicked(data: Dictionary)
 
@@ -72,12 +73,21 @@ func get_mouse_3d_position() -> Vector3:
 
 # Input handling to check for obstacles and other criteria before emitting the signal
 func _input(event):
-	if !visible or has_obstacle:
-		#print_debug("has_obstacle = " + str(has_obstacle))
+	if not visible:
 		return
+
+	# Handle left mouse button click for placing construction
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
-		construction_data = {"pos": global_transform.origin}
+		if has_obstacle:
+			return
+		construction_data = {"pos": global_transform.origin, "rotation": current_rotation}
 		construction_clicked.emit(construction_data)
+	
+	# Handle "r" key press for rotating the construction ghost
+	if event is InputEventKey and event.is_pressed() and event.keycode == KEY_R:
+		# Increment the current rotation by 90 degrees
+		var new_rotation = (current_rotation + 90) % 360
+		set_mesh_rotation(new_rotation)
 
 
 # Sets the material of the ConstructionGhost
@@ -143,7 +153,8 @@ func reset_position_offset_to_default() -> void:
 # Sets the rotation of the ConstructionGhost mesh
 func set_mesh_rotation(myrotation: int) -> void:
 	# Set the rotation offset to the desired value
-	rotation.y = myrotation
+	current_rotation = myrotation
+	rotation_degrees.y = myrotation
 
 # Resets the rotation of the ConstructionGhost mesh to the default (no rotation)
 func reset_rotation_to_default() -> void:

--- a/Scripts/ConstructionGhost.gd
+++ b/Scripts/ConstructionGhost.gd
@@ -14,6 +14,8 @@ var grid_size = 1.0
 var y_offset = 0.0  # Offset relative to the player's position in the Y-axis
 var build_range = 5.0  # Maximum build range from the player
 var construction_data: Dictionary
+# Offset for the ConstructionGhost's position
+var position_offset: Vector3 = Vector3.ZERO
 
 signal construction_clicked(data: Dictionary)
 
@@ -48,8 +50,8 @@ func _process(_delta):
 	var snapped_z = round(mouse_position.z / grid_size) * grid_size
 	var snapped_y = round(mouse_position.y / grid_size) * grid_size
 	
-	# Update the position of the constructionghost
-	global_transform.origin = Vector3(snapped_x, snapped_y, snapped_z)
+	# Update the position of the construction ghost with the offset applied
+	global_transform.origin = Vector3(snapped_x, snapped_y, snapped_z) + position_offset
 
 
 # Calculate the 3D position based on the mouse's 2D position and the player's Y offset
@@ -79,3 +81,64 @@ func set_material(new_material: Material) -> void:
 # Resets the material to the default CONSTRUCTION_GHOST_MATERIAL
 func reset_material_to_default() -> void:
 	set_material(CONSTRUCTION_GHOST_MATERIAL)
+
+
+# Sets the size of the ConstructionGhost mesh, which is a PlaneMesh
+func set_mesh_size(size: Vector2) -> void:
+	if mesh:
+		mesh.set_size = size
+
+# Resets the size of the ConstructionGhost mesh to the default size (Vector2(1, 1))
+func reset_mesh_size_to_default() -> void:
+	set_mesh_size(Vector2(1, 1))
+
+
+# Applies edge snapping and updates the position offset
+func _apply_edge_snapping(direction: String) -> Vector3:
+	# Block size, each block is 1x1 meter
+	var block_size = Vector3(1.0, 1.0, 1.0)
+	var offset = Vector3.ZERO
+
+	# Retrieve the furniture size from the mesh
+	var furniture_size = mesh.size if mesh else Vector3.ONE
+
+	# Adjust offset based on the edge-snapping direction
+	match direction:
+		"North":
+			offset.z -= block_size.z / 2 - furniture_size.z / 2
+		"South":
+			offset.z += block_size.z / 2 - furniture_size.z / 2
+		"East":
+			offset.x += block_size.x / 2 - furniture_size.x / 2
+		"West":
+			offset.x -= block_size.x / 2 - furniture_size.x / 2
+		_:
+			pass  # No adjustment for undefined directions
+
+	return offset
+
+
+# Sets the position offset of the ConstructionGhost
+func set_position_offset(edge_snapping_direction: String = "") -> void:
+	# Reset the position offset
+	position_offset = Vector3.ZERO
+
+	# Apply edge snapping if direction is provided
+	if edge_snapping_direction != "":
+		position_offset += _apply_edge_snapping(edge_snapping_direction)
+
+
+# Resets the position offset of the ConstructionGhost
+func reset_position_offset_to_default() -> void:
+	# Reset the offset to zero (default)
+	position_offset = Vector3.ZERO
+
+# Sets the rotation of the ConstructionGhost mesh
+func set_mesh_rotation(myrotation: int) -> void:
+	# Set the rotation offset to the desired value
+	rotation.y = myrotation
+
+# Resets the rotation of the ConstructionGhost mesh to the default (no rotation)
+func reset_rotation_to_default() -> void:
+	# Reset the rotation to 0
+	set_mesh_rotation(0)

--- a/Scripts/ConstructionGhost.gd
+++ b/Scripts/ConstructionGhost.gd
@@ -56,7 +56,7 @@ func _process(_delta):
 	
 	# Update the position of the construction ghost with the offset applied
 	global_transform.origin = Vector3(snapped_x, snapped_y, snapped_z) + position_offset
-	construction_ghost_area_3d.global_transform.origin = Vector3(snapped_x, snapped_y, snapped_z)
+	construction_ghost_area_3d.global_transform.origin = Vector3(snapped_x, snapped_y+0.5, snapped_z)
 
 
 # Calculate the 3D position based on the mouse's 2D position and the player's Y offset
@@ -73,6 +73,7 @@ func get_mouse_3d_position() -> Vector3:
 # Input handling to check for obstacles and other criteria before emitting the signal
 func _input(event):
 	if !visible or has_obstacle:
+		#print_debug("has_obstacle = " + str(has_obstacle))
 		return
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
 		construction_data = {"pos": global_transform.origin}

--- a/Scripts/ConstructionGhost.gd
+++ b/Scripts/ConstructionGhost.gd
@@ -63,5 +63,5 @@ func _input(event):
 	if !visible:
 		return
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
-		construction_data = {"pos": global_transform.origin, "id": "concrete_00"}
+		construction_data = {"pos": global_transform.origin}
 		construction_clicked.emit(construction_data)

--- a/Scripts/ConstructionGhost.gd
+++ b/Scripts/ConstructionGhost.gd
@@ -93,7 +93,7 @@ func reset_material_to_default() -> void:
 # Sets the size of the ConstructionGhost mesh, which is a PlaneMesh
 func set_mesh_size(size: Vector2) -> void:
 	if mesh:
-		mesh.set_size = size
+		mesh.set_size(size)
 
 # Resets the size of the ConstructionGhost mesh to the default size (Vector2(1, 1))
 func reset_mesh_size_to_default() -> void:
@@ -163,3 +163,9 @@ func _on_construction_ghost_area_3d_body_exited(body: Node3D) -> void:
 	if construction_ghost_area_3d.get_overlapping_bodies().size() == 0:
 		has_obstacle = false
 		print_debug("Obstacle cleared: ", body.name)
+
+func reset_to_default():
+	reset_rotation_to_default()
+	reset_position_offset_to_default()
+	reset_mesh_size_to_default()
+	reset_material_to_default()

--- a/Scripts/CraftingMenu.gd
+++ b/Scripts/CraftingMenu.gd
@@ -237,11 +237,11 @@ func display_feedback(message: String, color: Color):
 	timer.start()
 
 
-func _on_craft_successful(_item: DItem, _recipe: DItem.CraftRecipe):
+func _on_craft_successful(_item: RItem, _recipe: RItem.CraftRecipe):
 	var color = Color(0.4, 1, 0.4)  # Brighter green color with more white
 	display_feedback("craft succesful!", color)
 
 
-func _on_craft_failed(_item: DItem, _recipe: DItem.CraftRecipe, reason: String):
+func _on_craft_failed(_item: RItem, _recipe: RItem.CraftRecipe, reason: String):
 	var color = Color(1, 0, 0)  # Red color
 	display_feedback(reason, color)

--- a/Scripts/EscapeMenu.gd
+++ b/Scripts/EscapeMenu.gd
@@ -18,8 +18,6 @@ extends Control
 @export var quest_window: Control = null
 
 
-
-
 # A boolean variable used in an "if" statement to check if the game is paused or not.
 var game_paused: bool = false
 

--- a/Scripts/FurnitureStaticSpawner.gd
+++ b/Scripts/FurnitureStaticSpawner.gd
@@ -29,6 +29,7 @@ func _ready():
 
 
 # Function to spawn a FurnitureStaticSrv at a given position with given furniture data
+# furniture_data example: {"json": {"id": "kitchen_cupboard", "rotation": 0}, "pos": Vector3(12,2,189)}
 func spawn_furniture(furniture_data: Dictionary) -> void:
 	# Get the position using the helper function
 	var myposition: Vector3

--- a/Scripts/FurnitureStaticSrv.gd
+++ b/Scripts/FurnitureStaticSrv.gd
@@ -320,8 +320,11 @@ class FurnitureContainer:
 
 		# Set the material if items were added
 		if item_added:
-			material = Gamedata.materials.container_filled  # Use filled container material
-			sprite_mesh.material = material  # Update the mesh material
+			if rfurniture.function.random_container_sprite:
+				set_random_inventory_item_texture()
+			else:
+				material = Gamedata.materials.container_filled  # Use filled container material
+				sprite_mesh.material = material  # Update the mesh material
 		else:
 			# If no item was added we set the sprite to an empty container
 			_on_item_removed(null)

--- a/Scripts/Gamedata/DFurniture.gd
+++ b/Scripts/Gamedata/DFurniture.gd
@@ -13,7 +13,8 @@ extends RefCounted
 #		"sprite": "countertop_100_52.png",
 #		"Function": {
 #			"container_group": "kitchen_cupboard",
-#			"is_container": true,
+#			"is_container": true,,
+#			"random_container_sprite": false,
 #			"container_regeneration_time": -1
 #		},
 #		"categories": [
@@ -78,12 +79,14 @@ var parent: DFurnitures
 class Function:
 	var door: String = "None"  # Can be "None", "Open" or "Closed"
 	var is_container: bool = false
+	var random_container_sprite: bool = false
 	var container_group: String = ""
 	var container_regeneration_time: float = DEFAULT_CONTAINER_REGEN   # Time in days for container regeneration (-1.0 if it doesn't regenerate)
 
 	func _init(data: Dictionary):
 		door = data.get("door", "None")
 		is_container = data.get("is_container", false)
+		random_container_sprite = data.get("random_container_sprite", false)
 		container_group = data.get("container_group", "")
 		container_regeneration_time = data.get("container_regeneration_time", DEFAULT_CONTAINER_REGEN)
 
@@ -92,6 +95,8 @@ class Function:
 		var result = {}
 		if is_container:
 			result["is_container"] = is_container
+			if random_container_sprite != false:
+				result["random_container_sprite"] = random_container_sprite
 			if container_group != "":
 				result["container_group"] = container_group
 			if container_regeneration_time != DEFAULT_CONTAINER_REGEN:

--- a/Scripts/Gamedata/DMobgroups.gd
+++ b/Scripts/Gamedata/DMobgroups.gd
@@ -22,6 +22,17 @@ func _init(new_mod_id: String) -> void:
 	spritePath = "./Mods/" + mod_id + "/Mobs/"
 	load_sprites()
 	load_mobgroups_from_disk()
+	load_references()
+
+
+# Load references from references.json
+func load_references() -> void:
+	var path = dataPath + "references.json"
+	if FileAccess.file_exists(path):
+		references = Helper.json_helper.load_json_dictionary_file(path)
+	else:
+		references = {}  # Initialize an empty references dictionary if the file doesn't exist
+
 
 # Load all mob group data from disk into memory
 func load_mobgroups_from_disk() -> void:

--- a/Scripts/Helper/quest_helper.gd
+++ b/Scripts/Helper/quest_helper.gd
@@ -258,7 +258,7 @@ func _on_mob_killed(mobinstance: Mob):
 
 
 # The player has succesfully crafted an item.
-func _on_craft_successful(item: DItem, _recipe: DItem.CraftRecipe):
+func _on_craft_successful(item: RItem, _recipe: RItem.CraftRecipe):
 	# Get the current quests in progress
 	var quests_in_progress = QuestManager.get_quests_in_progress()
 	# Update each of the current quests with the collected item information

--- a/Scripts/Helper/signal_broker.gd
+++ b/Scripts/Helper/signal_broker.gd
@@ -16,6 +16,11 @@ signal inventory_window_visibility_changed(inventoryWindow: Control)
 # Nodes can use this signal to interrupt actions
 signal build_window_visibility_changed(buildWindow: Control)
 
+# Emitted when the user selects an option in the BuildingMenu.tscn scene
+# type: One of "block" or "furniture". Choice: can be "concrete_wall" or some furniture id
+@warning_ignore("unused_signal")
+signal construction_chosen(type: String, choice: String)
+
 # Signalled when an items were used
 # It can be one or more items. It's up to the receiver to figure it out
 @warning_ignore("unused_signal")

--- a/Scripts/Runtimedata/RFurniture.gd
+++ b/Scripts/Runtimedata/RFurniture.gd
@@ -268,5 +268,5 @@ func get_crafting_items() -> Array:
 	return crafting.get_items() if crafting else []
 
 # Returns the list of items from construction
-func get_construction_items() -> Array:
-	return construction.get_items() if construction else []
+func get_construction_items() -> Dictionary:
+	return construction.get_items() if construction else {}

--- a/Scripts/Runtimedata/RFurniture.gd
+++ b/Scripts/Runtimedata/RFurniture.gd
@@ -45,6 +45,7 @@ extends RefCounted
 class Function:
 	var door: String # Can be "None", "Open" or "Closed"
 	var is_container: bool
+	var random_container_sprite: bool = false
 	var container_group: String
 	var container_regeneration_time: float  # Time in minutes for container regeneration (-1 if it doesn't regenerate)
 
@@ -53,6 +54,7 @@ class Function:
 	func _init(data: Dictionary):
 		door = data.get("door", "None")
 		is_container = data.get("is_container", false)
+		random_container_sprite = data.get("random_container_sprite", false)
 		container_group = data.get("container_group", "")
 		container_regeneration_time = data.get("container_regeneration_time", -1.0)  # Default to -1
 
@@ -61,6 +63,8 @@ class Function:
 		var functiondata: Dictionary = {}
 		if is_container:
 			functiondata["is_container"] = is_container
+			if random_container_sprite != false:
+				functiondata["random_container_sprite"] = random_container_sprite
 			if not container_group == "":
 				functiondata["container_group"] = container_group
 			if container_regeneration_time != -1:  # Only include if not the default

--- a/Scripts/Runtimedata/RFurnitures.gd
+++ b/Scripts/Runtimedata/RFurnitures.gd
@@ -127,3 +127,15 @@ func _on_game_ended():
 
 func is_moveable(id: String) -> bool:
 	return by_id(id).moveable
+
+
+# Returns a list of all RFurniture instances that have construction items
+func get_constructable_furnitures() -> Array[RFurniture]:
+	var constructable_furnitures: Array[RFurniture] = []
+	
+	for furniture in furnituredict.values():
+		# Check if the furniture has construction items
+		if not furniture.get_construction_items().is_empty():
+			constructable_furnitures.append(furniture)
+	
+	return constructable_furnitures

--- a/Scripts/Runtimedata/RMobgroup.gd
+++ b/Scripts/Runtimedata/RMobgroup.gd
@@ -85,3 +85,18 @@ func get_random_mob_id() -> String:
 			return mob_id  # Return the selected mob ID
 
 	return ""  # Fallback in case of an error, should not be reached
+
+
+# Retrieves all maps associated with the mob group, including maps from its mobs.
+func get_maps() -> Array:
+	# Get a list of all maps that reference this mob
+	var mymaps: Array = referenced_maps.duplicate()
+	var modreferencedmaps: Array = []
+	# We check the reference for each mob in each mod
+	# Collect maps from each mob in the group
+	for mob_id in mobs.keys():
+		modreferencedmaps = Runtimedata.mobs.by_id(mob_id).referenced_maps # Get the maps from the references
+		mymaps = Helper.json_helper.merge_unique(mymaps, modreferencedmaps) # Merge with current list
+	
+	# Return the map data, or an empty array if no data is found
+	return mymaps if mymaps else []

--- a/Scripts/hud.gd
+++ b/Scripts/hud.gd
@@ -29,14 +29,8 @@ var progress_bar_timer_max_time : float
 
 var is_progress_bar_well_progressing_i_guess = false
 
-signal construction_chosen
-
-
 
 @export var item_protoset : ItemProtoset
-
-func test():
-	print("TESTING 123 123!")
 	
 func _process(_delta):
 	if is_progress_bar_well_progressing_i_guess:
@@ -90,10 +84,6 @@ func _input(event):
 
 func _on_player_update_stamina_hud(stamina):
 	get_node(stamina_HUD).text = str(round(stamina)) + "%"
-
-
-func _on_concrete_button_down():
-	construction_chosen.emit("concrete_wall")
 
 
 func start_progress_bar(time : float):

--- a/Scripts/item_manager.gd
+++ b/Scripts/item_manager.gd
@@ -362,7 +362,7 @@ func _on_items_used(usedItems: Array[InventoryItem]) -> void:
 # The user has pressed a button to start crafting
 # recipe: The currently selected recipe in the crafting menu
 # item: The currently selected item in the itemlist in the crafting menu
-func on_crafting_menu_start_craft(item: DItem, recipe: RItem.CraftRecipe):
+func on_crafting_menu_start_craft(item: RItem, recipe: RItem.CraftRecipe):
 	if recipe and item:
 		# If the player doesn't have the resources, return
 		if not CraftingRecipesManager.can_craft_recipe(recipe):

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -289,7 +289,7 @@ func play_footstep_audio():
 # The player has selected one or more items in the inventory and selected
 # 'use' from the context menu.
 func _on_food_item_used(usedItem: InventoryItem) -> void:
-	var food = DItem.Food.new(usedItem.get_property("Food"))
+	var food = RItem.Food.new(usedItem.get_property("Food"))
 	var was_used: bool = false
 
 	for attribute in food.attributes:
@@ -305,7 +305,7 @@ func _on_food_item_used(usedItem: InventoryItem) -> void:
 # 'use' from the context menu.
 func _on_medical_item_used(usedItem: InventoryItem) -> void:
 	
-	var medical = DItem.Medical.new(usedItem.get_property("Medical"))
+	var medical = RItem.Medical.new(usedItem.get_property("Medical"))
 	var was_used: bool = false
 
 	# Step 1: Apply specific amounts to each attribute
@@ -346,8 +346,8 @@ func _apply_specific_attribute_amounts(medattributes: Array) -> bool:
 
 
 # Function to apply the general medical amount from the pool
-# See the DItem class and its Medical subclass for the properties of DItem.Medical
-func _apply_general_medical_amount(medical: DItem.Medical) -> bool:
+# See the RItem class and its Medical subclass for the properties of RItem.Medical
+func _apply_general_medical_amount(medical: RItem.Medical) -> bool:
 	var was: Dictionary = {"used": false}  # Keep track of whether the item was used
 	var pool = medical.amount
 
@@ -520,7 +520,7 @@ func add_skill_xp(skill_id: String, xp: float) -> void:
 
 # The player has succesfully crafted an item. Get the skill id and xp from
 # the recipe and add it to the player's skill xp
-func _on_craft_successful(_item: DItem, recipe: DItem.CraftRecipe):
+func _on_craft_successful(_item: RItem, recipe: RItem.CraftRecipe):
 	if recipe.skill_progression:
 		add_skill_xp(recipe.skill_progression.id, recipe.skill_progression.xp)
 
@@ -575,7 +575,7 @@ func _modify_player_attribute_on_equip(wearableItem: InventoryItem, is_equipping
 		return
 
 	# Get the Wearable data from the item
-	var dwearable: DItem.Wearable = DItem.Wearable.new(wearableItem.get_property("Wearable"))
+	var dwearable: RItem.Wearable = RItem.Wearable.new(wearableItem.get_property("Wearable"))
 
 	# Get the list of player attributes from the wearable
 	var myattributes: Array = dwearable.player_attributes

--- a/hud.tscn
+++ b/hud.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=19 format=3 uid="uid://clhj525tmme3k"]
+[gd_scene load_steps=20 format=3 uid="uid://clhj525tmme3k"]
 
 [ext_resource type="FontFile" uid="uid://chm7lbcdeyo0h" path="res://Roboto-Bold.ttf" id="1_pxloi"]
 [ext_resource type="Script" path="res://Scripts/hud.gd" id="1_s3xoj"]
@@ -8,6 +8,7 @@
 [ext_resource type="Texture2D" uid="uid://dcgwgmsmi7mjn" path="res://Textures/bar_border.png" id="3_y43f5"]
 [ext_resource type="PackedScene" uid="uid://b6ooia1084wfx" path="res://Scenes/UI/AttributesWindow.tscn" id="6_6e87o"]
 [ext_resource type="PackedScene" uid="uid://drjw0yaxf8x1p" path="res://Scenes/UI/QuestTrackerUI.tscn" id="7_bbed4"]
+[ext_resource type="PackedScene" uid="uid://clpbtb0qfrk5j" path="res://Scenes/UI/BuildingMenu.tscn" id="9_v36fg"]
 [ext_resource type="PackedScene" uid="uid://sewnt37ji4s1" path="res://Scenes/UI/FurnitureWindow.tscn" id="11_40vt2"]
 [ext_resource type="PackedScene" uid="uid://bxyvtsslfr7kt" path="res://Scenes/UI/CraftingMenu.tscn" id="13_wjtvq"]
 [ext_resource type="PackedScene" uid="uid://cgxw4cu430nst" path="res://Scenes/UI/CharacterWindow.tscn" id="17_2f357"]
@@ -155,15 +156,8 @@ theme_override_font_sizes/font_size = 49
 text = "11:20"
 vertical_alignment = 1
 
-[node name="BuildingMenu" type="GridContainer" parent="."]
+[node name="BuildingMenu" parent="." instance=ExtResource("9_v36fg")]
 visible = false
-offset_right = 186.0
-offset_bottom = 33.0
-columns = 4
-
-[node name="Concrete" type="Button" parent="BuildingMenu"]
-layout_mode = 2
-text = "Concrete (2x plank)"
 
 [node name="CraftingMenu" parent="." instance=ExtResource("13_wjtvq")]
 visible = false
@@ -221,4 +215,3 @@ visible = false
 [connection signal="timeout" from="ProgressBar/ProgressBarTimer" to="." method="_on_progress_bar_timer_timeout"]
 [connection signal="mouse_entered" from="OutsideOfHUD" to="OutsideOfHUD" method="_on_mouse_entered"]
 [connection signal="mouse_exited" from="OutsideOfHUD" to="OutsideOfHUD" method="_on_mouse_exited"]
-[connection signal="button_down" from="BuildingMenu/Concrete" to="." method="_on_concrete_button_down"]

--- a/level_generation.tscn
+++ b/level_generation.tscn
@@ -267,4 +267,3 @@ transform = Transform3D(-0.946576, 0, -0.32248, 0, 1, 0, 0.32248, 0, -0.946576, 
 [connection signal="area_exited" from="TacticalMap/Entities/Player/ItemDetector" to="TacticalMap/Entities/Player/ItemDetector" method="_on_area_exited"]
 [connection signal="body_shape_entered" from="TacticalMap/Entities/Player/ItemDetector" to="TacticalMap/Entities/Player/ItemDetector" method="_on_body_shape_entered"]
 [connection signal="body_shape_exited" from="TacticalMap/Entities/Player/ItemDetector" to="TacticalMap/Entities/Player/ItemDetector" method="_on_body_shape_exited"]
-[connection signal="construction_chosen" from="HUD" to="TacticalMap/BuildManager" method="_on_hud_construction_chosen"]

--- a/level_generation.tscn
+++ b/level_generation.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=34 format=3 uid="uid://drl78uuphij1l"]
+[gd_scene load_steps=35 format=3 uid="uid://drl78uuphij1l"]
 
 [ext_resource type="Script" path="res://LevelGenerator.gd" id="1_i8qa4"]
 [ext_resource type="Script" path="res://LevelManager.gd" id="2_gm6x7"]
@@ -34,6 +34,8 @@ reflected_light_source = 1
 [sub_resource type="PlaneMesh" id="PlaneMesh_usfn3"]
 material = ExtResource("4_ujcgp")
 size = Vector2(1, 1)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_qial8"]
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_7gsdb"]
 albedo_color = Color(0, 1, 0, 1)
@@ -94,7 +96,7 @@ construction_ghost = NodePath("ConstructionGhost")
 LevelGenerator = NodePath("../LevelGenerator")
 hud = NodePath("../../HUD")
 
-[node name="ConstructionGhost" type="MeshInstance3D" parent="TacticalMap/BuildManager" node_paths=PackedStringArray("player", "sceneCam", "buildmanager")]
+[node name="ConstructionGhost" type="MeshInstance3D" parent="TacticalMap/BuildManager" node_paths=PackedStringArray("player", "sceneCam", "buildmanager", "construction_ghost_area_3d", "construction_ghost_collision_shape_3d")]
 editor_description = "Visualizes the construction of blocks and slopes for the player"
 visible = false
 cast_shadow = 0
@@ -103,6 +105,14 @@ script = ExtResource("5_iwiv4")
 player = NodePath("../../Entities/Player")
 sceneCam = NodePath("../../Entities/Player/Camera3D")
 buildmanager = NodePath("..")
+construction_ghost_area_3d = NodePath("../ConstructionGhostArea3D")
+construction_ghost_collision_shape_3d = NodePath("../ConstructionGhostArea3D/ConstructionGhostCollisionShape3D")
+
+[node name="ConstructionGhostArea3D" type="Area3D" parent="TacticalMap/BuildManager"]
+collision_mask = 255
+
+[node name="ConstructionGhostCollisionShape3D" type="CollisionShape3D" parent="TacticalMap/BuildManager/ConstructionGhostArea3D"]
+shape = SubResource("BoxShape3D_qial8")
 
 [node name="Entities" type="Node3D" parent="TacticalMap"]
 
@@ -260,6 +270,8 @@ bus = &"Music"
 [node name="TestCamera" type="Camera3D" parent="."]
 transform = Transform3D(-0.946576, 0, -0.32248, 0, 1, 0, 0.32248, 0, -0.946576, -20.8475, 0.21176, -31.9964)
 
+[connection signal="body_entered" from="TacticalMap/BuildManager/ConstructionGhostArea3D" to="TacticalMap/BuildManager/ConstructionGhost" method="_on_construction_ghost_area_3d_body_entered"]
+[connection signal="body_exited" from="TacticalMap/BuildManager/ConstructionGhostArea3D" to="TacticalMap/BuildManager/ConstructionGhost" method="_on_construction_ghost_area_3d_body_exited"]
 [connection signal="update_stamina_HUD" from="TacticalMap/Entities/Player" to="HUD" method="_on_player_update_stamina_hud"]
 [connection signal="ammo_changed" from="TacticalMap/Entities/Player/Sprite3D2/EquippedRight" to="HUD" method="_on_shooting_ammo_changed"]
 [connection signal="ammo_changed" from="TacticalMap/Entities/Player/Sprite3D2/EquippedLeft" to="HUD" method="_on_shooting_ammo_changed"]

--- a/level_generation.tscn
+++ b/level_generation.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=33 format=3 uid="uid://drl78uuphij1l"]
+[gd_scene load_steps=34 format=3 uid="uid://drl78uuphij1l"]
 
 [ext_resource type="Script" path="res://LevelGenerator.gd" id="1_i8qa4"]
 [ext_resource type="Script" path="res://LevelManager.gd" id="2_gm6x7"]
 [ext_resource type="PackedScene" path="res://day_night.tscn" id="3_0lu7f"]
+[ext_resource type="Material" uid="uid://ot2fpooebty0" path="res://Defaults/Blocks/Materials/construction_ghost_material.tres" id="4_ujcgp"]
 [ext_resource type="Script" path="res://Scripts/ConstructionGhost.gd" id="5_iwiv4"]
 [ext_resource type="Script" path="res://Scripts/BuildManager.gd" id="6_y7rk5"]
 [ext_resource type="Texture2D" uid="uid://d33h00t0fl7x" path="res://Defaults/Player/VestDude01.png" id="7_jr4x1"]
@@ -31,6 +32,7 @@ ambient_light_energy = 0.0
 reflected_light_source = 1
 
 [sub_resource type="PlaneMesh" id="PlaneMesh_usfn3"]
+material = ExtResource("4_ujcgp")
 size = Vector2(1, 1)
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_7gsdb"]

--- a/level_generation.tscn
+++ b/level_generation.tscn
@@ -109,7 +109,7 @@ construction_ghost_area_3d = NodePath("../ConstructionGhostArea3D")
 construction_ghost_collision_shape_3d = NodePath("../ConstructionGhostArea3D/ConstructionGhostCollisionShape3D")
 
 [node name="ConstructionGhostArea3D" type="Area3D" parent="TacticalMap/BuildManager"]
-collision_mask = 255
+collision_mask = 191
 
 [node name="ConstructionGhostCollisionShape3D" type="CollisionShape3D" parent="TacticalMap/BuildManager/ConstructionGhostArea3D"]
 shape = SubResource("BoxShape3D_qial8")
@@ -205,6 +205,7 @@ reload_audio_player = NodePath("../../Shooting/ReloadAudio")
 
 [node name="MeleeRange" type="Area3D" parent="TacticalMap/Entities/Player/Sprite3D2"]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, -0.277026)
+collision_layer = 0
 collision_mask = 14
 
 [node name="MeleeCollisionShape3D" type="CollisionShape3D" parent="TacticalMap/Entities/Player/Sprite3D2/MeleeRange"]


### PR DESCRIPTION
Requires #600 

The trees were made into containers before, but they all had the `container_full` sprite as the container sprite. This was very ugly when walking trough the forest. 

This pr allows furniture to set a random item sprite for the container instead. When the checkbox is off, the furniture container will use the default `container_full` sprite until an item is added or removed from the container. If the checkbox is on, the initial container sprite will be the sprite of a random item inside the container.