### PR TITLE
Dev/remove hand specific fields

### DIFF
--- a/Scripts/Helper/SignalBroker/signal_broker.gd
+++ b/Scripts/Helper/SignalBroker/signal_broker.gd
@@ -119,7 +119,7 @@ signal player_skill_changed(player: Player)
 @warning_ignore("unused_signal")
 signal player_attribute_changed(player: Player, attribute: PlayerAttribute)
 @warning_ignore("unused_signal")
-signal player_ammo_changed(current_ammo: int, max_ammo: int, lefthand: bool)
+signal player_ammo_changed(current_ammo: int, max_ammo: int, slot_index: int)
 
 # Save load start end events
 @warning_ignore("unused_signal")

--- a/Scripts/hud.gd
+++ b/Scripts/hud.gd
@@ -4,8 +4,7 @@ extends CanvasLayer
 @export var clock_label: Label = null
 
 
-@export var ammo_HUD_left: NodePath
-@export var ammo_HUD_right: NodePath
+@export var ammo_HUD_container: Node
 
 @export var healthy_color: Color
 @export var damaged_color: Color
@@ -107,15 +106,12 @@ func _on_progress_bar_timer_timeout():
 	interrupt_progress_bar()
 
 
-func _on_shooting_ammo_changed(current_ammo: int, max_ammo: int, leftHand:bool):
-	var ammo_HUD: Label = get_node(ammo_HUD_left)
-	var prefix: String = "L: "
-	if !leftHand:
-		ammo_HUD = get_node(ammo_HUD_right)
-		prefix = "R: "
+func _on_shooting_ammo_changed(current_ammo: int, max_ammo: int, slot_index: int):
+	var ammo_HUD: Label = ammo_HUD_container.get_children()[slot_index]
 	if current_ammo == -1 and max_ammo == -1:  # Assuming -1 is the value when no weapon is equipped
 		ammo_HUD.hide()
 	else:
+		var prefix: String = ammo_HUD.text.substr(0, 2)
 		ammo_HUD.text = prefix + str(current_ammo) + "/" + str(max_ammo)
 		ammo_HUD.show()
 

--- a/Scripts/input_manager.gd
+++ b/Scripts/input_manager.gd
@@ -18,7 +18,6 @@ func process_mouse_press() -> void:
 		return
 	
 	if Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT):
-		print("left click")
 		PlayerInputSignalBroker.try_activate_equipped_item(0).emit(0)
 	if Input.is_mouse_button_pressed(MOUSE_BUTTON_RIGHT):
 		PlayerInputSignalBroker.try_activate_equipped_item(1).emit(1)

--- a/Scripts/input_manager.gd
+++ b/Scripts/input_manager.gd
@@ -5,8 +5,20 @@ extends Node
 # signals usable by the rest of the scene.  This class should have limited knowledge about the current
 # game state, merely mapping input to signal
 
+var is_inventory_open: bool
+
+func _init():
+	Helper.signal_broker.inventory_window_visibility_changed.connect(func(inventory: Control): is_inventory_open = inventory.visible)
+
 func _process(_delta: float) -> void:
+	process_mouse_press()
+
+func process_mouse_press() -> void:
+	if is_inventory_open:
+		return
+	
 	if Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT):
+		print("left click")
 		PlayerInputSignalBroker.try_activate_equipped_item(0).emit(0)
-	elif Input.is_mouse_button_pressed(MOUSE_BUTTON_RIGHT):
+	if Input.is_mouse_button_pressed(MOUSE_BUTTON_RIGHT):
 		PlayerInputSignalBroker.try_activate_equipped_item(1).emit(1)

--- a/hud.tscn
+++ b/hud.tscn
@@ -23,12 +23,11 @@
 default_font = ExtResource("1_pxloi")
 default_font_size = 0
 
-[node name="HUD" type="CanvasLayer" node_paths=PackedStringArray("clock_label", "inventoryWindow", "characterWindow", "questWindow", "overmap")]
+[node name="HUD" type="CanvasLayer" node_paths=PackedStringArray("clock_label", "ammo_HUD_container", "inventoryWindow", "characterWindow", "questWindow", "overmap")]
 script = ExtResource("1_s3xoj")
 stamina_HUD = NodePath("StaminaLevel")
 clock_label = NodePath("ClockLabel")
-ammo_HUD_left = NodePath("AmmoVisuals/LeftAmmo")
-ammo_HUD_right = NodePath("AmmoVisuals/RightAmmo")
+ammo_HUD_container = NodePath("AmmoVisuals")
 healthy_color = Color(0, 0.635294, 0, 1)
 damaged_color = Color(0.635294, 0, 0, 1)
 inventoryWindow = NodePath("InventoryWindow")


### PR DESCRIPTION
Remove hand-specific data so that hands share logic without checking for left/right.  
This change also fixes a bug(?) where holding left/right click would keep the recoil from resetting even if not actively firing a weapon.