### PR TITLE
Equipped items count for quest

### DIFF
--- a/Scripts/EquipmentSlot.gd
+++ b/Scripts/EquipmentSlot.gd
@@ -127,5 +127,3 @@ func _handle_magazine_drop(magazine: InventoryItem):
 	else:
 		# Equip the item if no weapon is wielded
 		equip(magazine)
-
-


### PR DESCRIPTION
Fixes #605 

Adds tracking of equipped items to the quest manager. Now we are tracking the equipped items at two places, which I don't prefer. I'd like to move the quest helper into the actual game scene down the line since that's where it needs to be used. Then we can access the player's slots directly.