### PR TITLE
Sprite carries over to duplicate when an entity is duplicated in the content editor

### DIFF
--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="ItemProtoset" load_steps=2 format=3]
+[gd_resource type="Resource" script_class="ItemProtoset" load_steps=2 format=3 uid="uid://cgkq7vfjq07jm"]
 
 [ext_resource type="Script" path="res://addons/gloot/core/item_protoset.gd" id="1_o35lu"]
 

--- a/Mods/Dimensionfall/Itemgroups/Itemgroups.json
+++ b/Mods/Dimensionfall/Itemgroups/Itemgroups.json
@@ -666,7 +666,7 @@
 				"probability": 20
 			},
 			{
-				"id": "pack_sigarrettes",
+				"id": "pack_cigarettes",
 				"max": 1,
 				"min": 1,
 				"probability": 20
@@ -1094,12 +1094,6 @@
 				"probability": 60
 			},
 			{
-				"id": "pack_sigarrettes",
-				"max": 1,
-				"min": 1,
-				"probability": 40
-			},
-			{
 				"id": "guide_survival_basic",
 				"max": 1,
 				"min": 1,
@@ -1134,6 +1128,12 @@
 				"max": 1,
 				"min": 1,
 				"probability": 5
+			},
+			{
+				"id": "pack_cigarettes",
+				"max": 1,
+				"min": 1,
+				"probability": 40
 			}
 		],
 		"mode": "Collection",
@@ -1498,12 +1498,6 @@
 				"probability": 1
 			},
 			{
-				"id": "pack_sigarrettes",
-				"max": 1,
-				"min": 1,
-				"probability": 40
-			},
-			{
 				"id": "can_beer",
 				"max": 1,
 				"min": 1,
@@ -1532,6 +1526,12 @@
 				"max": 1,
 				"min": 1,
 				"probability": 5
+			},
+			{
+				"id": "pack_cigarettes",
+				"max": 1,
+				"min": 1,
+				"probability": 20
 			}
 		],
 		"mode": "Collection",

--- a/Mods/Dimensionfall/Items/Items.json
+++ b/Mods/Dimensionfall/Items/Items.json
@@ -487,18 +487,6 @@
 		"weight": 0.5
 	},
 	{
-		"description": "It's a carton pack that contains sigarrettes. You need a fire source to light them and start smoking",
-		"id": "pack_sigarrettes",
-		"image": "./Mods/Dimensionfall/Items/sigarrette_pack_32.png",
-		"max_stack_size": 5,
-		"name": "Pack of sigarrettes",
-		"sprite": "sigarrette_pack_32.png",
-		"stack_size": 1,
-		"two_handed": false,
-		"volume": 10,
-		"weight": 0.1
-	},
-	{
 		"Wearable": {
 			"slot": "head"
 		},
@@ -2909,5 +2897,17 @@
 		"two_handed": false,
 		"volume": 20,
 		"weight": 0.5
+	},
+	{
+		"description": "It's a carton pack that contains cigarettes. You need a fire source to light them and start smoking",
+		"id": "pack_cigarettes",
+		"image": "./Mods/Dimensionfall/Items/sigarrette_pack_32.png",
+		"max_stack_size": 5,
+		"name": "Pack of cigarettes",
+		"sprite": "sigarrette_pack_32.png",
+		"stack_size": 1,
+		"two_handed": false,
+		"volume": 10,
+		"weight": 0.1
 	}
 ]

--- a/Mods/Dimensionfall/Items/references.json
+++ b/Mods/Dimensionfall/Items/references.json
@@ -452,7 +452,7 @@
 			"debris_urban"
 		]
 	},
