### PR TITLE
Mark items as hand-craftable

### DIFF
--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -46,6 +46,9 @@ json_data = "[
 			{
 				\"craft_amount\": 1,
 				\"craft_time\": 10,
+				\"flags\": {
+					\"requires_light\": true
+				},
 				\"required_resources\": [
 					{
 						\"amount\": 1,
@@ -267,6 +270,9 @@ json_data = "[
 			{
 				\"craft_amount\": 1,
 				\"craft_time\": 1,
+				\"flags\": {
+					\"requires_light\": true
+				},
 				\"required_resources\": [
 					{
 						\"amount\": 1,
@@ -446,6 +452,14 @@ json_data = "[
 		\"weight\": 0.5
 	},
 	{
+		\"Food\": {
+			\"attributes\": [
+				{
+					\"amount\": 35,
+					\"id\": \"water\"
+				}
+			]
+		},
 		\"description\": \"It's a can that contains beer. Don't drink a lot of it or you will get drunk\",
 		\"id\": \"can_beer\",
 		\"image\": \"./Mods/Dimensionfall/Items/can_beer_32.png\",
@@ -708,6 +722,10 @@ json_data = "[
 			{
 				\"craft_amount\": 1,
 				\"craft_time\": 10,
+				\"flags\": {
+					\"hand_craftable\": false,
+					\"requires_light\": true
+				},
 				\"required_resources\": [
 					{
 						\"amount\": 1,
@@ -783,6 +801,9 @@ json_data = "[
 			{
 				\"craft_amount\": 1,
 				\"craft_time\": 10,
+				\"flags\": {
+					\"requires_light\": true
+				},
 				\"required_resources\": [
 					{
 						\"amount\": 1,
@@ -2292,6 +2313,9 @@ json_data = "[
 			{
 				\"craft_amount\": 1,
 				\"craft_time\": 10,
+				\"flags\": {
+					\"requires_light\": false
+				},
 				\"required_resources\": [
 					{
 						\"amount\": 1,
@@ -2489,6 +2513,9 @@ json_data = "[
 			{
 				\"craft_amount\": 1,
 				\"craft_time\": 10,
+				\"flags\": {
+					\"requires_light\": false
+				},
 				\"required_resources\": [
 					{
 						\"amount\": 1,

--- a/Mods/Dimensionfall/Items/Items.json
+++ b/Mods/Dimensionfall/Items/Items.json
@@ -756,6 +756,7 @@
 				"craft_amount": 1,
 				"craft_time": 10,
 				"flags": {
+					"hand_craftable": false,
 					"requires_light": true
 				},
 				"required_resources": [

--- a/Mods/Dimensionfall/Items/Items.json
+++ b/Mods/Dimensionfall/Items/Items.json
@@ -467,6 +467,14 @@
 		"weight": 0.5
 	},
 	{
+		"Food": {
+			"attributes": [
+				{
+					"amount": 35,
+					"id": "water"
+				}
+			]
+		},
 		"description": "It's a can that contains beer. Don't drink a lot of it or you will get drunk",
 		"id": "can_beer",
 		"image": "./Mods/Dimensionfall/Items/can_beer_32.png",

--- a/Mods/Dimensionfall/PlayerAttributes/references.json
+++ b/Mods/Dimensionfall/PlayerAttributes/references.json
@@ -107,7 +107,8 @@
 			"kiwi",
 			"zombie_organ",
 			"zombie_eye",
-			"rotten_flesh_chunk"
+			"rotten_flesh_chunk",
+			"can_beer"
 		]
 	}
 }

--- a/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemCraftEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemCraftEditor.tscn
@@ -19,7 +19,7 @@ corner_radius_top_right = 5
 corner_radius_bottom_right = 5
 corner_radius_bottom_left = 5
 
-[node name="ItemCraftEditor" type="Control" node_paths=PackedStringArray("craftAmountNumber", "craftTimeNumber", "requiresLightCheckbox", "resourcesGridContainer", "recipesContainer", "required_skill_text_edit", "skill_level_requirement_spin_box", "skill_progression_text_edit", "skill_progression_spin_box")]
+[node name="ItemCraftEditor" type="Control" node_paths=PackedStringArray("craftAmountNumber", "craftTimeNumber", "requiresLightCheckbox", "hand_craftable_check_box", "resourcesGridContainer", "recipesContainer", "required_skill_text_edit", "skill_level_requirement_spin_box", "skill_progression_text_edit", "skill_progression_spin_box")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -29,7 +29,8 @@ grow_vertical = 2
 script = ExtResource("1_6wvrt")
 craftAmountNumber = NodePath("Craft/CraftAmountNumber")
 craftTimeNumber = NodePath("Craft/CraftTimeNumber")
-requiresLightCheckbox = NodePath("Craft/RequiresLightCheckBox")
+requiresLightCheckbox = NodePath("Craft/HBoxContainer2/RequiresLightCheckBox")
+hand_craftable_check_box = NodePath("Craft/HBoxContainer2/HandCraftableCheckBox")
 resourcesGridContainer = NodePath("Craft/PanelContainer/ResourcesGridContainer")
 recipesContainer = NodePath("Craft/HBoxContainer/RecipeContainerOptionButton")
 required_skill_text_edit = NodePath("Craft/SkillRequirementHBoxContainer/RequiredSkillNameDropEnabledTextEdit")
@@ -122,11 +123,23 @@ editable = false
 layout_mode = 2
 text = "Flags"
 
-[node name="RequiresLightCheckBox" type="CheckBox" parent="Craft"]
+[node name="HBoxContainer2" type="HBoxContainer" parent="Craft"]
+layout_mode = 2
+
+[node name="RequiresLightCheckBox" type="CheckBox" parent="Craft/HBoxContainer2"]
 layout_mode = 2
 tooltip_text = "Enable this if the item weapon occupies both hands when held. Disable this if the item occupies one hand when held"
 disabled = true
 text = "Requires light"
+
+[node name="HandCraftableCheckBox" type="CheckBox" parent="Craft/HBoxContainer2"]
+layout_mode = 2
+tooltip_text = "Checked: This item can be crafted by hand and by crafting stations.
+Unchecked: This item can only be crafted by crafting stations.
+Note: In order to be craftable by crafting stations, you have to edit 
+a furniture and add this item to the craftable items there."
+button_pressed = true
+text = "Hand craftable"
 
 [node name="SkillRequirementLabel" type="Label" parent="Craft"]
 layout_mode = 2

--- a/Scenes/ContentManager/Scripts/addremovemods.gd
+++ b/Scenes/ContentManager/Scripts/addremovemods.gd
@@ -210,7 +210,6 @@ func populate_mods_item_list() -> void:
 	print_debug("Populated mods_item_list successfully.")
 
 
-
 # When the user presses the save button
 func _on_save_button_button_up() -> void:
 	# Get the selected mod

--- a/Scripts/FurnitureStaticSrv.gd
+++ b/Scripts/FurnitureStaticSrv.gd
@@ -598,21 +598,23 @@ class CraftingContainer:
 				return false
 		return true
 
-
+# --------------------------------------------------------------
+# Initialization
+# --------------------------------------------------------------
 
 # Function to initialize the furniture object
-func _init(furniturepos: Vector3, newFurnitureJSON: Dictionary, world3d: World3D):
+func _init(furniturepos: Vector3, new_furniture_json: Dictionary, world3d: World3D):
 	furniture_position = furniturepos
-	furnitureJSON = newFurnitureJSON
-	furniture_rotation = furnitureJSON.get("rotation", 0)
-	rfurniture = Runtimedata.furnitures.by_id(furnitureJSON.id)
+	furnitureJSON = new_furniture_json
 	myworld3d = world3d
-
+	rfurniture = Runtimedata.furnitures.by_id(furnitureJSON.id)
 	sprite_texture = rfurniture.sprite
-	var furniture_size: Vector3 = calculate_furniture_size()
+	furniture_rotation = furnitureJSON.get("rotation", 0)
 
-	furniture_transform = FurnitureTransform.new(furniturepos, furniture_rotation, furniture_size)
-
+	furniture_transform = FurnitureTransform.new(
+		furniturepos, furniture_rotation, calculate_furniture_size()
+	)
+	
 	if _is_new_furniture():
 		furniture_transform.correct_new_position()
 		_apply_edge_snapping_if_needed()
@@ -631,6 +633,7 @@ func _init(furniturepos: Vector3, newFurnitureJSON: Dictionary, world3d: World3D
 	update_door_visuals()  # Set initial door visuals based on its state
 	add_container()  # Adds container if the furniture is a container
 	add_crafting_container() # Adds crafting container if the furniture is a crafting station
+
 
 # If this furniture is a container, it will add a container node to the furniture.
 func add_container():

--- a/Scripts/FurnitureStaticSrv.gd
+++ b/Scripts/FurnitureStaticSrv.gd
@@ -979,7 +979,7 @@ func add_corpse(pos: Vector3):
 		Helper.map_manager.level_generator.get_tree().get_root().add_child.call_deferred(newItem)
 		
 		# Check if inventory has items and insert them into the new item
-		if container.get_inventory():
+		if is_container() and container.get_inventory():
 			for item in container.get_inventory().get_items():
 				newItem.insert_item(item)
 

--- a/Scripts/FurnitureWindow.gd
+++ b/Scripts/FurnitureWindow.gd
@@ -343,7 +343,7 @@ func _on_all_accessible_items_changed(_items_added: Array, _items_removed: Array
 
 # Callback for when the inventory contents change.
 func _on_inventory_contents_changed():
-	if furniture_instance:
+	if furniture_instance and current_item_id:
 		_refresh_ingredient_list(Runtimedata.items.by_id(current_item_id))
 		_update_craft_status_label()
 

--- a/Scripts/Gamedata/DItem.gd
+++ b/Scripts/Gamedata/DItem.gd
@@ -38,7 +38,7 @@ var wearable: Wearable
 class CraftRecipe:
 	var craft_amount: int
 	var craft_time: int
-	var flags: Dictionary
+	var flags: Dictionary # Example: { "requires_light": false, "hand_craftable": true }
 	var required_resources: Array # A list of objects like {"amount": 1, "id": "steel_scrap"}
 	var skill_progression: Dictionary # example: { "id": "fabrication", "xp": 10 }
 	var skill_requirement: Dictionary # example: { "id": "fabrication", "level": 1 }

--- a/Scripts/Gamedata/DMods.gd
+++ b/Scripts/Gamedata/DMods.gd
@@ -324,7 +324,7 @@ func has_mod(mod_id: String) -> bool:
 
 # ------------------------------------------------------------------
 # Retrieves all mod IDs as an array of strings.
-func get_all_mod_ids() -> Array[String]:
+func get_all_mod_ids() -> Array:
 	return mod_dict.keys()
 
 # ------------------------------------------------------------------

--- a/Scripts/Gamedata/DMods.gd
+++ b/Scripts/Gamedata/DMods.gd
@@ -4,7 +4,7 @@ extends RefCounted
 # This script handles the list of mods. You can access it through Gamedata.mods
 
 # All loaded mods
-var moddict: Dictionary = {}
+var mod_dict: Dictionary = {}
 
 # Constructor
 # Initialize with a mod_id to dynamically set the dataPath
@@ -12,10 +12,10 @@ func _init() -> void:
 	load_mods_from_disk()
 
 
-# Function to load all mods from the ./Mods directory and populate the moddict dictionary
+# Function to load all mods from the ./Mods directory and populate the mod_dict dictionary
 func load_mods_from_disk() -> void:
-	# Clear the moddict dictionary
-	moddict.clear()
+	# Clear the mod_dict dictionary
+	mod_dict.clear()
 
 	# Get the list of saved mod states
 	var mod_states = get_mod_list_states()
@@ -36,7 +36,7 @@ func load_mods_from_disk() -> void:
 		if FileAccess.file_exists(modinfo_path):
 			var modinfo = Helper.json_helper.load_json_dictionary_file(modinfo_path)
 
-			# Validate modinfo data and add it to the moddict dictionary
+			# Validate modinfo data and add it to the mod_dict dictionary
 			if modinfo.has("id"):
 				var mod_id = modinfo["id"]
 				
@@ -44,7 +44,7 @@ func load_mods_from_disk() -> void:
 				var mod = DMod.new(modinfo, self)
 				mod.is_enabled = enabled_states.get(mod_id, true)  # Default to enabled if not in saved states
 
-				moddict[mod_id] = mod
+				mod_dict[mod_id] = mod
 			else:
 				print_debug("Invalid modinfo.json in folder: " + folder_name)
 		else:
@@ -53,40 +53,32 @@ func load_mods_from_disk() -> void:
 
 # Returns the dictionary containing all mods
 func get_all() -> Dictionary:
-	return moddict
+	return mod_dict
 
 # Adds a new mod with a given ID
 func add_new(newid: String, modinfo: Dictionary) -> void:
 	modinfo["id"] = newid
 	var newmod: DMod = DMod.new(modinfo, self)
-	moddict[newmod.id] = newmod
+	mod_dict[newmod.id] = newmod
 
 # Deletes a mod by its ID and saves changes to disk
 func delete_by_id(modid: String) -> void:
-	moddict.erase(modid)
+	mod_dict.erase(modid)
 
 # Returns a mod by its ID
 func by_id(modid: String) -> DMod:
-	return moddict.get(modid, null)
+	return mod_dict.get(modid, null)
 
 # Checks if a mod exists by its ID
 func has_id(modid: String) -> bool:
-	return moddict.has(modid)
-
-# Returns an array of all mod IDs (keys in the moddict dictionary)
-func get_all_mod_ids() -> Array:
-	return moddict.keys()
-
-# Returns an array of all mod IDs (keys in the moddict dictionary)
-func get_all_mods() -> Array:
-	return moddict.values()
+	return mod_dict.has(modid)
 
 # Function to retrieve content by its type and ID across all mods
 # The returned value may be a DMap, DItem, DMobgroup or anything
 # contentType: A DMod.ContentType
 func get_content_by_id(contentType: DMod.ContentType, id: String) -> RefCounted:
-	# Loop over all mods in the moddict
-	for mod: DMod in moddict.values():
+	# Loop over all mods in the mod_dict
+	for mod: DMod in mod_dict.values():
 		# Get the content instance of the specified type for the current mod
 		var content_instance: RefCounted = mod.get_data_of_type(contentType)
 		if content_instance:
@@ -105,8 +97,8 @@ func get_content_by_id(contentType: DMod.ContentType, id: String) -> RefCounted:
 func get_all_content_by_id(contentType: DMod.ContentType, id: String) -> Array[RefCounted]:
 	var results: Array[RefCounted] = []
 	
-	# Loop over all mods in the moddict
-	for mod in moddict.values():
+	# Loop over all mods in the mod_dict
+	for mod in mod_dict.values():
 		# Get the content instance of the specified type for the current mod
 		var content_instance: RefCounted = mod.get_data_of_type(contentType)
 		if content_instance:
@@ -136,8 +128,8 @@ func get_all_content_by_id(contentType: DMod.ContentType, id: String) -> Array[R
 #		}
 #	}
 func add_reference(contentType: DMod.ContentType, id: String, ref_type: DMod.ContentType, ref_id: String) -> void:
-	# Loop over all mods in the moddict
-	for mod: DMod in moddict.values():
+	# Loop over all mods in the mod_dict
+	for mod: DMod in mod_dict.values():
 		# Get the content instance of the specified type for the current mod
 		var content_instance: RefCounted = mod.get_data_of_type(contentType)
 		if content_instance:
@@ -152,8 +144,8 @@ func add_reference(contentType: DMod.ContentType, id: String, ref_type: DMod.Con
 # ref_type: The type of the entity that we remove as a reference
 # ref_id: The id of the entity that we remove as a reference
 func remove_reference(contentType: DMod.ContentType, id: String, ref_type: DMod.ContentType, ref_id: String) -> void:
-	# Loop over all mods in the moddict
-	for mod: DMod in moddict.values():
+	# Loop over all mods in the mod_dict
+	for mod: DMod in mod_dict.values():
 		# Get the content instance of the specified type for the current mod
 		var content_instance: RefCounted = mod.get_data_of_type(contentType)
 		if content_instance:
@@ -229,8 +221,8 @@ func get_mod_list_states() -> Array:
 # Returns an array of IDs for all enabled mods
 func get_enabled_mod_ids() -> Array:
 	var enabled_mods: Array = []
-	for mod_id in moddict.keys():
-		if moddict[mod_id].is_enabled:
+	for mod_id in mod_dict.keys():
+		if mod_dict[mod_id].is_enabled:
 			enabled_mods.append(mod_id)
 	return enabled_mods
 
@@ -242,9 +234,9 @@ func get_mods_in_state_order(only_enabled: bool) -> Array[DMod]:
 	var ordered_mods: Array[DMod] = []
 	var mod_states = get_mod_list_states()  # Retrieve the saved mod states
 
-	# Add the "Core" mod first if it exists in the moddict
-	if moddict.has("Core"):
-		ordered_mods.append(moddict["Core"])
+	# Add the "Core" mod first if it exists in the mod_dict
+	if mod_dict.has("Core"):
+		ordered_mods.append(mod_dict["Core"])
 
 	# Add the remaining mods in the order specified by mod_states
 	for mod_state in mod_states:
@@ -255,9 +247,9 @@ func get_mods_in_state_order(only_enabled: bool) -> Array[DMod]:
 			continue
 
 		var is_enabled = mod_state["enabled"]
-		if moddict.has(mod_id):
+		if mod_dict.has(mod_id):
 			if not only_enabled or (only_enabled and is_enabled):
-				ordered_mods.append(moddict[mod_id])
+				ordered_mods.append(mod_dict[mod_id])
 
 	return ordered_mods
 
@@ -319,3 +311,34 @@ func write_default_mods_state() -> void:
 			print_debug("Default mod states written to mods_state.cfg.")
 		else:
 			print_debug("Failed to write default mod states to mods_state.cfg. Error code: ", err)
+
+# ------------------------------------------------------------------
+# Adds a new mod to the dictionary and initializes it with the given data.
+func add_new_mod(mod_id: String, mod_info: Dictionary) -> void:
+	mod_info["id"] = mod_id
+	mod_dict[mod_id] = DMod.new(mod_info, self)
+
+# ------------------------------------------------------------------
+# Removes a mod from the dictionary by its ID.
+func delete_mod_by_id(mod_id: String) -> void:
+	mod_dict.erase(mod_id)
+
+# ------------------------------------------------------------------
+# Retrieves a DMod instance by its ID.
+func get_mod_by_id(mod_id: String) -> DMod:
+	return mod_dict.get(mod_id, null)
+
+# ------------------------------------------------------------------
+# Checks if a mod exists in the dictionary by its ID.
+func has_mod(mod_id: String) -> bool:
+	return mod_dict.has(mod_id)
+
+# ------------------------------------------------------------------
+# Retrieves all mod IDs as an array of strings.
+func get_all_mod_ids() -> Array[String]:
+	return mod_dict.keys()
+
+# ------------------------------------------------------------------
+# Retrieves all loaded mods as an array of DMod instances.
+func get_all_mods() -> Array[DMod]:
+	return mod_dict.values()

--- a/Scripts/Gamedata/DPlayerAttributes.gd
+++ b/Scripts/Gamedata/DPlayerAttributes.gd
@@ -26,6 +26,7 @@ func _init(new_mod_id: String) -> void:
 	
 	load_sprites()
 	load_playerattributes_from_disk()
+	load_references()
 
 # Load all playerattributedata from disk into memory
 func load_playerattributes_from_disk() -> void:

--- a/Scripts/ItemCraftEditor.gd
+++ b/Scripts/ItemCraftEditor.gd
@@ -6,6 +6,7 @@ extends Control
 @export var craftAmountNumber: SpinBox = null
 @export var craftTimeNumber: SpinBox = null
 @export var requiresLightCheckbox: CheckBox = null
+@export var hand_craftable_check_box: CheckBox = null
 @export var resourcesGridContainer: GridContainer = null
 @export var recipesContainer: OptionButton = null  # Dropdown to select which recipe to edit
 @export var required_skill_text_edit: HBoxContainer
@@ -47,6 +48,7 @@ func load_recipe_into_ui(recipe: DItem.CraftRecipe):
 	craftAmountNumber.value = recipe.craft_amount
 	craftTimeNumber.value = recipe.craft_time
 	requiresLightCheckbox.button_pressed = recipe.flags.get("requires_light", false)
+	hand_craftable_check_box.button_pressed = recipe.flags.get("hand_craftable", true)
 
 	# Load skill requirements
 	required_skill_text_edit.set_text(recipe.skill_requirement.get("id", ""))
@@ -84,7 +86,10 @@ func _update_current_recipe():
 		var current_recipe = craft_recipes[current_recipe_index]
 		current_recipe.craft_amount = craftAmountNumber.value
 		current_recipe.craft_time = craftTimeNumber.value
-		current_recipe.flags = {"requires_light": requiresLightCheckbox.button_pressed}
+		current_recipe.flags = {
+			"requires_light": requiresLightCheckbox.button_pressed,
+			"hand_craftable": hand_craftable_check_box.button_pressed
+		}
 		current_recipe.required_resources = _get_resources_from_ui()
 
 		# Add skill_requirement if required_skill_text_edit has a value

--- a/Scripts/ItemFoodEditor.gd
+++ b/Scripts/ItemFoodEditor.gd
@@ -87,13 +87,20 @@ func _delete_attribute_entry(elements_to_remove: Array) -> void:
 
 
 # Function to determine if the dragged data can be dropped in the attributesGridContainer
+# We are expecting a dictionary like this:
+#	{
+#		"id": selected_item_id,
+#		"text": selected_item_text,
+#		"mod_id": mod_id,
+#		"contentType": contentType
+#	}
 func _can_drop_attribute_data(_newpos, data) -> bool:
 	# Check if the data dictionary has the 'id' property
 	if not data or not data.has("id"):
 		return false
 
 	# Fetch attribute by ID from the Gamedata to ensure it exists and is valid
-	if not Gamedata.mods.by_id("Core").playerattributes.has_id(data["id"]):
+	if not Gamedata.mods.by_id(data["mod_id"]).playerattributes.has_id(data["id"]):
 		return false
 
 	# Check if the attribute ID already exists in the attributes grid
@@ -115,11 +122,18 @@ func _drop_attribute_data(newpos, data) -> void:
 
 # Called when the user has successfully dropped data onto the attributesGridContainer
 # We have to check the dropped_data for the id property
+# We are expecting a dictionary like this:
+#	{
+#		"id": selected_item_id,
+#		"text": selected_item_text,
+#		"mod_id": mod_id,
+#		"contentType": contentType
+#	}
 func _handle_attribute_drop(dropped_data, _newpos) -> void:
 	# dropped_data is a Dictionary that includes an 'id'
 	if dropped_data and "id" in dropped_data:
 		var attribute_id = dropped_data["id"]
-		if not Gamedata.mods.by_id("Core").playerattributes.has_id(attribute_id):
+		if not Gamedata.mods.by_id(dropped_data["mod_id"]).playerattributes.has_id(attribute_id):
 			print_debug("No attribute data found for ID: " + attribute_id)
 			return
 		

--- a/Scripts/Runtimedata/RItem.gd
+++ b/Scripts/Runtimedata/RItem.gd
@@ -29,6 +29,7 @@ extends RefCounted
 class CraftRecipe:
 	var craft_amount: int
 	var craft_time: int
+	var flags: Dictionary # Example: { "requires_light": false, "hand_craftable": true }
 	var required_resources: Array
 	var skill_requirement: Dictionary
 	var skill_progression: Dictionary
@@ -36,6 +37,7 @@ class CraftRecipe:
 	func _init(data: Dictionary):
 		craft_amount = data.get("craft_amount", 1)
 		craft_time = data.get("craft_time", 0)
+		flags = data.get("flags", {})
 		required_resources = data.get("required_resources", [])
 		skill_requirement = data.get("skill_requirement", {})
 		skill_progression = data.get("skill_progression", {})
@@ -44,6 +46,7 @@ class CraftRecipe:
 		var data: Dictionary = {
 			"craft_amount": craft_amount,
 			"craft_time": craft_time,
+			"flags": flags,
 			"required_resources": required_resources
 		}
 		if not skill_requirement.is_empty():

--- a/Scripts/Runtimedata/RItems.gd
+++ b/Scripts/Runtimedata/RItems.gd
@@ -147,3 +147,23 @@ func save_items_protoset() -> void:
 
 func get_first_recipe_by_id(item_id: String) -> RItem.CraftRecipe:
 	return by_id(item_id).get_first_recipe()
+
+
+# Returns a list of items that are hand-craftable.
+# These items must have the craft property and at least one recipe with the "hand_craftable" flag set to true.
+func get_hand_craftable_items() -> Array[RItem]:
+	var hand_craftable_items: Array[RItem] = []
+
+	for item: RItem in itemdict.values():
+		# Check if the item has the `craft` property and at least one recipe
+		if not item.get("craft") == null and item.craft.recipes.size() > 0:
+			# Check if any recipe has the "hand_craftable" flag set to true
+			for recipe: RItem.CraftRecipe in item.craft.recipes:
+				if recipe.get("flags") == null:
+					hand_craftable_items.append(item)
+					break  # The item has no flags so assume it's hand craftable
+				elif recipe.flags.get("hand_craftable", true):
+					hand_craftable_items.append(item)
+					break  # Exit the loop as we only need one matching recipe
+
+	return hand_craftable_items

--- a/Scripts/crafting_recipes_manager.gd
+++ b/Scripts/crafting_recipes_manager.gd
@@ -11,7 +11,7 @@ func _ready():
 	Helper.signal_broker.game_started.connect(get_crafting_recipes_from_json)
 
 func get_crafting_recipes_from_json() -> void:
-	craftable_items = Runtimedata.items.get_items_by_type("craft")
+	craftable_items = Runtimedata.items.get_hand_craftable_items()
 
 
 # Function to check if there are enough resources in the inventory to craft a given recipe.

--- a/Scripts/scene_selector.gd
+++ b/Scripts/scene_selector.gd
@@ -15,6 +15,7 @@ func _ready():
 	# Populate the load_game_list with the saved game folders
 	for saved_game in saved_game_folders:
 		load_game_list.add_item(saved_game)
+	Gamedata.mods.write_default_mods_state()
 
 
 func _on_load_game_button_pressed():


### PR DESCRIPTION
Fixes #597
Fixes #580 

Adds a check for items so they are either included or excluded from hand crafting. 
When an item is included for handcrafting, it will show up in the crafting menu for the player and also in any crafting station that allows the craft
When an item is excluded from handcrafting, it will not show up in the crafting menu for the player, but can still be crafted in a crafting station.

The check is still very simple, because one item can have multiple recipes. What happens when one item has two recipes, where one is handcraftable and the other isn't? Well right now both recipes will be handcraftable if only one is marked as handcraftable. We can probably fix it at some point.