### PR TITLE
Update crafting ui when re-opened

### DIFF
--- a/Scripts/ConstructionGhost.gd
+++ b/Scripts/ConstructionGhost.gd
@@ -190,14 +190,12 @@ func reset_rotation_to_default() -> void:
 func _on_construction_ghost_area_3d_body_entered(body: Node3D) -> void:
 	# Mark that an obstacle is present
 	has_obstacle = true
-	print_debug("Obstacle detected: ", body.name)
 
 # Called when a body exits the construction ghost's area
 func _on_construction_ghost_area_3d_body_exited(body: Node3D) -> void:
 	# Check if no other obstacles remain in the area
 	if construction_ghost_area_3d.get_overlapping_bodies().size() == 0:
 		has_obstacle = false
-		print_debug("Obstacle cleared: ", body.name)
 
 func reset_to_default():
 	reset_rotation_to_default()

--- a/Scripts/CraftingMenu.gd
+++ b/Scripts/CraftingMenu.gd
@@ -21,6 +21,7 @@ var item_buttons = {}
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
+	self.visibility_changed.connect(_on_visibility_changed)
 	start_craft.connect(ItemManager.on_crafting_menu_start_craft)
 	ItemManager.allAccessibleItems_changed.connect(_on_allAccessibleItems_changed)
 	Helper.signal_broker.player_skill_changed.connect(_on_player_skill_changed)
@@ -245,3 +246,11 @@ func _on_craft_successful(_item: RItem, _recipe: RItem.CraftRecipe):
 func _on_craft_failed(_item: RItem, _recipe: RItem.CraftRecipe, reason: String):
 	var color = Color(1, 0, 0)  # Red color
 	display_feedback(reason, color)
+
+
+# Check if the window is visible and update the ui
+func _on_visibility_changed():
+	if visible:
+		# If there's an active recipe, refresh the required items display
+		if active_recipe != null:
+			update_required_items_display(active_recipe)


### PR DESCRIPTION
Fixes #610 

When the crafting menu was re-opened, the ui wasn't refreshed. This pr changes the script so the UI is refreshed after it is re-opened.