-	"pack_sigarrettes": {
+	"pack_cigarettes": {
 		"itemgroups": [
 			"vending_machine_snacks",
 			"urban_litter",

--- a/Scenes/ContentManager/Custom_Editors/FurnitureEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/FurnitureEditor.tscn
@@ -5,7 +5,7 @@
 [ext_resource type="PackedScene" uid="uid://b8i6wfk3fngy4" path="res://Scenes/ContentManager/Custom_Widgets/Editable_Item_List.tscn" id="2_ekwf5"]
 [ext_resource type="PackedScene" uid="uid://d1h1rpwt8f807" path="res://Scenes/ContentManager/Custom_Widgets/Sprite_Selector_Popup.tscn" id="3_o3k3a"]
 [ext_resource type="PackedScene" uid="uid://dsax7il2yggw8" path="res://Scenes/ContentManager/Custom_Widgets/DropEnabledTextEdit.tscn" id="4_fbact"]
-[ext_resource type="Texture2D" uid="uid://lqavxdrjc078" path="res://Mods/Dimensionfall/Furniture/wardrobe_80_40.png" id="5_61cds"]
+[ext_resource type="Texture2D" uid="uid://c31w0wuk8qabw" path="res://Defaults/Sprites/2.png" id="5_q64hk"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_61e60"]
 
@@ -13,7 +13,7 @@
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_nv8h1"]
 
-[node name="FurnitureEditor" type="Control" node_paths=PackedStringArray("tab_container", "furniture_image_display", "id_label", "name_edit", "description_edit", "categories_list", "furniture_selector", "image_name_label", "moveable_checkbox", "weight_label", "weight_spinbox", "edge_snapping_option", "door_option", "container_checkbox", "container_text_edit", "regeneration_label", "regeneration_spin_box", "sprite_mode_option_button", "destroy_container", "can_destroy_checkbox", "destruction_text_edit", "destruction_image_display", "destruction_sprite_label", "disassembly_container", "can_disassemble_checkbox", "disassembly_text_edit", "disassembly_image_display", "disassembly_sprite_label", "support_shape_option_button", "width_scale_label", "depth_scale_label", "radius_scale_label", "width_scale_spin_box", "depth_scale_spin_box", "radius_scale_spin_box", "heigth_spin_box", "color_picker", "sprite_texture_rect", "transparent_check_box", "crafting_items_container", "construction_items_container", "pool_spin_box", "drain_rate_spin_box", "transform_into_drop_enabled_text_edit", "button_text_text_edit", "consumption_items_grid_container", "consumption_tab")]
+[node name="FurnitureEditor" type="Control" node_paths=PackedStringArray("tab_container", "furniture_image_display", "id_label", "name_edit", "description_edit", "categories_list", "furniture_selector", "image_name_label", "moveable_checkbox", "weight_label", "weight_spinbox", "edge_snapping_option", "door_option", "container_checkbox", "container_text_edit", "regeneration_label", "regeneration_spin_box", "sprite_mode_option_button", "destroy_container", "can_destroy_checkbox", "destruction_text_edit", "destruction_image_display", "destruction_sprite_label", "disassembly_container", "can_disassemble_checkbox", "disassembly_text_edit", "disassembly_image_display", "disassembly_sprite_label", "support_shape_option_button", "width_scale_label", "depth_scale_label", "radius_scale_label", "width_scale_spin_box", "depth_scale_spin_box", "radius_scale_spin_box", "height_spin_box", "color_picker", "sprite_texture_rect", "transparent_check_box", "crafting_items_container", "construction_items_container", "pool_spin_box", "drain_rate_spin_box", "transform_into_text_edit", "button_text_edit", "consumption_items_grid_container")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -56,7 +56,7 @@ radius_scale_label = NodePath("VBoxContainer/TabContainer/Shape/RadiusScaleLabel
 width_scale_spin_box = NodePath("VBoxContainer/TabContainer/Shape/WidthScaleSpinBox")
 depth_scale_spin_box = NodePath("VBoxContainer/TabContainer/Shape/DepthScaleSpinBox")
 radius_scale_spin_box = NodePath("VBoxContainer/TabContainer/Shape/RadiusScaleSpinBox")
-heigth_spin_box = NodePath("VBoxContainer/TabContainer/Shape/HeigthSpinBox")
+height_spin_box = NodePath("VBoxContainer/TabContainer/Shape/HeigthSpinBox")
 color_picker = NodePath("VBoxContainer/TabContainer/Shape/HBoxContainer/ColorPicker")
 sprite_texture_rect = NodePath("VBoxContainer/TabContainer/Shape/HBoxContainer/SpriteTextureRect")
 transparent_check_box = NodePath("VBoxContainer/TabContainer/Shape/TransparentCheckBox")
@@ -64,10 +64,9 @@ crafting_items_container = NodePath("VBoxContainer/TabContainer/Crafting/ItemsPa
 construction_items_container = NodePath("VBoxContainer/TabContainer/Construction/ConstructionItemsPanelContainer/ConstructionItemsScrollContainer/ConstructionItemsVBoxContainer/ConstructionItemsGridContainer")
 pool_spin_box = NodePath("VBoxContainer/TabContainer/Consumption/PoolSpinBox")
 drain_rate_spin_box = NodePath("VBoxContainer/TabContainer/Consumption/DrainRateSpinBox")
-transform_into_drop_enabled_text_edit = NodePath("VBoxContainer/TabContainer/Consumption/TransformIntoDropEnabledTextEdit")
-button_text_text_edit = NodePath("VBoxContainer/TabContainer/Consumption/ButtonTextTextEdit")
+transform_into_text_edit = NodePath("VBoxContainer/TabContainer/Consumption/TransformIntoDropEnabledTextEdit")
+button_text_edit = NodePath("VBoxContainer/TabContainer/Consumption/ButtonTextTextEdit")
 consumption_items_grid_container = NodePath("VBoxContainer/TabContainer/Consumption/ItemsPanelContainer/ItemsVBoxContainer/ItemsGridContainer")
-consumption_tab = NodePath("VBoxContainer/TabContainer/Consumption")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 1
@@ -489,7 +488,7 @@ presets_visible = false
 
 [node name="SpriteTextureRect" type="TextureRect" parent="VBoxContainer/TabContainer/Shape/HBoxContainer"]
 layout_mode = 2
-texture = ExtResource("5_61cds")
+texture = ExtResource("5_q64hk")
 
 [node name="TransparentLabel" type="Label" parent="VBoxContainer/TabContainer/Shape"]
 layout_mode = 2

--- a/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
@@ -126,6 +126,8 @@ func _load_metadata():
 	moveable_checkbox.button_pressed = dfurniture.moveable
 	weight_spinbox.value = dfurniture.weight
 	select_option_by_string(edge_snapping_option, dfurniture.edgesnapping)
+	# Update sprite_texture_rect with the current sprite
+	update_sprite_texture_rect(furniture_image_display.texture)
 
 func _load_destruction_data():
 	# Load destruction-specific data

--- a/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
@@ -1,44 +1,49 @@
 extends Control
 
-#This scene is intended to be used inside the content editor
-#It is supposed to edit exactly one piece of furniture
-#It expects to save the data to a JSON file that contains all furniture data from a mod
-#To load data, provide the name of the furniture data file and an ID
+# This scene is for editing a single piece of furniture.
+# It loads and saves data to a JSON file containing furniture data for a mod.
+# Provide the name of the furniture data file and an ID to load.
 
+# -------------------------------
+# Exported Variables (UI Elements)
+# -------------------------------
+@export_group("General Metadata")
 @export var tab_container: TabContainer
-
-@export var furniture_image_display: TextureRect = null
-@export var id_label: Label = null
-@export var name_edit: TextEdit = null
-@export var description_edit: TextEdit = null
-@export var categories_list: Control = null
-@export var furniture_selector: Popup = null
-@export var image_name_label: Label = null
-@export var moveable_checkbox: CheckBox = null # The player can push it if selected
+@export var furniture_image_display: TextureRect
+@export var id_label: Label
+@export var name_edit: TextEdit
+@export var description_edit: TextEdit
+@export var categories_list: Control
+@export var furniture_selector: Popup
+@export var image_name_label: Label
+@export var moveable_checkbox: CheckBox
 @export var weight_label: Label = null
-@export var weight_spinbox: SpinBox = null # The wight considered when pushing
-@export var edge_snapping_option: OptionButton = null # Apply edge snapping if selected
-@export var door_option: OptionButton = null # Maks the furniture as a door
-@export var container_checkbox: CheckBox = null # Marks the furniture as a container
-@export var container_text_edit: HBoxContainer = null # Might contain the id of a loot group
+@export var weight_spinbox: SpinBox
+@export var edge_snapping_option: OptionButton
+@export var door_option: OptionButton
+
+@export_group("Container Settings")
+@export var container_checkbox: CheckBox
+@export var container_text_edit: HBoxContainer
 @export var regeneration_label: Label = null
-@export var regeneration_spin_box: SpinBox = null # The time in days before regeneration
-@export var sprite_mode_option_button: OptionButton = null
+@export var regeneration_spin_box: SpinBox
+@export var sprite_mode_option_button: OptionButton
 
+@export_group("Destruction Settings")
+@export var destroy_container: HBoxContainer
+@export var can_destroy_checkbox: CheckBox
+@export var destruction_text_edit: HBoxContainer
+@export var destruction_image_display: TextureRect
+@export var destruction_sprite_label: Label
 
-@export var destroy_container: HBoxContainer = null # contains destroy controls
-@export var can_destroy_checkbox: CheckBox = null # If the furniture can be destroyed or not
-@export var destruction_text_edit: HBoxContainer = null # Might contain the id of a loot group
-@export var destruction_image_display: TextureRect = null # What it looks like when destroyed
-@export var destruction_sprite_label: Label = null # The name of the destroyed sprite
+@export_group("Disassembly Settings")
+@export var disassembly_container: HBoxContainer
+@export var can_disassemble_checkbox: CheckBox
+@export var disassembly_text_edit: HBoxContainer
+@export var disassembly_image_display: TextureRect
+@export var disassembly_sprite_label: Label
 
-@export var disassembly_container: HBoxContainer = null # contains destroy controls
-@export var can_disassemble_checkbox: CheckBox = null # If the furniture can be disassembled or not
-@export var disassembly_text_edit: HBoxContainer = null # Might contain the id of a loot group
-@export var disassembly_image_display: TextureRect = null # What it looks like when disassembled
-@export var disassembly_sprite_label: Label = null # The name of the disassembly sprite
-
-# Controls for the shape:
+@export_group("Support Shape")
 @export var support_shape_option_button: OptionButton
 @export var width_scale_label: Label = null
 @export var depth_scale_label: Label = null
@@ -46,29 +51,26 @@ extends Control
 @export var width_scale_spin_box: SpinBox
 @export var depth_scale_spin_box: SpinBox
 @export var radius_scale_spin_box: SpinBox
-@export var heigth_spin_box: SpinBox
+@export var height_spin_box: SpinBox
 @export var color_picker: ColorPicker
 @export var sprite_texture_rect: TextureRect
 @export var transparent_check_box: CheckBox
 
-# Container for items that can be crafted
-@export var crafting_items_container: GridContainer = null
-# Container for items that are requires to construct this furniture.
-@export var construction_items_container: GridContainer = null
+@export_group("CraftingConstruction")
+@export var crafting_items_container: GridContainer
+@export var construction_items_container: GridContainer
+
+@export_group("Consumption Settings")
+@export var pool_spin_box: SpinBox
+@export var drain_rate_spin_box: SpinBox
+@export var transform_into_text_edit: HBoxContainer
+@export var button_text_edit: TextEdit
+@export var consumption_items_grid_container: GridContainer
 
 # For controlling the focus when the tab button is pressed
 var control_elements: Array = []
 # Tracks which image display control is currently being updated
 var current_image_display: String = ""
-
-# Controls for consumption:
-@export var pool_spin_box: SpinBox = null
-@export var drain_rate_spin_box: SpinBox = null
-@export var transform_into_drop_enabled_text_edit: HBoxContainer = null
-@export var button_text_text_edit: TextEdit = null
-@export var consumption_items_grid_container: GridContainer = null
-@export var consumption_tab: GridContainer = null
-
 
 # This signal will be emitted when the user presses the save button
 signal data_changed()
@@ -163,7 +165,7 @@ func _load_support_shape_data():
 	select_option_by_string(support_shape_option_button, support_shape.shape)
 	color_picker.color = Color.html(support_shape.color)
 	transparent_check_box.button_pressed = support_shape.transparent
-	heigth_spin_box.value = support_shape.height
+	height_spin_box.value = support_shape.height
 	width_scale_spin_box.value = support_shape.width_scale
 	depth_scale_spin_box.value = support_shape.depth_scale
 	radius_scale_spin_box.value = support_shape.radius_scale
@@ -227,8 +229,8 @@ func _on_save_button_button_up():
 	# Save consumption values
 	dfurniture.consumption.pool = int(pool_spin_box.value)
 	dfurniture.consumption.drain_rate = int(drain_rate_spin_box.value)
-	dfurniture.consumption.transform_into = transform_into_drop_enabled_text_edit.get_text()
-	dfurniture.consumption.button_text = button_text_text_edit.text
+	dfurniture.consumption.transform_into = transform_into_text_edit.get_text()
+	dfurniture.consumption.button_text = button_text_edit.text
 
 	# Save crafting and construction items
 	_save_crafting_items()
@@ -245,7 +247,7 @@ func handle_support_shape_option():
 	if not moveable_checkbox.button_pressed:
 		var shape = support_shape_option_button.get_item_text(support_shape_option_button.selected)
 		dfurniture.support_shape.shape = shape
-		dfurniture.support_shape.height = heigth_spin_box.value
+		dfurniture.support_shape.height = height_spin_box.value
 		dfurniture.support_shape.color = color_picker.color.to_html()
 		dfurniture.support_shape.transparent = transparent_check_box.button_pressed
 		if shape == "Box":
@@ -383,9 +385,9 @@ func set_drop_functions():
 	
 	construction_items_container.set_drag_forwarding(Callable(), _can_construction_item_drop, _construction_item_drop)
 	consumption_items_grid_container.set_drag_forwarding(Callable(), _can_consumption_item_drop, _consumption_item_drop)
-	# Assign drop functions for transform_into_drop_enabled_text_edit
-	transform_into_drop_enabled_text_edit.drop_function = furniture_drop.bind(transform_into_drop_enabled_text_edit)
-	transform_into_drop_enabled_text_edit.can_drop_function = can_furniture_drop
+	# Assign drop functions for transform_into_text_edit
+	transform_into_text_edit.drop_function = furniture_drop.bind(transform_into_text_edit)
+	transform_into_text_edit.can_drop_function = can_furniture_drop
 
 
 # When the furniture_image_display is clicked, the user will be prompted to select an image from
@@ -736,8 +738,8 @@ func _load_consumption_data():
 	# Load values from dfurniture.consumption
 	pool_spin_box.value = dfurniture.consumption.pool
 	drain_rate_spin_box.value = dfurniture.consumption.drain_rate
-	transform_into_drop_enabled_text_edit.set_text(dfurniture.consumption.transform_into)
-	button_text_text_edit.text = dfurniture.consumption.button_text
+	transform_into_text_edit.set_text(dfurniture.consumption.transform_into)
+	button_text_edit.text = dfurniture.consumption.button_text
 	_load_consumption_items()
 
 

--- a/Scenes/ContentManager/Scripts/content_list.gd
+++ b/Scenes/ContentManager/Scripts/content_list.gd
@@ -128,7 +128,6 @@ func _on_ok_button_up():
 	load_data()
 
 
-
 # Called after the users presses cancel on the popup asking for an ID
 func _on_cancel_button_up():
 	pupup_ID.hide()

--- a/Scripts/Gamedata/DFurnitures.gd
+++ b/Scripts/Gamedata/DFurnitures.gd
@@ -83,6 +83,8 @@ func duplicate_to_disk(furnitureid: String, newfurnitureid: String, new_mod_id: 
 	var newparent: DFurnitures = self if new_mod_id == mod_id else Gamedata.mods.by_id(new_mod_id).furnitures
 	# Instantiate and append the new DFurniture instance
 	var newfurniture: DFurniture = DFurniture.new(furnituredata, newparent)
+	if furnituredata.has("sprite"):
+		newfurniture.sprite = newparent.sprite_by_file(furnituredata["sprite"])
 	newparent.append_new(newfurniture)
 
 

--- a/Scripts/Gamedata/DItem.gd
+++ b/Scripts/Gamedata/DItem.gd
@@ -628,8 +628,8 @@ func delete():
 		return
 		
 	# For each mod, remove this item from the itemgroup in this item's references
-	for mod: DMod in Gamedata.mods.get_all_mods():
-		mod.itemgroups.remove_item_by_id(id)
+	for mod: DMod in (Gamedata.mods.get_all_mods() as Array[DMod]):
+		mod.itemgroups.remove_item_from_all_itemgroups(id)
 		mod.items.remove_item_from_all_recipes(id)
 		mod.quests.remove_item_from_all_quests(id)
 		mod.furnitures.remove_item_from_all_furniture(id)

--- a/Scripts/Gamedata/DItemgroups.gd
+++ b/Scripts/Gamedata/DItemgroups.gd
@@ -127,3 +127,10 @@ func sprite_by_file(spritefile: String) -> Texture:
 func remove_reference(itemgroupid: String):
 	references.erase(itemgroupid)
 	Gamedata.mods.save_references(self)
+
+
+# Remove the provided item from all itemgroups
+# This will erase it from the items list in the itemgroup
+func remove_item_from_all_itemgroups(item_id: String):
+	for itemgroup: DItemgroup in itemgroupdict.values():
+		itemgroup.remove_item_by_id(item_id)

--- a/Scripts/Gamedata/DItemgroups.gd
+++ b/Scripts/Gamedata/DItemgroups.gd
@@ -84,6 +84,8 @@ func duplicate_to_disk(itemgroupid: String, newitemgroupid: String, new_mod_id: 
 
 	# Instantiate and append the new DItemgroup instance
 	var newitemgroup: DItemgroup = DItemgroup.new(itemgroupdata, newparent)
+	if itemgroupdata.has("sprite"):
+		newitemgroup.sprite = newparent.sprite_by_file(itemgroupdata["sprite"])
 	newparent.append_new(newitemgroup)
 
 

--- a/Scripts/Gamedata/DItems.gd
+++ b/Scripts/Gamedata/DItems.gd
@@ -6,172 +6,127 @@ extends RefCounted
 # This script handles the list of items. You can access it trough Gamedata.mods.by_id("Core").items
 
 
-var dataPath: String = "./Mods/Core/Items/"
-var filePath: String = "./Mods/Core/Items/Items.json"
-var spritePath: String = "./Mods/Core/Items/"
-var itemdict: Dictionary = {}
+var data_path: String = "./Mods/Core/Items/"
+var file_path: String = "./Mods/Core/Items/Items.json"
+var sprite_path: String = "./Mods/Core/Items/"
+var items: Dictionary = {}
 var sprites: Dictionary = {}
 var references: Dictionary = {}
 var mod_id: String = "Core"
 
-# Add a mod_id parameter to dynamically initialize paths
+# Initialize paths and load all data
 func _init(new_mod_id: String) -> void:
 	mod_id = new_mod_id
-	# Update dataPath and spritePath using the provided mod_id
-	dataPath = "./Mods/" + mod_id + "/Items/"
-	filePath = "./Mods/" + mod_id + "/Items/Items.json"
-	spritePath = "./Mods/" + mod_id + "/Items/"
+	# Update data_path and sprite_path using the provided mod_id
+	data_path = "./Mods/" + mod_id + "/Items/"
+	file_path = "./Mods/" + mod_id + "/Items/Items.json"
+	sprite_path = "./Mods/" + mod_id + "/Items/"
 	load_sprites()
 	load_items_from_disk()
 	load_references()
 
 
-# Load references from references.json
+# -----------------------
+# Data Loading Functions
+# -----------------------
+# Load item references from "references.json"
 func load_references() -> void:
-	var path = dataPath + "references.json"
+	var path = data_path + "references.json"
 	if FileAccess.file_exists(path):
 		references = Helper.json_helper.load_json_dictionary_file(path)
 	else:
 		references = {}  # Initialize an empty references dictionary if the file doesn't exist
 
-
-# Load all itemdata from disk into memory
+# Load all item data from disk and populate `items`
 func load_items_from_disk() -> void:
-	var itemlist: Array = Helper.json_helper.load_json_array_file(filePath)
-	for myitem in itemlist:
-		var item: DItem = DItem.new(myitem, self)
-		if myitem.has("sprite"):
-			item.sprite = sprites[item.spriteid]
-		itemdict[item.id] = item
+	var item_list: Array = Helper.json_helper.load_json_array_file(file_path)
+	for item_data: Dictionary in item_list:
+		var item = DItem.new(item_data, self)
+		if item_data.has("sprite"):
+			item.sprite = sprites.get(item.spriteid, null)
+		items[item.id] = item
 
-
-# Loads sprites and assigns them to the proper dictionary
+# Load all PNG files in the sprite directory into `sprites`
 func load_sprites() -> void:
-	var png_files: Array = Helper.json_helper.file_names_in_dir(spritePath, ["png"])
+	var png_files: Array = Helper.json_helper.file_names_in_dir(sprite_path, ["png"])
 	for png_file in png_files:
-		# Load the .png file as a texture
-		var texture := load(spritePath + png_file) 
-		# Add the material to the dictionary
-		sprites[png_file] = texture
+		sprites[png_file] = load(sprite_path + png_file)
 
-
-func on_data_changed():
-	save_items_to_disk()
-
-
-# Saves all items to disk
+# -----------------------
+# Data Saving Functions
+# -----------------------
+# Save all items back to disk
 func save_items_to_disk() -> void:
 	var save_data: Array = []
-	for item: DItem in itemdict.values():
+	for item: DItem in items.values():
 		save_data.append(item.get_data())
-	Helper.json_helper.write_json_file(filePath, JSON.stringify(save_data, "\t"))
+	Helper.json_helper.write_json_file(file_path, JSON.stringify(save_data, "\t"))
 
+# Called when data is modified
+func on_data_changed() -> void:
+	save_items_to_disk()
 
+# -----------------------
+# Item Management
+# -----------------------
+# Get all items as a dictionary
 func get_all() -> Dictionary:
-	return itemdict
+	return items
 
+# Add a new item by ID
+func add_new(item_id: String) -> void:
+	var new_item = DItem.new({"id": item_id}, self)
+	_append_new_item(new_item)
 
-# Duplicate the item to disk. A new mod id may be provided to save the duplicate to.
-# itemid: The item to duplicate.
-# newitemid: The id of the new duplicate (can be the same as itemid if new_mod_id equals mod_id).
-# new_mod_id: The id of the mod that the duplicate will be entered into. May differ from mod_id.
-func duplicate_to_disk(itemid: String, newitemid: String, new_mod_id: String) -> void:
-	# Duplicate the item data and set the new id
-	var itemdata: Dictionary = by_id(itemid).get_data().duplicate(true)
-	itemdata.id = newitemid
-
-	# Determine the new parent based on the new_mod_id
-	var newparent: DItems = self if new_mod_id == mod_id else Gamedata.mods.by_id(new_mod_id).items
-
-	# Instantiate and append the new DItem instance
-	var newitem: DItem = DItem.new(itemdata, newparent)
-	newparent.append_new(newitem)
-
-
-func add_new(newid: String) -> void:
-	append_new(DItem.new({"id":newid}, self))
-
-
-func append_new(newitem: DItem) -> void:
-	itemdict[newitem.id] = newitem
+# Append a new item to the dictionary and save
+func _append_new_item(new_item: DItem) -> void:
+	items[new_item.id] = new_item
 	save_items_to_disk()
 
+# Delete an item by ID
+func delete_by_id(item_id: String) -> void:
+	if items.has(item_id):
+		items[item_id].delete()
+		items.erase(item_id)
+		save_items_to_disk()
 
-func delete_by_id(itemid: String) -> void:
-	itemdict[itemid].delete()
-	itemdict.erase(itemid)
-	save_items_to_disk()
+# Get an item by ID
+func by_id(item_id: String) -> DItem:
+	return items.get(item_id)
 
+# Check if an item ID exists
+func has_id(item_id: String) -> bool:
+	return items.has(item_id)
 
-func by_id(itemid: String) -> DItem:
-	return itemdict[itemid]
+# -----------------------
+# Sprite Management
+# -----------------------
+# Get the sprite texture for an item by ID
+func sprite_by_id(item_id: String) -> Texture:
+	return items.get(item_id).sprite
 
+# Get the sprite texture by file name
+func sprite_by_file(file_name: String) -> Texture:
+	return sprites.get(file_name)
 
-func has_id(itemid: String) -> bool:
-	return itemdict.has(itemid)
-
-
-# Returns the sprite of the item
-# itemid: The id of the item to return the sprite of
-func sprite_by_id(itemid: String) -> Texture:
-	return itemdict[itemid].sprite
-
-# Returns the sprite of the item
-# itemid: The id of the item to return the sprite of
-func sprite_by_file(spritefile: String) -> Texture:
-	return sprites[spritefile]
-
-
-# Filters items by type. Returns a list of items of that type
-# item_type: Any of craft, magazine, ranged, melee, food, wearable
+# -----------------------
+# Filtering and References
+# -----------------------
+# Get all items of a specific type
 func get_items_by_type(item_type: String) -> Array[DItem]:
 	var filtered_items: Array[DItem] = []
-	for item in itemdict.values():
+	for item in items.values():
 		if not item.get(item_type) == null:
 			filtered_items.append(item)
 	return filtered_items
 
 
-# Removes the reference of the selected item
-func remove_reference(itemid: String):
-	references.erase(itemid)
+# Remove a reference for an item
+func remove_reference(item_id: String) -> void:
+	references.erase(item_id)
 	Gamedata.mods.save_references(self)
 
-
-# Removes a specific item from all crafting recipes across all items.
-# item_id: The ID of the item to be removed from the required resources of all crafting recipes.
-func remove_item_from_all_recipes(item_id: String) -> void:
-	for item in itemdict.values():
-		if item.craft:
-			item.craft.remove_item_from_recipes(item_id)
-	save_items_to_disk()
-
-
-# Removes a specific playerattribute across all items.
-# playerattribute_id: The ID of the playerattribute to be removed
-func remove_playerattribute_from_all_items(playerattribute_id: String) -> void:
-	for item: DItem in itemdict.values():
-		item.remove_playerattribute(playerattribute_id)
-	save_items_to_disk()
-
-
-# Removes a specific wearableslot across all items.
-# wearableslot_id: The ID of the wearableslot to be removed
-func remove_wearableslot_from_all_items(wearableslot_id: String) -> void:
-	for item: DItem in itemdict.values():
-		item.remove_wearableslot(wearableslot_id)
-	save_items_to_disk()
-
-
-# Removes a specific skill across all items.
-# wearableslot_id: The ID of the skill to be removed
-func remove_skill_from_all_items(skill_id: String) -> void:
-	for item: DItem in itemdict.values():
-		item.remove_skill(skill_id)
-	save_items_to_disk()
-
-
-# Returns an array of references for the item id
+# Get all references for a specific item ID
 # The return value might look like this:
 #{
 #	"itemgroups": [
@@ -180,6 +135,45 @@ func remove_skill_from_all_items(skill_id: String) -> void:
 #	]
 #}
 func get_references_by_id(item_id: String) -> Dictionary:
-	if not references.has(item_id):
-		return {}
 	return references.get(item_id, {})
+
+# -----------------------
+# Duplication Functions
+# -----------------------
+# Duplicate an item to another mod or ID
+func duplicate_to_disk(item_id: String, new_item_id: String, new_mod_id: String) -> void:
+	var original_item = by_id(item_id)
+	if original_item:
+		var duplicated_data = original_item.get_data().duplicate(true)
+		duplicated_data.id = new_item_id
+		var target_items = self if new_mod_id == mod_id else Gamedata.mods.by_id(new_mod_id).items
+		var new_item = DItem.new(duplicated_data, target_items)
+		target_items._append_new_item(new_item)
+
+# -----------------------
+# Bulk Editing
+# -----------------------
+# Remove an item from all crafting recipes
+func remove_item_from_all_recipes(item_id: String) -> void:
+	for item in items.values():
+		if item.craft:
+			item.craft.remove_item_from_recipes(item_id)
+	save_items_to_disk()
+
+# Remove a player attribute across all items
+func remove_playerattribute_from_all_items(attribute_id: String) -> void:
+	for item in items.values():
+		item.remove_playerattribute(attribute_id)
+	save_items_to_disk()
+
+# Remove a wearable slot across all items
+func remove_wearableslot_from_all_items(slot_id: String) -> void:
+	for item in items.values():
+		item.remove_wearableslot(slot_id)
+	save_items_to_disk()
+
+# Remove a skill across all items
+func remove_skill_from_all_items(skill_id: String) -> void:
+	for item in items.values():
+		item.remove_skill(skill_id)
+	save_items_to_disk()

--- a/Scripts/Gamedata/DItems.gd
+++ b/Scripts/Gamedata/DItems.gd
@@ -144,11 +144,21 @@ func get_references_by_id(item_id: String) -> Dictionary:
 func duplicate_to_disk(item_id: String, new_item_id: String, new_mod_id: String) -> void:
 	var original_item = by_id(item_id)
 	if original_item:
+		# Duplicate the item data and update the ID
 		var duplicated_data = original_item.get_data().duplicate(true)
 		duplicated_data.id = new_item_id
+
+		# Determine the target items container (current mod or another mod)
 		var target_items = self if new_mod_id == mod_id else Gamedata.mods.by_id(new_mod_id).items
+
+		# Create the new item and update its sprite
 		var new_item = DItem.new(duplicated_data, target_items)
+		if duplicated_data.has("sprite"):
+			new_item.sprite = target_items.sprite_by_file(duplicated_data["sprite"])
+
+		# Add the new item to the target items container
 		target_items._append_new_item(new_item)
+
 
 # -----------------------
 # Bulk Editing

--- a/Scripts/Gamedata/DMobfactions.gd
+++ b/Scripts/Gamedata/DMobfactions.gd
@@ -81,6 +81,8 @@ func duplicate_to_disk(mobfactionid: String, newmobfactionid: String, new_mod_id
 
 	# Instantiate and append the new DMobfaction instance
 	var newmobfaction: DMobfaction = DMobfaction.new(mobfactiondata, newparent)
+	if mobfactiondata.has("sprite"):
+		newmobfaction.sprite = newparent.sprite_by_file(mobfactiondata["sprite"])
 	newparent.append_new(newmobfaction)
 
 

--- a/Scripts/Gamedata/DMobgroups.gd
+++ b/Scripts/Gamedata/DMobgroups.gd
@@ -79,6 +79,8 @@ func duplicate_to_disk(mobgroupid: String, newmobgroupid: String, new_mod_id: St
 
 	# Instantiate and append the new DMobgroup instance
 	var newmobgroup: DMobgroup = DMobgroup.new(mobgroupdata, newparent)
+	if mobgroupdata.has("sprite"):
+		newmobgroup.sprite = newparent.sprite_by_file(mobgroupdata["sprite"])
 	newparent.append_new(newmobgroup)
 
 

--- a/Scripts/Gamedata/DMobs.gd
+++ b/Scripts/Gamedata/DMobs.gd
@@ -85,6 +85,8 @@ func duplicate_to_disk(mobid: String, newmobid: String, new_mod_id: String) -> v
 
 	# Instantiate and append the new DMob instance
 	var newmob: DMob = DMob.new(mobdata, newparent)
+	if mobdata.has("sprite"):
+		newmob.sprite = newparent.sprite_by_file(mobdata["sprite"])
 	newparent.append_new(newmob)
 
 

--- a/Scripts/Gamedata/DMods.gd
+++ b/Scripts/Gamedata/DMods.gd
@@ -365,5 +365,5 @@ func get_all_mod_ids() -> Array:
 
 # ------------------------------------------------------------------
 # Retrieves all loaded mods as an array of DMod instances.
-func get_all_mods() -> Array[DMod]:
+func get_all_mods() -> Array:
 	return mod_dict.values()

--- a/Scripts/Gamedata/DOvermaparea.gd
+++ b/Scripts/Gamedata/DOvermaparea.gd
@@ -192,7 +192,7 @@ func delete():
 	# Check to see if any mod has a copy of this overmaparea. if one or more remain, we can keep references
 	# Otherwise, the last copy was removed and we need to remove references
 	var all_results: Array = Gamedata.mods.get_all_content_by_id(DMod.ContentType.OVERMAPAREAS, id)
-	if all_results.size() > 0:
+	if all_results.size() > 1:
 		return
 		
 	var map_ids = get_all_map_ids()

--- a/Scripts/Gamedata/DPlayerAttributes.gd
+++ b/Scripts/Gamedata/DPlayerAttributes.gd
@@ -87,6 +87,8 @@ func duplicate_to_disk(playerattributeid: String, newplayerattributeid: String, 
 
 	# Instantiate and append the new DPlayerAttribute instance
 	var newplayerattribute: DPlayerAttribute = DPlayerAttribute.new(playerattributedata, newparent)
+	if playerattributedata.has("sprite"):
+		newplayerattribute.sprite = newparent.sprite_by_file(playerattributedata["sprite"])
 	newparent.append_new(newplayerattribute)
 
 

--- a/Scripts/Gamedata/DQuests.gd
+++ b/Scripts/Gamedata/DQuests.gd
@@ -76,6 +76,8 @@ func duplicate_to_disk(questid: String, newquestid: String, new_mod_id: String) 
 
 	# Instantiate and append the new DQuest instance
 	var newquest: DQuest = DQuest.new(questdata, newparent)
+	if questdata.has("sprite"):
+		newquest.sprite = newparent.sprite_by_file(questdata["sprite"])
 	newparent.append_new(newquest)
 
 

--- a/Scripts/Gamedata/DSkills.gd
+++ b/Scripts/Gamedata/DSkills.gd
@@ -85,6 +85,8 @@ func duplicate_to_disk(skillid: String, newskillid: String, new_mod_id: String) 
 
 	# Instantiate and append the new DSkill instance
 	var newskill: DSkill = DSkill.new(skilldata, newparent)
+	if skilldata.has("sprite"):
+		newskill.sprite = newparent.sprite_by_file(skilldata["sprite"])
 	newparent.append_new(newskill)
 
 

--- a/Scripts/Gamedata/DStats.gd
+++ b/Scripts/Gamedata/DStats.gd
@@ -72,6 +72,8 @@ func duplicate_to_disk(statid: String, newstatid: String, new_mod_id: String) ->
 
 	# Instantiate and append the new DStat instance
 	var newstat: DStat = DStat.new(statdata, newparent)
+	if statdata.has("sprite"):
+		newstat.sprite = newparent.sprite_by_file(statdata["sprite"])
 	newparent.append_new(newstat)
 
 

--- a/Scripts/Gamedata/DTiles.gd
+++ b/Scripts/Gamedata/DTiles.gd
@@ -86,6 +86,8 @@ func duplicate_to_disk(tileid: String, newtileid: String, new_mod_id: String) ->
 
 	# Instantiate and append the new DTile instance
 	var newtile: DTile = DTile.new(tiledata, newparent)
+	if tiledata.has("sprite"):
+		newtile.sprite = newparent.sprite_by_file(tiledata["sprite"])
 	newparent.append_new(newtile)
 
 

--- a/Scripts/Gamedata/DWearableSlot.gd
+++ b/Scripts/Gamedata/DWearableSlot.gd
@@ -88,4 +88,4 @@ func delete():
 func remove_item(item_id: String):
 	if starting_item == item_id:
 		starting_item = ""
-	parent.save_furnitures_to_disk()
+	parent.save_wearableslots_to_disk()

--- a/Scripts/Gamedata/DWearableSlots.gd
+++ b/Scripts/Gamedata/DWearableSlots.gd
@@ -84,6 +84,8 @@ func duplicate_to_disk(wearableslotid: String, newwearableslotid: String, new_mo
 
 	# Instantiate and append the new DWearableSlot instance
 	var newwearableslot: DWearableSlot = DWearableSlot.new(wearableslotdata, newparent)
+	if wearableslotdata.has("sprite"):
+		newwearableslot.sprite = newparent.sprite_by_file(wearableslotdata["sprite"])
 	newparent.append_new(newwearableslot)
 
 

--- a/Scripts/ItemEditor.gd
+++ b/Scripts/ItemEditor.gd
@@ -104,7 +104,7 @@ func _on_save_button_button_up() -> void:
 	ditem.spriteid = PathTextLabel.text
 	ditem.sprite = itemImageDisplay.texture
 	# We add this image property only for the itemprotosets of gloot
-	ditem.image = ditem.parent.spritePath + PathTextLabel.text
+	ditem.image = ditem.parent.sprite_path + PathTextLabel.text
 	ditem.name = NameTextEdit.text
 	ditem.description = DescriptionTextEdit.text
 	ditem.volume = VolumeNumberBox.value

--- a/Scripts/OvermapGrid.gd
+++ b/Scripts/OvermapGrid.gd
@@ -47,7 +47,7 @@ class map_cell:
 			map_id = value
 			rmap = Runtimedata.maps.by_id(map_id)
 	var tacticalmapname: String = "town_00.json"
-	var revealed: int = RevealedState.REVEALED  # Default state is HIDDEN
+	var revealed: int = RevealedState.HIDDEN  # Default state is HIDDEN
 	var rotation: int = 0  # Will be any of [0, 90, 180, 270]
 
 	func get_data() -> Dictionary:


### PR DESCRIPTION
Fixes #640 

Since the sprite is not set on initialization, we have to set it afterwards.