### PR TITLE
Furniture can consume items, enabling the concept of fuel or power

### DIFF
--- a/Mods/Dimensionfall/Furniture/Furniture.json
+++ b/Mods/Dimensionfall/Furniture/Furniture.json
@@ -1059,6 +1059,10 @@
 			"Survival",
 			"Crafting"
 		],
+		"consumption": {
+			"button_text": "Light",
+			"transform_into": "campfire_on"
+		},
 		"description": "A campfire that is not lit. Useful for cooking or staying warm once ignited.",
 		"destruction": {
 			"group": "tree_destroyed"
@@ -1088,7 +1092,17 @@
 			"button_text": "Put out",
 			"drain_rate": 30,
 			"items": {
-				"plank_2x4": 100
+				"cutting_board": 100,
+				"kindling_bundle": 25,
+				"log": 100,
+				"long_stick": 100,
+				"plank_2x4": 100,
+				"plant_remnants": 5,
+				"rolling_pin": 100,
+				"small_stick": 10,
+				"stick": 50,
+				"stone_spear": 100,
+				"wood_bundle": 75
 			},
 			"pool": 1000,
 			"transform_into": "campfire_off"

--- a/Mods/Dimensionfall/Furniture/Furniture.json
+++ b/Mods/Dimensionfall/Furniture/Furniture.json
@@ -1082,6 +1082,7 @@
 	},
 	{
 		"Function": {
+			"container_sprite_mode": "Hide",
 			"is_container": true
 		},
 		"categories": [
@@ -1092,10 +1093,13 @@
 			"button_text": "Put out",
 			"drain_rate": 30,
 			"items": {
+				"branch": 50,
 				"cutting_board": 100,
 				"kindling_bundle": 25,
+				"leaf": 2,
 				"log": 100,
 				"long_stick": 100,
+				"pine_branch": 60,
 				"plank_2x4": 100,
 				"plant_remnants": 5,
 				"rolling_pin": 100,

--- a/Mods/Dimensionfall/Furniture/Furniture.json
+++ b/Mods/Dimensionfall/Furniture/Furniture.json
@@ -1084,6 +1084,15 @@
 			"Survival",
 			"Crafting"
 		],
+		"consumption": {
+			"button_text": "Put out",
+			"drain_rate": 30,
+			"items": {
+				"plank_2x4": 100
+			},
+			"pool": 1000,
+			"transform_into": "campfire_off"
+		},
 		"description": "A lit campfire providing light, warmth, and a way to cook food.",
 		"destruction": {
 			"group": "tree_destroyed"

--- a/Scenes/ContentManager/Custom_Editors/FurnitureEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/FurnitureEditor.tscn
@@ -13,7 +13,7 @@
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_nv8h1"]
 
-[node name="FurnitureEditor" type="Control" node_paths=PackedStringArray("tab_container", "furniture_image_display", "id_label", "name_edit", "description_edit", "categories_list", "furniture_selector", "image_name_label", "moveable_checkbox", "weight_label", "weight_spinbox", "edge_snapping_option", "door_option", "container_checkbox", "container_text_edit", "regeneration_label", "regeneration_spin_box", "sprite_mode_option_button", "destroy_container", "can_destroy_checkbox", "destruction_text_edit", "destruction_image_display", "destruction_sprite_label", "disassembly_container", "can_disassemble_checkbox", "disassembly_text_edit", "disassembly_image_display", "disassembly_sprite_label", "support_shape_option_button", "width_scale_label", "depth_scale_label", "radius_scale_label", "width_scale_spin_box", "depth_scale_spin_box", "radius_scale_spin_box", "heigth_spin_box", "color_picker", "sprite_texture_rect", "transparent_check_box", "crafting_items_container", "construction_items_container", "pool_spin_box", "drain_rate_spin_box", "transform_into_drop_enabled_text_edit", "button_text_text_edit", "consumption_items_grid_container")]
+[node name="FurnitureEditor" type="Control" node_paths=PackedStringArray("tab_container", "furniture_image_display", "id_label", "name_edit", "description_edit", "categories_list", "furniture_selector", "image_name_label", "moveable_checkbox", "weight_label", "weight_spinbox", "edge_snapping_option", "door_option", "container_checkbox", "container_text_edit", "regeneration_label", "regeneration_spin_box", "sprite_mode_option_button", "destroy_container", "can_destroy_checkbox", "destruction_text_edit", "destruction_image_display", "destruction_sprite_label", "disassembly_container", "can_disassemble_checkbox", "disassembly_text_edit", "disassembly_image_display", "disassembly_sprite_label", "support_shape_option_button", "width_scale_label", "depth_scale_label", "radius_scale_label", "width_scale_spin_box", "depth_scale_spin_box", "radius_scale_spin_box", "heigth_spin_box", "color_picker", "sprite_texture_rect", "transparent_check_box", "crafting_items_container", "construction_items_container", "pool_spin_box", "drain_rate_spin_box", "transform_into_drop_enabled_text_edit", "button_text_text_edit", "consumption_items_grid_container", "consumption_tab")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -67,6 +67,7 @@ drain_rate_spin_box = NodePath("VBoxContainer/TabContainer/Consumption/DrainRate
 transform_into_drop_enabled_text_edit = NodePath("VBoxContainer/TabContainer/Consumption/TransformIntoDropEnabledTextEdit")
 button_text_text_edit = NodePath("VBoxContainer/TabContainer/Consumption/ButtonTextTextEdit")
 consumption_items_grid_container = NodePath("VBoxContainer/TabContainer/Consumption/ItemsPanelContainer/ItemsVBoxContainer/ItemsGridContainer")
+consumption_tab = NodePath("VBoxContainer/TabContainer/Consumption")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 1
@@ -90,10 +91,9 @@ text = "Save"
 [node name="TabContainer" type="TabContainer" parent="VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
-current_tab = 4
+current_tab = 0
 
 [node name="General" type="GridContainer" parent="VBoxContainer/TabContainer"]
-visible = false
 layout_mode = 2
 size_flags_vertical = 3
 columns = 2
@@ -577,6 +577,7 @@ size_flags_vertical = 3
 columns = 4
 
 [node name="Consumption" type="GridContainer" parent="VBoxContainer/TabContainer"]
+visible = false
 layout_mode = 2
 columns = 2
 metadata/_tab_index = 4
@@ -587,9 +588,9 @@ text = "Hint:"
 
 [node name="HintTextLabel" type="Label" parent="VBoxContainer/TabContainer/Consumption"]
 layout_mode = 2
-text = "This allows you to configure the consumption mechanic for the furniture. When a furniture is 
-consuming, items inside the container will be destroyed in order to fill up the \"fuel pool\"
-The furniture only starts consuming if the \"fuel pool\" is greater then 0."
+text = "This allows you to configure the consumption mechanic for the furniture. When a furniture is consuming, items inside the container 
+will be destroyed in order to fill up the \"fuel pool\". The furniture only starts consuming if the \"fuel pool\" is greater then 0.
+Note: The furniture needs to be a container in order to consume items."
 
 [node name="PoolLabel" type="Label" parent="VBoxContainer/TabContainer/Consumption"]
 layout_mode = 2
@@ -658,6 +659,7 @@ layout_mode = 2
 [node name="ItemsGridContainer" type="GridContainer" parent="VBoxContainer/TabContainer/Consumption/ItemsPanelContainer/ItemsVBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
+columns = 4
 
 [node name="Sprite_selector" parent="." instance=ExtResource("3_o3k3a")]
 visible = false

--- a/Scenes/ContentManager/Custom_Editors/FurnitureEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/FurnitureEditor.tscn
@@ -609,8 +609,8 @@ text = "Drain rate"
 
 [node name="DrainRateSpinBox" type="SpinBox" parent="VBoxContainer/TabContainer/Consumption"]
 layout_mode = 2
-tooltip_text = "The amount to consume per real-life minute. For example, if the pool has a 
-capacity of 1000 and the drain rate is 100, it will be depleted in 10 real-life minutes."
+tooltip_text = "The amount to consume per in-game hour. For example, if the pool has a 
+capacity of 1000 and the drain rate is 100, it will be depleted in 10 in-game hours. For reference, one in-game day is about real-life 35 minutes."
 max_value = 1000.0
 
 [node name="TransformIntoLabel" type="Label" parent="VBoxContainer/TabContainer/Consumption"]

--- a/Scenes/ContentManager/Custom_Editors/FurnitureEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/FurnitureEditor.tscn
@@ -611,7 +611,7 @@ text = "Drain rate"
 layout_mode = 2
 tooltip_text = "The amount to consume per in-game hour. For example, if the pool has a 
 capacity of 1000 and the drain rate is 100, it will be depleted in 10 in-game hours. For reference, one in-game day is about real-life 35 minutes."
-max_value = 1000.0
+max_value = 10000.0
 
 [node name="TransformIntoLabel" type="Label" parent="VBoxContainer/TabContainer/Consumption"]
 layout_mode = 2

--- a/Scenes/ContentManager/Custom_Editors/FurnitureEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/FurnitureEditor.tscn
@@ -13,7 +13,7 @@
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_nv8h1"]
 
-[node name="FurnitureEditor" type="Control" node_paths=PackedStringArray("tab_container", "furniture_image_display", "id_label", "name_edit", "description_edit", "categories_list", "furniture_selector", "image_name_label", "moveable_checkbox", "weight_label", "weight_spinbox", "edge_snapping_option", "door_option", "container_checkbox", "container_text_edit", "regeneration_label", "regeneration_spin_box", "sprite_mode_option_button", "destroy_container", "can_destroy_checkbox", "destruction_text_edit", "destruction_image_display", "destruction_sprite_label", "disassembly_container", "can_disassemble_checkbox", "disassembly_text_edit", "disassembly_image_display", "disassembly_sprite_label", "support_shape_option_button", "width_scale_label", "depth_scale_label", "radius_scale_label", "width_scale_spin_box", "depth_scale_spin_box", "radius_scale_spin_box", "heigth_spin_box", "color_picker", "sprite_texture_rect", "transparent_check_box", "crafting_items_container", "construction_items_container", "pool_spin_box", "drain_rate_spin_box", "transform_into_drop_enabled_text_edit", "button_text_text_edit", "items_grid_container")]
+[node name="FurnitureEditor" type="Control" node_paths=PackedStringArray("tab_container", "furniture_image_display", "id_label", "name_edit", "description_edit", "categories_list", "furniture_selector", "image_name_label", "moveable_checkbox", "weight_label", "weight_spinbox", "edge_snapping_option", "door_option", "container_checkbox", "container_text_edit", "regeneration_label", "regeneration_spin_box", "sprite_mode_option_button", "destroy_container", "can_destroy_checkbox", "destruction_text_edit", "destruction_image_display", "destruction_sprite_label", "disassembly_container", "can_disassemble_checkbox", "disassembly_text_edit", "disassembly_image_display", "disassembly_sprite_label", "support_shape_option_button", "width_scale_label", "depth_scale_label", "radius_scale_label", "width_scale_spin_box", "depth_scale_spin_box", "radius_scale_spin_box", "heigth_spin_box", "color_picker", "sprite_texture_rect", "transparent_check_box", "crafting_items_container", "construction_items_container", "pool_spin_box", "drain_rate_spin_box", "transform_into_drop_enabled_text_edit", "button_text_text_edit", "consumption_items_grid_container")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -66,7 +66,7 @@ pool_spin_box = NodePath("VBoxContainer/TabContainer/Consumption/PoolSpinBox")
 drain_rate_spin_box = NodePath("VBoxContainer/TabContainer/Consumption/DrainRateSpinBox")
 transform_into_drop_enabled_text_edit = NodePath("VBoxContainer/TabContainer/Consumption/TransformIntoDropEnabledTextEdit")
 button_text_text_edit = NodePath("VBoxContainer/TabContainer/Consumption/ButtonTextTextEdit")
-items_grid_container = NodePath("VBoxContainer/TabContainer/Consumption/ItemsPanelContainer/ItemsVBoxContainer/ItemsGridContainer")
+consumption_items_grid_container = NodePath("VBoxContainer/TabContainer/Consumption/ItemsPanelContainer/ItemsVBoxContainer/ItemsGridContainer")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 1
@@ -620,6 +620,7 @@ text = "Tranform into:"
 layout_mode = 2
 size_flags_vertical = 1
 tooltip_text = "The furniture to transform into when the pool is empty."
+myplaceholdertext = "Drop a furniture here"
 
 [node name="ButtonTextLabel" type="Label" parent="VBoxContainer/TabContainer/Consumption"]
 layout_mode = 2
@@ -656,18 +657,7 @@ layout_mode = 2
 
 [node name="ItemsGridContainer" type="GridContainer" parent="VBoxContainer/TabContainer/Consumption/ItemsPanelContainer/ItemsVBoxContainer"]
 layout_mode = 2
-
-[node name="Label8" type="Label" parent="VBoxContainer/TabContainer/Consumption"]
-layout_mode = 2
-text = "text"
-
-[node name="Label9" type="Label" parent="VBoxContainer/TabContainer/Consumption"]
-layout_mode = 2
-text = "text"
-
-[node name="Label10" type="Label" parent="VBoxContainer/TabContainer/Consumption"]
-layout_mode = 2
-text = "text"
+size_flags_vertical = 3
 
 [node name="Sprite_selector" parent="." instance=ExtResource("3_o3k3a")]
 visible = false

--- a/Scenes/ContentManager/Custom_Editors/FurnitureEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/FurnitureEditor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3 uid="uid://cng4m3os6smj8"]
+[gd_scene load_steps=10 format=3 uid="uid://cng4m3os6smj8"]
 
 [ext_resource type="Texture2D" uid="uid://c8ragmxitca47" path="res://Scenes/ContentManager/Mapeditor/Images/emptyTile.png" id="1_gm4uu"]
 [ext_resource type="Script" path="res://Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd" id="1_wqqit"]
@@ -11,7 +11,9 @@
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ujqyk"]
 
-[node name="FurnitureEditor" type="Control" node_paths=PackedStringArray("tab_container", "furniture_image_display", "id_label", "name_edit", "description_edit", "categories_list", "furniture_selector", "image_name_label", "moveable_checkbox", "weight_label", "weight_spinbox", "edge_snapping_option", "door_option", "container_checkbox", "container_text_edit", "regeneration_label", "regeneration_spin_box", "sprite_mode_option_button", "destroy_container", "can_destroy_checkbox", "destruction_text_edit", "destruction_image_display", "destruction_sprite_label", "disassembly_container", "can_disassemble_checkbox", "disassembly_text_edit", "disassembly_image_display", "disassembly_sprite_label", "support_shape_option_button", "width_scale_label", "depth_scale_label", "radius_scale_label", "width_scale_spin_box", "depth_scale_spin_box", "radius_scale_spin_box", "heigth_spin_box", "color_picker", "sprite_texture_rect", "transparent_check_box", "crafting_items_container", "construction_items_container")]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_nv8h1"]
+
+[node name="FurnitureEditor" type="Control" node_paths=PackedStringArray("tab_container", "furniture_image_display", "id_label", "name_edit", "description_edit", "categories_list", "furniture_selector", "image_name_label", "moveable_checkbox", "weight_label", "weight_spinbox", "edge_snapping_option", "door_option", "container_checkbox", "container_text_edit", "regeneration_label", "regeneration_spin_box", "sprite_mode_option_button", "destroy_container", "can_destroy_checkbox", "destruction_text_edit", "destruction_image_display", "destruction_sprite_label", "disassembly_container", "can_disassemble_checkbox", "disassembly_text_edit", "disassembly_image_display", "disassembly_sprite_label", "support_shape_option_button", "width_scale_label", "depth_scale_label", "radius_scale_label", "width_scale_spin_box", "depth_scale_spin_box", "radius_scale_spin_box", "heigth_spin_box", "color_picker", "sprite_texture_rect", "transparent_check_box", "crafting_items_container", "construction_items_container", "pool_spin_box", "drain_rate_spin_box", "transform_into_drop_enabled_text_edit", "button_text_text_edit", "items_grid_container")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -60,6 +62,11 @@ sprite_texture_rect = NodePath("VBoxContainer/TabContainer/Shape/HBoxContainer/S
 transparent_check_box = NodePath("VBoxContainer/TabContainer/Shape/TransparentCheckBox")
 crafting_items_container = NodePath("VBoxContainer/TabContainer/Crafting/ItemsPanelContainer/ItemsScrollContainer/ItemsGridContainer")
 construction_items_container = NodePath("VBoxContainer/TabContainer/Construction/ConstructionItemsPanelContainer/ConstructionItemsScrollContainer/ConstructionItemsVBoxContainer/ConstructionItemsGridContainer")
+pool_spin_box = NodePath("VBoxContainer/TabContainer/Consumption/PoolSpinBox")
+drain_rate_spin_box = NodePath("VBoxContainer/TabContainer/Consumption/DrainRateSpinBox")
+transform_into_drop_enabled_text_edit = NodePath("VBoxContainer/TabContainer/Consumption/TransformIntoDropEnabledTextEdit")
+button_text_text_edit = NodePath("VBoxContainer/TabContainer/Consumption/ButtonTextTextEdit")
+items_grid_container = NodePath("VBoxContainer/TabContainer/Consumption/ItemsPanelContainer/ItemsVBoxContainer/ItemsGridContainer")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 1
@@ -83,9 +90,10 @@ text = "Save"
 [node name="TabContainer" type="TabContainer" parent="VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
-current_tab = 0
+current_tab = 4
 
 [node name="General" type="GridContainer" parent="VBoxContainer/TabContainer"]
+visible = false
 layout_mode = 2
 size_flags_vertical = 3
 columns = 2
@@ -567,6 +575,99 @@ size_flags_vertical = 3
 layout_mode = 2
 size_flags_vertical = 3
 columns = 4
+
+[node name="Consumption" type="GridContainer" parent="VBoxContainer/TabContainer"]
+layout_mode = 2
+columns = 2
+metadata/_tab_index = 4
+
+[node name="HintLabel" type="Label" parent="VBoxContainer/TabContainer/Consumption"]
+layout_mode = 2
+text = "Hint:"
+
+[node name="HintTextLabel" type="Label" parent="VBoxContainer/TabContainer/Consumption"]
+layout_mode = 2
+text = "This allows you to configure the consumption mechanic for the furniture. When a furniture is 
+consuming, items inside the container will be destroyed in order to fill up the \"fuel pool\"
+The furniture only starts consuming if the \"fuel pool\" is greater then 0."
+
+[node name="PoolLabel" type="Label" parent="VBoxContainer/TabContainer/Consumption"]
+layout_mode = 2
+text = "Pool:"
+
+[node name="PoolSpinBox" type="SpinBox" parent="VBoxContainer/TabContainer/Consumption"]
+layout_mode = 2
+tooltip_text = "The maximum capacity of the pool of fuel.
+0: This furniture does not consume
+>0: This furniture will consume items and add their fuel value to the pool"
+max_value = 1000.0
+
+[node name="DrainRateLabel" type="Label" parent="VBoxContainer/TabContainer/Consumption"]
+layout_mode = 2
+text = "Drain rate"
+
+[node name="DrainRateSpinBox" type="SpinBox" parent="VBoxContainer/TabContainer/Consumption"]
+layout_mode = 2
+tooltip_text = "The amount to consume per real-life minute. For example, if the pool has a 
+capacity of 1000 and the drain rate is 100, it will be depleted in 10 real-life minutes."
+max_value = 1000.0
+
+[node name="TransformIntoLabel" type="Label" parent="VBoxContainer/TabContainer/Consumption"]
+layout_mode = 2
+text = "Tranform into:"
+
+[node name="TransformIntoDropEnabledTextEdit" parent="VBoxContainer/TabContainer/Consumption" instance=ExtResource("4_fbact")]
+layout_mode = 2
+size_flags_vertical = 1
+tooltip_text = "The furniture to transform into when the pool is empty."
+
+[node name="ButtonTextLabel" type="Label" parent="VBoxContainer/TabContainer/Consumption"]
+layout_mode = 2
+text = "Button text"
+
+[node name="ButtonTextTextEdit" type="TextEdit" parent="VBoxContainer/TabContainer/Consumption"]
+custom_minimum_size = Vector2(0, 30)
+layout_mode = 2
+tooltip_text = "Allows you to set the (de)activate button text that will be visible in the furniture interface in-game. When the 
+(de)activate button is pressed, the furniture will tranform into the furniture listed in the \"Transform into\" property.
+empty: The activate button will not display
+not empty: The (de)activate button will be displayed in the furniture interaction interface in-game with the assigned text.
+Recommendation:
+If the pool capacity is 0: write something like \"Activate\"
+If the pool capacity is greater then 0: write something like \"Deactivate\"
+The existing pool value will transfer over, so no fuel is lost."
+
+[node name="ItemsLabel" type="Label" parent="VBoxContainer/TabContainer/Consumption"]
+layout_mode = 2
+text = "Items:"
+
+[node name="ItemsPanelContainer" type="PanelContainer" parent="VBoxContainer/TabContainer/Consumption"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+tooltip_text = "Drag items from the list on the left to add them so they are consumed into the pool. Modify the fuel value to set how much they add to the 
+pool. An item will only be consumed when the entire fuel value can fit 
+into the current pool. In other words, if the pool capacity is 1000 and is 
+filled with 990 fuel, only items with a fuel value of 10 or less will fit."
+theme_override_styles/panel = SubResource("StyleBoxFlat_nv8h1")
+
+[node name="ItemsVBoxContainer" type="VBoxContainer" parent="VBoxContainer/TabContainer/Consumption/ItemsPanelContainer"]
+layout_mode = 2
+
+[node name="ItemsGridContainer" type="GridContainer" parent="VBoxContainer/TabContainer/Consumption/ItemsPanelContainer/ItemsVBoxContainer"]
+layout_mode = 2
+
+[node name="Label8" type="Label" parent="VBoxContainer/TabContainer/Consumption"]
+layout_mode = 2
+text = "text"
+
+[node name="Label9" type="Label" parent="VBoxContainer/TabContainer/Consumption"]
+layout_mode = 2
+text = "text"
+
+[node name="Label10" type="Label" parent="VBoxContainer/TabContainer/Consumption"]
+layout_mode = 2
+text = "text"
 
 [node name="Sprite_selector" parent="." instance=ExtResource("3_o3k3a")]
 visible = false

--- a/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
@@ -108,6 +108,7 @@ func _load_furniture_data():
 	_load_disassembly_data()
 	_load_container_data()
 	_load_support_shape_data()
+	_load_consumption_data()
 	# Refresh crafting and construction item lists
 	update_item_list()
 	update_construction_item_list()
@@ -222,6 +223,11 @@ func _on_save_button_button_up():
 	handle_container_option()
 	handle_destruction_option()
 	handle_disassembly_option()
+	# Save consumption values
+	dfurniture.consumption.pool = int(pool_spin_box.value)
+	dfurniture.consumption.drain_rate = int(drain_rate_spin_box.value)
+	dfurniture.consumption.transform_into = transform_into_drop_enabled_text_edit.get_text()
+	dfurniture.consumption.button_text = button_text_text_edit.text
 
 	# Save crafting and construction items
 	_save_crafting_items()
@@ -709,3 +715,10 @@ func _update_shape_visibility(shape: String):
 	depth_scale_spin_box.visible = is_box
 	radius_scale_label.visible = not is_box
 	radius_scale_spin_box.visible = not is_box
+
+func _load_consumption_data():
+	# Load values from dfurniture.consumption
+	pool_spin_box.value = dfurniture.consumption.pool
+	drain_rate_spin_box.value = dfurniture.consumption.drain_rate
+	transform_into_drop_enabled_text_edit.set_text(dfurniture.consumption.transform_into)
+	button_text_text_edit.text = dfurniture.consumption.button_text

--- a/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
@@ -61,6 +61,13 @@ var control_elements: Array = []
 # Tracks which image display control is currently being updated
 var current_image_display: String = ""
 
+# Controls for consumption:
+@export var pool_spin_box: SpinBox = null
+@export var drain_rate_spin_box: SpinBox = null
+@export var transform_into_drop_enabled_text_edit: HBoxContainer = null
+@export var button_text_text_edit: TextEdit = null
+@export var items_grid_container: GridContainer = null
+
 
 # This signal will be emitted when the user presses the save button
 signal data_changed()

--- a/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
@@ -67,6 +67,7 @@ var current_image_display: String = ""
 @export var transform_into_drop_enabled_text_edit: HBoxContainer = null
 @export var button_text_text_edit: TextEdit = null
 @export var consumption_items_grid_container: GridContainer = null
+@export var consumption_tab: GridContainer = null
 
 
 # This signal will be emitted when the user presses the save button
@@ -310,9 +311,18 @@ func _input(event):
 		get_viewport().set_input_as_handled()
 
 
-func _on_container_check_box_toggled(toggled_on):
+# The user has checked the 'container' checkbox
+# Since some functionality relies on the furniture being a container,
+# We need to hide the controls if this furniture is not a container.
+func _on_container_check_box_toggled(toggled_on: bool):
+	# Clear the text field if the container checkbox is toggled off
 	if not toggled_on:
 		container_text_edit.mytextedit.clear()
+	
+	# Find the tab index for the "Consumption" tab
+	var tabIndex = get_tab_by_title("Consumption")
+	if tabIndex != -1:  # Check if a valid tab index is returned
+		tab_container.set_tab_hidden(tabIndex, !toggled_on)  # Hide or show the tab
 
 
 # Called when the user has successfully dropped data onto the ItemGroupTextEdit
@@ -808,6 +818,7 @@ func _handle_consumption_item_drop(dropped_data: Dictionary) -> void:
 	consumption_items_grid_container.add_child(amount_spinbox)
 	consumption_items_grid_container.add_child(delete_button)
 
+
 # Handle the deletion of an item from the consumption_items_grid_container
 func _on_delete_consumption_item_button_pressed(item_id: String) -> void:
 	# Determine the number of columns in the grid container
@@ -869,3 +880,13 @@ func can_furniture_drop(dropped_data: Dictionary) -> bool:
 		return false
 
 	return true  # Passed all validation checks
+
+
+
+# Returns the tab control with the given name
+func get_tab_by_title(tabName: String) -> int:
+	# Loop over all children of the types_container
+	for i in range(tab_container.get_tab_count()):
+		if tab_container.get_tab_title(i) == tabName:
+			return i
+	return -1

--- a/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
@@ -66,7 +66,7 @@ var current_image_display: String = ""
 @export var drain_rate_spin_box: SpinBox = null
 @export var transform_into_drop_enabled_text_edit: HBoxContainer = null
 @export var button_text_text_edit: TextEdit = null
-@export var items_grid_container: GridContainer = null
+@export var consumption_items_grid_container: GridContainer = null
 
 
 # This signal will be emitted when the user presses the save button
@@ -232,6 +232,7 @@ func _on_save_button_button_up():
 	# Save crafting and construction items
 	_save_crafting_items()
 	_save_construction_items()
+	_save_consumption_items()
 
 	dfurniture.on_data_changed(olddata)
 	data_changed.emit()
@@ -371,6 +372,10 @@ func set_drop_functions():
 	destruction_text_edit.can_drop_function = can_itemgroup_drop
 	
 	construction_items_container.set_drag_forwarding(Callable(), _can_construction_item_drop, _construction_item_drop)
+	consumption_items_grid_container.set_drag_forwarding(Callable(), _can_consumption_item_drop, _consumption_item_drop)
+	# Assign drop functions for transform_into_drop_enabled_text_edit
+	transform_into_drop_enabled_text_edit.drop_function = furniture_drop.bind(transform_into_drop_enabled_text_edit)
+	transform_into_drop_enabled_text_edit.can_drop_function = can_furniture_drop
 
 
 # When the furniture_image_display is clicked, the user will be prompted to select an image from
@@ -716,9 +721,151 @@ func _update_shape_visibility(shape: String):
 	radius_scale_label.visible = not is_box
 	radius_scale_spin_box.visible = not is_box
 
+
 func _load_consumption_data():
 	# Load values from dfurniture.consumption
 	pool_spin_box.value = dfurniture.consumption.pool
 	drain_rate_spin_box.value = dfurniture.consumption.drain_rate
 	transform_into_drop_enabled_text_edit.set_text(dfurniture.consumption.transform_into)
 	button_text_text_edit.text = dfurniture.consumption.button_text
+	_load_consumption_items()
+
+
+func _load_consumption_items():
+	# Clear existing items from the grid
+	Helper.free_all_children(consumption_items_grid_container)
+
+	if not dfurniture.consumption or not dfurniture.consumption.items:
+		return
+
+	# Add items back into the grid
+	for item_id in dfurniture.consumption.items.keys():
+		_handle_consumption_item_drop({"id": item_id})
+
+# Check if the dragged item can be dropped into the consumption_items_grid_container
+func _can_consumption_item_drop(_newpos: Vector2, data: Dictionary) -> bool:
+	# Validate that data is a dictionary and contains the required "id" key
+	if not data or not data.has("id"):
+		return false
+
+	# Validate that the item exists in Gamedata
+	if not Gamedata.mods.by_id(data["mod_id"]).items.has_id(data["id"]):
+		return false
+	
+	# Check for duplicate items in the grid container
+	for child in consumption_items_grid_container.get_children():
+		if child is Label and child.text == data["id"]:
+			return false  # Item already exists
+
+	return true  # Passed all validation checks
+
+# Handle the drop of an item into the consumption_items_grid_container
+func _consumption_item_drop(_newpos: Vector2, data: Dictionary) -> void:
+	# Validate if the item can be dropped
+	if not _can_consumption_item_drop(_newpos, data):
+		return
+
+	# Handle the drop and add the item to the grid
+	_handle_consumption_item_drop(data)
+
+# Function to handle adding the dropped item to the consumption grid container
+func _handle_consumption_item_drop(dropped_data: Dictionary) -> void:
+	# Retrieve item details from Gamedata
+	var item_id = dropped_data["id"]
+	var item_sprite = Gamedata.mods.get_content_by_id(DMod.ContentType.ITEMS, item_id).sprite
+
+	# Create components for the dropped item row
+	var item_icon = TextureRect.new()
+	item_icon.texture = item_sprite
+	item_icon.custom_minimum_size = Vector2(32, 32)  # Ensure a minimum size for the icon
+
+	var item_label = Label.new()
+	item_label.text = item_id
+
+	# Add a SpinBox to allow setting the required amount
+	var amount_spinbox = SpinBox.new()
+	amount_spinbox.min_value = 1
+	amount_spinbox.value = dfurniture.consumption.items.get(item_id, 1)  # Default to 1 if not set
+	amount_spinbox.custom_minimum_size = Vector2(50, 32)
+	amount_spinbox.tooltip_text = "The 'fuel value' that will be added to the pool when" + \
+								  "  the item is consumed. The consumption of items will" + \
+								  "  automatically start when the current value of the\n" + \
+								  "  pool is below maximum. This requires that the pool" + \
+								  "  has space for the amount of fuel this item provides.\n" + \
+								  "  For example, if the current pool value is 990 and " + \
+								  " the max pool size is 1000, only items with a fuel \n" + \
+								  " value of 10 or less will be consumed. When an item is " + \
+								  " consumed, it is removed from the furniture's inventory and destroyed."
+
+	var delete_button = Button.new()
+	delete_button.text = "X"
+	delete_button.tooltip_text = "Remove this item"
+	delete_button.button_up.connect(_on_delete_consumption_item_button_pressed.bind(item_id))
+
+	# Add components to the grid container
+	consumption_items_grid_container.add_child(item_icon)
+	consumption_items_grid_container.add_child(item_label)
+	consumption_items_grid_container.add_child(amount_spinbox)
+	consumption_items_grid_container.add_child(delete_button)
+
+# Handle the deletion of an item from the consumption_items_grid_container
+func _on_delete_consumption_item_button_pressed(item_id: String) -> void:
+	# Determine the number of columns in the grid container
+	var num_columns = consumption_items_grid_container.columns
+	var children_to_remove = []
+
+	# Find and queue the row containing the matching item ID
+	for i in range(consumption_items_grid_container.get_child_count()):
+		var child = consumption_items_grid_container.get_child(i)
+		if child is Label and child.text == item_id:
+			var start_index = i - (i % num_columns)
+			for j in range(num_columns):
+				children_to_remove.append(consumption_items_grid_container.get_child(start_index + j))
+			break
+
+	# Remove and free the queued children
+	for child in children_to_remove:
+		consumption_items_grid_container.remove_child(child)
+		child.queue_free()
+
+	# Remove the item ID from dfurniture.consumption.items
+	if dfurniture.consumption and dfurniture.consumption.items:
+		dfurniture.consumption.items.erase(item_id)
+
+func _save_consumption_items():
+	var new_items: Dictionary = {}
+	var num_children = consumption_items_grid_container.get_child_count()
+	var num_columns = consumption_items_grid_container.columns
+
+	for i in range(0, num_children, num_columns):
+		var item_label = consumption_items_grid_container.get_child(i + 1)  # Second child is the label with item ID
+		var amount_spinbox = consumption_items_grid_container.get_child(i + 2)  # Third child is the SpinBox
+		if item_label is Label and amount_spinbox is SpinBox:
+			new_items[item_label.text] = int(amount_spinbox.value)
+
+	dfurniture.consumption.items = new_items  # Update furniture's consumption items
+
+# Called when the user drops a furniture ID onto the TextEdit
+func furniture_drop(dropped_data: Dictionary, texteditcontrol: HBoxContainer) -> void:
+	# Assuming dropped_data is a Dictionary that includes an 'id'
+	if dropped_data and "id" in dropped_data:
+		var furniture_id = dropped_data["id"]
+		# Validate that the furniture ID exists in the current mod
+		if not Gamedata.mods.by_id(dropped_data["mod_id"]).furnitures.has_id(furniture_id):
+			print_debug("No furniture data found for ID: " + furniture_id)
+			return
+		texteditcontrol.set_text(furniture_id)  # Set the furniture ID into the TextEdit
+	else:
+		print_debug("Dropped data does not contain an 'id' key.")
+
+# Check if the dropped data is valid for assigning a furniture ID
+func can_furniture_drop(dropped_data: Dictionary) -> bool:
+	# Validate that the data is a dictionary and contains the 'id' property
+	if not dropped_data or not dropped_data.has("id"):
+		return false
+
+	# Validate that the furniture ID exists in the current mod
+	if not Gamedata.mods.by_id(dropped_data["mod_id"]).furnitures.has_id(dropped_data["id"]):
+		return false
+
+	return true  # Passed all validation checks

--- a/Scenes/UI/FurnitureWindow.tscn
+++ b/Scenes/UI/FurnitureWindow.tscn
@@ -14,7 +14,7 @@ bg_color = Color(0.67826, 0.567447, 0.588873, 1)
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_tl3co"]
 bg_color = Color(0.563549, 0.621184, 0.54067, 1)
 
-[node name="FurnitureWindow" type="Control" node_paths=PackedStringArray("furniture_container_view", "inventory_label", "furniture_name_label", "crafting_queue_container", "crafting_recipe_container", "crafting_v_box_container", "craft_status_label", "craft_status_timer", "recipe_panel_container", "item_name_label", "item_description_label", "item_craft_time_label", "ingredients_grid_container", "add_to_queue_button")]
+[node name="FurnitureWindow" type="Control" node_paths=PackedStringArray("furniture_container_view", "inventory_label", "furniture_name_label", "crafting_queue_container", "crafting_recipe_container", "crafting_v_box_container", "craft_status_label", "craft_status_timer", "transform_into_button", "fuel_label", "recipe_panel_container", "item_name_label", "item_description_label", "item_craft_time_label", "ingredients_grid_container", "add_to_queue_button")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -30,6 +30,8 @@ crafting_recipe_container = NodePath("PanelContainer/VBoxContainer/HBoxContainer
 crafting_v_box_container = NodePath("PanelContainer/VBoxContainer/HBoxContainer/CraftingVBoxContainer")
 craft_status_label = NodePath("PanelContainer/VBoxContainer/HBoxContainer/CraftingVBoxContainer/HBoxContainer2/CraftStatusLabel")
 craft_status_timer = NodePath("PanelContainer/VBoxContainer/HBoxContainer/CraftingVBoxContainer/HBoxContainer2/CraftStatusTimer")
+transform_into_button = NodePath("PanelContainer/VBoxContainer/HBoxContainer2/TransformIntoButton")
+fuel_label = NodePath("PanelContainer/VBoxContainer/HBoxContainer2/FuelLabel")
 recipe_panel_container = NodePath("PanelContainer/VBoxContainer/HBoxContainer/CraftingVBoxContainer/RecipePanelContainer")
 item_name_label = NodePath("PanelContainer/VBoxContainer/HBoxContainer/CraftingVBoxContainer/RecipePanelContainer/HBoxContainer/ItemInfoVBoxContainer/ItemNameLabel")
 item_description_label = NodePath("PanelContainer/VBoxContainer/HBoxContainer/CraftingVBoxContainer/RecipePanelContainer/HBoxContainer/ItemInfoVBoxContainer/ItemDescriptionLabel")
@@ -57,6 +59,10 @@ layout_mode = 2
 size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 36
 text = "FurnitureName"
+
+[node name="FuelLabel" type="Label" parent="PanelContainer/VBoxContainer/HBoxContainer2"]
+layout_mode = 2
+text = "Fuel: 0"
 
 [node name="TransformIntoButton" type="Button" parent="PanelContainer/VBoxContainer/HBoxContainer2"]
 layout_mode = 2

--- a/Scenes/UI/FurnitureWindow.tscn
+++ b/Scenes/UI/FurnitureWindow.tscn
@@ -58,6 +58,10 @@ size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 36
 text = "FurnitureName"
 
+[node name="TransformIntoButton" type="Button" parent="PanelContainer/VBoxContainer/HBoxContainer2"]
+layout_mode = 2
+text = "transform_into"
+
 [node name="CloseMenuButton" type="Button" parent="PanelContainer/VBoxContainer/HBoxContainer2"]
 layout_mode = 2
 tooltip_text = "Close menu"
@@ -185,4 +189,5 @@ layout_mode = 2
 size_flags_vertical = 3
 columns = 4
 
+[connection signal="button_up" from="PanelContainer/VBoxContainer/HBoxContainer2/TransformIntoButton" to="." method="_on_transform_into_button_button_up"]
 [connection signal="button_up" from="PanelContainer/VBoxContainer/HBoxContainer2/CloseMenuButton" to="." method="_on_close_menu_button_button_up"]

--- a/Scripts/FurnitureStaticSpawner.gd
+++ b/Scripts/FurnitureStaticSpawner.gd
@@ -42,6 +42,7 @@ func spawn_furniture(furniture_data: Dictionary) -> void:
 		myposition = get_furniture_position_from_mapdata(furniture_data)
 		new_furniture = FurnitureStaticSrv.new(myposition, furniture_data, world3d)
 	new_furniture.about_to_be_destroyed.connect(_on_furniture_about_to_be_destroyed)
+	new_furniture.spawner = self
 	Helper.time_helper.minute_passed.connect.call_deferred(new_furniture.on_minute_passed)
 	# Add the collider to the dictionary
 	collider_to_furniture[new_furniture.collider] = new_furniture

--- a/Scripts/FurnitureStaticSpawner.gd
+++ b/Scripts/FurnitureStaticSpawner.gd
@@ -43,7 +43,6 @@ func spawn_furniture(furniture_data: Dictionary) -> void:
 		new_furniture = FurnitureStaticSrv.new(myposition, furniture_data, world3d)
 	new_furniture.about_to_be_destroyed.connect(_on_furniture_about_to_be_destroyed)
 	new_furniture.spawner = self
-	Helper.time_helper.minute_passed.connect.call_deferred(new_furniture.on_minute_passed)
 	# Add the collider to the dictionary
 	collider_to_furniture[new_furniture.collider] = new_furniture
 

--- a/Scripts/FurnitureStaticSrv.gd
+++ b/Scripts/FurnitureStaticSrv.gd
@@ -613,6 +613,10 @@ class Consumption:
 	var current_pool: int = 1000  # Default value for the consumption pool
 	# Add a counter to track the number of minutes passed
 	var minute_counter: int = 0
+	var parent_furniture: FurnitureStaticSrv
+
+	func _init(myparent_furniture: FurnitureStaticSrv):
+		parent_furniture = myparent_furniture
 
 	# Getter for `current_pool`
 	func get_current_pool() -> int:
@@ -628,11 +632,29 @@ class Consumption:
 		# Increment the minute counter
 		minute_counter += 1
 
-		# Check if 60 minutes have passed
+		# Check if 60 in-game minutes have passed
 		if minute_counter >= 60:
 			# Reset the counter and subtract 100 from current_pool
 			minute_counter = 0
-			set_current_pool(get_current_pool() - 100)
+			set_current_pool(get_current_pool() - parent_furniture.rfurniture.consumption.drain_rate)
+
+	# Serialize the data
+	func serialize() -> Dictionary:
+		var data: Dictionary = {}
+		data["current_pool"] = current_pool  # Save the current pool value
+		data["minute_counter"] = minute_counter  # Save the minute counter
+		return data
+
+	# Deserialize the Consumption class
+	func deserialize(data: Dictionary) -> void:
+		# Check if the data contains "current_pool" and set it
+		if data.has("current_pool"):
+			current_pool = data["current_pool"]
+
+		# Check if the data contains "minute_counter" and set it
+		if data.has("minute_counter"):
+			minute_counter = data["minute_counter"]
+
 
 
 # --------------------------------------------------------------
@@ -671,7 +693,7 @@ func _init(furniturepos: Vector3, new_furniture_json: Dictionary, world3d: World
 	add_container()  # Adds container if the furniture is a container
 	add_crafting_container() # Adds crafting container if the furniture is a crafting station
 	if rfurniture.consumption:
-		consumption = Consumption.new()
+		consumption = Consumption.new(self)
 
 
 # If this furniture is a container, it will add a container node to the furniture.

--- a/Scripts/FurnitureStaticSrv.gd
+++ b/Scripts/FurnitureStaticSrv.gd
@@ -627,8 +627,22 @@ class Consumption:
 
 	# Setter for `current_pool`
 	func set_current_pool(value: float) -> void:
-		# Ensure the value is non-negative
-		current_pool = max(value, 0)
+		# Get the maximum pool size from rfurniture.consumption.pool
+		var pool_size: float = parent_furniture.rfurniture.consumption.pool
+		
+		# Clamp the value to ensure current_pool is within the valid range [0, pool_size]
+		current_pool = clamp(value, 0, pool_size)
+		
+		# Get the drain_rate per in-game hour from the parent furniture
+		var drain_rate: float = parent_furniture.rfurniture.consumption.drain_rate
+		
+		# Only consider transforming automatically if pool and drain_rate are valid
+		if pool_size <= 0 or drain_rate <= 0:
+			return
+		
+		# Trigger transformation logic if the pool is depleted
+		if current_pool <= 0:
+			parent_furniture.transform_into()
 
 	# Function to compare the current pool with the maximum pool capacity
 	func get_available_pool_capacity() -> float:

--- a/Scripts/FurnitureStaticSrv.gd
+++ b/Scripts/FurnitureStaticSrv.gd
@@ -1330,11 +1330,11 @@ func are_all_ingredients_available(recipe: RItem.CraftRecipe) -> bool:
 
 
 # Function to handle transformation and spawn new furniture
-func transform_into(furniture_id: String):
+func transform_into():
 	if not spawner or not spawner.chunk:
 		print("Spawner or Spawner Chunk is null.")
 		return
-	
+	var furniture_id: String = rfurniture.consumption.transform_into
 	var chunk: Chunk = spawner.chunk
 	var construction_pos: Vector3 = furniture_transform.get_position()
 	construction_pos.y -= 0.75

--- a/Scripts/FurnitureStaticSrv.gd
+++ b/Scripts/FurnitureStaticSrv.gd
@@ -1362,6 +1362,8 @@ func transform_into():
 		print("Spawner or Spawner Chunk is null.")
 		return
 	var furniture_id: String = rfurniture.consumption.transform_into
+	if not furniture_id:
+		return
 	var chunk: Chunk = spawner.chunk
 	var construction_pos: Vector3 = furniture_transform.get_position()
 	# Decrease y by half the height of the furniture

--- a/Scripts/FurnitureWindow.gd
+++ b/Scripts/FurnitureWindow.gd
@@ -11,7 +11,7 @@ extends Control
 @export var crafting_v_box_container: VBoxContainer = null
 @export var craft_status_label: Label = null
 @export var craft_status_timer: Timer = null
-
+@export var transform_into_button: Button = null
 
 # Recipe panel controls:
 @export var recipe_panel_container: PanelContainer = null
@@ -58,6 +58,8 @@ func _update_ui_from_furniture():
 
 	furniture_name_label.text = furniture_instance.get_furniture_name()
 	_refresh_crafting_ui()
+	_update_transform_into_button()  # New function to handle the transform_into_button UI update
+
 
 # Refresh the crafting UI elements
 func _refresh_crafting_ui():
@@ -374,3 +376,22 @@ func _create_label(text: String) -> Label:
 	var label = Label.new()
 	label.text = text
 	return label
+
+
+func _on_transform_into_button_button_up() -> void:
+	furniture_instance.transform_into()
+
+# Updates the visibility and text of the transform_into_button based on the furniture instance
+func _update_transform_into_button():
+	if not furniture_instance or not furniture_instance.rfurniture.consumption:
+		transform_into_button.visible = false
+		return
+
+	var transform_into_target = furniture_instance.rfurniture.consumption.transform_into
+	var button_text = furniture_instance.rfurniture.consumption.button_text
+
+	if transform_into_target == "":
+		transform_into_button.visible = false  # Hide the button if no transform target exists
+	else:
+		transform_into_button.visible = true  # Show the button and update its text
+		transform_into_button.text = button_text

--- a/Scripts/FurnitureWindow.gd
+++ b/Scripts/FurnitureWindow.gd
@@ -31,7 +31,7 @@ var furniture_instance: FurnitureStaticSrv = null:
 		current_item_id = ""  # Reset current_item_id when furniture changes
 		if furniture_instance:
 			_connect_furniture_signals()
-			_update_furniture_ui()
+			_update_ui_from_furniture()
 			# Show or hide crafting container based on whether this furniture is a crafting station
 			crafting_v_box_container.visible = furniture_instance.is_crafting_station()
 			# Automatically display the first recipe in the panel if available
@@ -48,14 +48,19 @@ func _ready():
 	craft_status_timer.start()
 
 
-# Updates UI elements based on the current furniture_instance.
-func _update_furniture_ui():
-	var iscontainer: bool = furniture_instance.is_container()
-	furniture_container_view.visible = iscontainer
-	inventory_label.visible = iscontainer
-	if iscontainer:
+# Update all UI components from the current furniture_instance
+func _update_ui_from_furniture():
+	furniture_container_view.visible = furniture_instance.is_container()
+	inventory_label.visible = furniture_instance.is_container()
+
+	if furniture_instance.is_container():
 		furniture_container_view.set_inventory(furniture_instance.get_inventory())
+
 	furniture_name_label.text = furniture_instance.get_furniture_name()
+	_refresh_crafting_ui()
+
+# Refresh the crafting UI elements
+func _refresh_crafting_ui():
 	_populate_crafting_recipe_container()
 	_populate_crafting_queue_container()
 	_update_craft_status_label()
@@ -173,26 +178,6 @@ func _on_furniture_about_to_be_destroyed(furniture: FurnitureStaticSrv):
 		_disconnect_furniture_signals()
 		furniture_instance = null
 
-
-# Utility function to create a TextureRect for item icons.
-func _create_icon(texture: Texture) -> TextureRect:
-	var icon = TextureRect.new()
-	icon.texture = texture
-	icon.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
-	return icon
-
-# Utility function to create a Label for item names.
-func _create_label(text: String) -> Label:
-	var label = Label.new()
-	label.text = text
-	return label
-
-# Utility function to create a Button with a connected callback.
-func _create_button(text: String, callback: Callable) -> Button:
-	var button = Button.new()
-	button.text = text
-	button.button_up.connect(callback)
-	return button
 
 # Handles the recipe button being pressed. Updates the Recipe panel.
 func _on_recipe_button_pressed(item_id: String):
@@ -367,3 +352,25 @@ func _update_craft_status_label():
 			craft_status_label.text = "Waiting for resources"
 		else:
 			craft_status_label.text = "Time remaining: " + str(time_remaining) + " seconds"
+
+# ---- UTILITIES ----
+
+# Utility function to create a TextureRect for item icons.
+func _create_icon(texture: Texture) -> TextureRect:
+	var icon = TextureRect.new()
+	icon.texture = texture
+	icon.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+	return icon
+
+# Utility function to create a Label for item names.
+func _create_button(text: String, callback: Callable) -> Button:
+	var button = Button.new()
+	button.text = text
+	button.button_up.connect(callback)
+	return button
+
+# Utility function to create a Button with a connected callback.
+func _create_label(text: String) -> Label:
+	var label = Label.new()
+	label.text = text
+	return label

--- a/Scripts/FurnitureWindow.gd
+++ b/Scripts/FurnitureWindow.gd
@@ -12,6 +12,7 @@ extends Control
 @export var craft_status_label: Label = null
 @export var craft_status_timer: Timer = null
 @export var transform_into_button: Button = null
+@export var fuel_label: Label = null
 
 # Recipe panel controls:
 @export var recipe_panel_container: PanelContainer = null
@@ -79,6 +80,9 @@ func _connect_furniture_signals():
 		if my_inventory.contents_changed.is_connected(_on_inventory_contents_changed):
 			my_inventory.contents_changed.disconnect(_on_inventory_contents_changed)
 		my_inventory.contents_changed.connect(_on_inventory_contents_changed)
+	
+	if furniture_instance.consumption:
+		furniture_instance.consumption.current_pool_changed.connect(_on_current_pool_changed)
 
 
 # Disconnects signals from the previous furniture_instance.
@@ -92,6 +96,9 @@ func _disconnect_furniture_signals():
 			var my_inventory = furniture_instance.get_inventory()
 			if my_inventory.contents_changed.is_connected(_on_inventory_contents_changed):
 				my_inventory.contents_changed.disconnect(_on_inventory_contents_changed)
+	
+		if furniture_instance.consumption:
+			furniture_instance.consumption.current_pool_changed.disconnect(_on_current_pool_changed)
 
 
 # Callback for furniture interaction. Only for FurnitureStaticSrv types
@@ -385,6 +392,7 @@ func _on_transform_into_button_button_up() -> void:
 func _update_transform_into_button():
 	if not furniture_instance or not furniture_instance.rfurniture.consumption:
 		transform_into_button.visible = false
+		fuel_label.visible = false
 		return
 
 	var transform_into_target = furniture_instance.rfurniture.consumption.transform_into
@@ -392,6 +400,13 @@ func _update_transform_into_button():
 
 	if transform_into_target == "":
 		transform_into_button.visible = false  # Hide the button if no transform target exists
+		fuel_label.visible = false  # Hide the button if no transform target exists
 	else:
+		fuel_label.visible = true  # Show the button and update its text
 		transform_into_button.visible = true  # Show the button and update its text
 		transform_into_button.text = button_text
+		fuel_label.text = "Fuel: " + str(round(furniture_instance.consumption.current_pool))
+
+
+func _on_current_pool_changed(_new_value: float):
+	_update_transform_into_button()

--- a/Scripts/Gamedata/DFurniture.gd
+++ b/Scripts/Gamedata/DFurniture.gd
@@ -355,6 +355,31 @@ func on_data_changed(old_furniture: DFurniture):
 	for current_item in current_items:
 		Gamedata.mods.add_reference(DMod.ContentType.ITEMS, current_item, DMod.ContentType.FURNITURES, id)
 
+	# Handle consumption item references
+	old_items = old_furniture.consumption.items.keys()  # Get old consumption item IDs
+	current_items = consumption.items.keys()  # Get current consumption item IDs
+
+	# Remove references for items no longer in the list
+	for old_item in old_items:
+		if old_item not in current_items:
+			Gamedata.mods.remove_reference(DMod.ContentType.ITEMS, old_item, DMod.ContentType.FURNITURES, id)
+
+	# Add references for new items
+	for current_item in current_items:
+		Gamedata.mods.add_reference(DMod.ContentType.ITEMS, current_item, DMod.ContentType.FURNITURES, id)
+
+	# Handle consumption.transform_into references
+	var old_transform_into = old_furniture.consumption.transform_into
+	var current_transform_into = consumption.transform_into
+
+	# Remove the old reference if it differs from the current one
+	if old_transform_into != "" and old_transform_into != current_transform_into:
+		Gamedata.mods.remove_reference(DMod.ContentType.FURNITURES, old_transform_into, DMod.ContentType.FURNITURES, id)
+
+	# Add the new reference if it differs from the old one
+	if current_transform_into != "":
+		Gamedata.mods.add_reference(DMod.ContentType.FURNITURES, current_transform_into, DMod.ContentType.FURNITURES, id)
+
 
 func _update_references(old_value: String, new_value: String):
 	if old_value != new_value:

--- a/Scripts/Gamedata/DFurniture.gd
+++ b/Scripts/Gamedata/DFurniture.gd
@@ -69,6 +69,7 @@ var destruction: Destruction
 var disassembly: Disassembly
 var crafting: Crafting
 var construction: Construction
+var consumption: Consumption
 var parent: DFurnitures
 
 # -------------------------------
@@ -216,6 +217,38 @@ class Construction:
 		items.erase(item_id)
 
 
+# Represents the consumption properties of a furniture
+class Consumption:
+	var pool: int = 0  # The initial value of the pool
+	var drain_rate: int = 0  # How much to drain per interval
+	var transform_into: String = ""  # The furniture ID to transform into after consumption
+	var button_text: String = ""  # Text for the action button
+	var items: Dictionary = {}  # Items required for consumption, e.g., {"wood": 12, "copper": 2}
+
+	# Constructor to initialize consumption data from a dictionary
+	func _init(data: Dictionary) -> void:
+		pool = data.get("pool", 0)
+		drain_rate = data.get("drain_rate", 0)
+		transform_into = data.get("transform_into", "")
+		button_text = data.get("button_text", "")
+		items = data.get("items", {})  # Default to an empty dictionary if not provided
+
+	# Get data function to return a dictionary with all properties
+	func get_data() -> Dictionary:
+		var result = {}
+		if pool > 0:
+			result["pool"] = pool
+		if drain_rate > 0:
+			result["drain_rate"] = drain_rate
+		if transform_into != "":
+			result["transform_into"] = transform_into
+		if button_text != "":
+			result["button_text"] = button_text
+		if not items.is_empty():
+			result["items"] = items
+		return result
+
+
 # -------------------------------
 # Initialization
 # -------------------------------
@@ -242,6 +275,7 @@ func _initialize_properties(data: Dictionary) -> void:
 	disassembly = Disassembly.new(data.get("disassembly", {}))
 	crafting = Crafting.new(data.get("crafting", {}))
 	construction = Construction.new(data.get("construction", {}))
+	consumption = Consumption.new(data.get("consumption", {}))
 
 
 # -------------------------------
@@ -276,6 +310,8 @@ func get_data() -> Dictionary:
 		result["crafting"] = crafting.get_data()
 	if not construction.get_data().is_empty():
 		result["construction"] = construction.get_data()
+	if not consumption.get_data().is_empty():
+		result["consumption"] = consumption.get_data()
 
 	return result
 

--- a/Scripts/Gamedata/DFurniture.gd
+++ b/Scripts/Gamedata/DFurniture.gd
@@ -220,7 +220,7 @@ class Construction:
 # Represents the consumption properties of a furniture
 class Consumption:
 	var pool: int = 0  # The initial value of the pool
-	var drain_rate: int = 0  # How much to drain per interval
+	var drain_rate: int = 0  # How much to drain per in-game hour
 	var transform_into: String = ""  # The furniture ID to transform into after consumption
 	var button_text: String = ""  # Text for the action button
 	var items: Dictionary = {}  # Items required for consumption, e.g., {"wood": 12, "copper": 2}

--- a/Scripts/Gamedata/DFurnitures.gd
+++ b/Scripts/Gamedata/DFurnitures.gd
@@ -134,11 +134,15 @@ func remove_itemgroup_from_all_furniture(itemgroup_id: String):
 # This will erase it from crating.items
 func remove_item_from_all_furniture(item_id: String):
 	for furniture in furnituredict.values():
-		furniture.remove_item_from_crafting(item_id)
-		furniture.remove_item_from_construction(item_id)
+		furniture.remove_item(item_id)
 
 
 # Removes the reference of the selected furniture
 func remove_reference(furniture_id: String):
 	references.erase(furniture_id)
 	Gamedata.mods.save_references(self)
+
+# Remove the provided furniture_id from all furniture's consumption.transform_into
+func remove_furniture_from_all_furniture(furniture_id: String):
+	for furniture in furnituredict.values():
+		furniture.remove_furniture(furniture_id)

--- a/Scripts/Runtimedata/RFurniture.gd
+++ b/Scripts/Runtimedata/RFurniture.gd
@@ -178,7 +178,7 @@ class Construction:
 # Represents the consumption properties of a furniture
 class Consumption:
 	var pool: int = 0  # The initial value of the pool
-	var drain_rate: int = 0  # How much to drain per interval
+	var drain_rate: int = 0  # How much to drain per in-game hour
 	var transform_into: String = ""  # The furniture ID to transform into after consumption
 	var button_text: String = ""  # Text for the action button
 	var items: Dictionary = {}  # Items required for consumption, e.g., {"wood": 12, "copper": 2}

--- a/Scripts/Runtimedata/RFurniture.gd
+++ b/Scripts/Runtimedata/RFurniture.gd
@@ -175,6 +175,38 @@ class Construction:
 		return items
 
 
+# Represents the consumption properties of a furniture
+class Consumption:
+	var pool: int = 0  # The initial value of the pool
+	var drain_rate: int = 0  # How much to drain per interval
+	var transform_into: String = ""  # The furniture ID to transform into after consumption
+	var button_text: String = ""  # Text for the action button
+	var items: Dictionary = {}  # Items required for consumption, e.g., {"wood": 12, "copper": 2}
+
+	# Constructor to initialize consumption data from a dictionary
+	func _init(data: Dictionary) -> void:
+		pool = data.get("pool", 0)
+		drain_rate = data.get("drain_rate", 0)
+		transform_into = data.get("transform_into", "")
+		button_text = data.get("button_text", "")
+		items = data.get("items", {})  # Default to an empty dictionary if not provided
+
+	# Get data function to return a dictionary with all properties
+	func get_data() -> Dictionary:
+		var result = {}
+		if pool > 0:
+			result["pool"] = pool
+		if drain_rate > 0:
+			result["drain_rate"] = drain_rate
+		if transform_into != "":
+			result["transform_into"] = transform_into
+		if button_text != "":
+			result["button_text"] = button_text
+		if not items.is_empty():
+			result["items"] = items
+		return result
+
+
 # Properties defined in the furniture
 var id: String
 var name: String
@@ -190,6 +222,7 @@ var destruction: Destruction
 var disassembly: Disassembly
 var crafting: Crafting
 var construction: Construction
+var consumption: Consumption
 var sprite: Texture
 var parent: RFurnitures  # Reference to the list containing all runtime furnitures for this mod
 
@@ -220,6 +253,8 @@ func overwrite_from_dfurniture(dfurniture: DFurniture) -> void:
 	disassembly.sprite = dfurniture.parent.sprite_by_file(dfurniture.disassembly.sprite)
 	crafting = Crafting.new(dfurniture.crafting.get_data())
 	construction = Construction.new(dfurniture.construction.get_data())
+	consumption = Consumption.new(dfurniture.consumption.get_data())
+
 
 # Get data function to return a dictionary with all properties
 func get_data() -> Dictionary:
@@ -259,6 +294,10 @@ func get_data() -> Dictionary:
 	var constructiondata: Dictionary = construction.get_data()
 	if not constructiondata.is_empty():
 		data["construction"] = constructiondata
+
+	var consumptiondata: Dictionary = consumption.get_data()
+	if not consumptiondata.is_empty():
+		data["consumption"] = consumptiondata
 
 	return data
 


### PR DESCRIPTION
Furniture can now consume items from it's inventory in order to fill up a "fuel pool". Kind of like how one would fill up a coal based furnace or the tank of a generator. Each furniture has a list of items that it can accept and you can assign a fuel value to each item.

This also enables furniture to transform into another furniture. When the user presses "light" on a campfire, it transforms into campfire (lit). When the fuel pool runs out or the player presses the "put out" button, the campfire (lit) transforms into campfire.

The list of fuel is not very convenient to maintain so we might come up with another idea for that. I did consider using an itemgroup there, but there is no "fuel value" in the itemgroup. I also considered adding a "fuel value" to each item, but it seems like a very specific property. You'd end up with a bunch of items with a fuel value of 0. 