### PR TITLE
Overmapgrid no longer overwrites tacticalmaps with roads

### DIFF
--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -471,17 +471,6 @@ json_data = "[
 		\"weight\": 0.5
 	},
 	{
-		\"description\": \"It's a carton pack that contains sigarrettes. You need a fire source to light them and start smoking\",
-		\"id\": \"pack_sigarrettes\",
-		\"image\": \"./Mods/Dimensionfall/Items/sigarrette_pack_32.png\",
-		\"max_stack_size\": 5,
-		\"name\": \"Pack of sigarrettes\",
-		\"sprite\": \"sigarrette_pack_32.png\",
-		\"stack_size\": 1,
-		\"volume\": 10,
-		\"weight\": 0.1
-	},
-	{
 		\"Wearable\": {
 			\"player_attributes\": [],
 			\"slot\": \"head\"
@@ -2757,5 +2746,16 @@ json_data = "[
 		\"stack_size\": 1,
 		\"volume\": 20,
 		\"weight\": 0.5
+	},
+	{
+		\"description\": \"It's a carton pack that contains cigarettes. You need a fire source to light them and start smoking\",
+		\"id\": \"pack_cigarettes\",
+		\"image\": \"./Mods/Dimensionfall/Items/sigarrette_pack_32.png\",
+		\"max_stack_size\": 5,
+		\"name\": \"Pack of cigarettes\",
+		\"sprite\": \"sigarrette_pack_32.png\",
+		\"stack_size\": 1,
+		\"volume\": 10,
+		\"weight\": 0.1
 	}
 ]"

--- a/Scripts/OvermapGrid.gd
+++ b/Scripts/OvermapGrid.gd
@@ -13,6 +13,7 @@ var pos: Vector2 = Vector2.ZERO
 var cells: Dictionary = {}
 # Dictionary to store map_id and their corresponding coordinates
 var map_id_to_coordinates: Dictionary = {}
+var tactical_map_positions: Dictionary = {}  # Tracks tactical map cell coordinates
 var grid_width: int = 100 # TODO: Pass the global grid_width to this class
 var grid_height: int = 100
 # Dictionary to store lists of area positions sorted by dovermaparea.id
@@ -47,7 +48,7 @@ class map_cell:
 			map_id = value
 			rmap = Runtimedata.maps.by_id(map_id)
 	var tacticalmapname: String = "town_00.json"
-	var revealed: int = RevealedState.HIDDEN  # Default state is HIDDEN
+	var revealed: int = RevealedState.REVEALED  # Default state is HIDDEN
 	var rotation: int = 0  # Will be any of [0, 90, 180, 270]
 
 	func get_data() -> Dictionary:
@@ -204,7 +205,7 @@ func build_map_id_to_coordinates():
 func connect_cities_by_riverlike_path(city_positions: Array) -> void:
 	var all_road_positions: Array = []  # To collect all road positions
 
-	# Step 1: Generate paths between each city and assign road maps
+	# Generate paths between each city and assign road maps
 	for i in range(city_positions.size() - 1):
 		var start_pos = city_positions[i]
 		var end_pos = city_positions[i + 1]
@@ -222,7 +223,7 @@ func connect_cities_by_riverlike_path(city_positions: Array) -> void:
 		# Collect all positions in the path for later connection updates
 		all_road_positions.append_array(path)
 
-	# Step 2: Once all paths are generated, update road connections for all roads
+	# Once all paths are generated, update road connections for all roads
 	update_all_road_connections(all_road_positions)
 
 
@@ -266,11 +267,16 @@ func update_path_on_grid(path: Array) -> void:
 		print("Missing road or forest road maps!")
 		return
 
-	# Step 1: Assign road maps to path cells without updating connections
+	# Assign road maps to path cells without overwriting tactical maps
 	for global_position in path:
 		if cells.has(global_position):
-			var cell = cells[global_position] # Will be a map_cell instance
-			if not "Urban" in cell.rmap.categories: # Skip urban areas
+			var cell = cells[global_position]
+
+			# 🚨 Prevent roads from replacing tactical maps
+			if tactical_map_positions.has(global_position):
+				continue  # Skip this cell since it contains a tactical map
+
+			if not "Urban" in cell.rmap.categories:  # Skip urban areas
 				assign_road_map_to_cell(global_position, cell)
 
 
@@ -280,26 +286,43 @@ func update_all_road_connections(road_positions: Array) -> void:
 	var edge_positions: Dictionary = edge_data["edge_positions"]
 	var edgeglobals: Array = edge_data["edgeglobals"]
 
-	# Step 2: Update connections for non-edge positions within this grid
+	# Update connections for non-edge positions within this grid
 	for global_position in road_positions:
 		if cells.has(global_position) and not global_position in edgeglobals:
 			var cell = cells[global_position]
+
+			# 🚨 Prevent roads from replacing tactical maps
+			if tactical_map_positions.has(global_position):
+				continue  # Skip this cell since it contains a tactical map
+
 			if not "Urban" in cell.rmap.categories:
 				update_road_connections(global_position, cell)
 
-	# Step 3: Handle connections for edge positions with neighboring grids
+	# Handle connections for edge positions with neighboring grids
 	for direction in edge_positions.keys():
 		for edge_position in edge_positions[direction]: # All positions on the south border for example
 			# Update within this grid first
 			if cells.has(edge_position): # Should be true for all edge positions
-				update_road_connections(edge_position, cells[edge_position])
-			
+				var cell = cells[edge_position]
+
+				# 🚨 Prevent roads from replacing tactical maps
+				if tactical_map_positions.has(edge_position):
+					continue
+
+				update_road_connections(edge_position, cell)
+
 			# Update in the neighboring grid
 			var neighbor_pos: Vector2 = edge_position + Gamedata.DIRECTION_OFFSETS[direction]
 			if neighbor_pos:
 				var neighbor_grid: OvermapGrid = Helper.overmap_manager.get_grid_from_local_pos(neighbor_pos)
 				var neighbor_cell = neighbor_grid.get_cell_from_global_pos(neighbor_pos) # A map_cell instance
+
+				# 🚨 Prevent roads from replacing tactical maps in neighboring grids
+				if neighbor_cell and neighbor_grid.tactical_map_positions.has(neighbor_pos):
+					continue
+				
 				neighbor_grid.update_road_connections(neighbor_pos, neighbor_cell)
+
 
 
 # Function to categorize road positions by grid edge
@@ -333,6 +356,10 @@ func get_edge_positions(road_positions: Array) -> Dictionary:
 # Assign the appropriate road map (forest or regular) to a cell
 # cell: A map_cell instance
 func assign_road_map_to_cell(global_position: Vector2, cell) -> void:
+	# 🚨 Prevent roads from replacing tactical maps
+	if tactical_map_positions.has(global_position):
+		return
+
 	# If it's a forest cell, assign a forest road, otherwise a normal road
 	var map_to_use = road_maps
 	if "Forest" in cell.rmap.categories:
@@ -528,10 +555,12 @@ func _place_single_overmap_area(placed_positions: Array) -> void:
 # Function to place tactical maps on this grid
 func place_tactical_maps() -> void:
 	var placed_positions = []
+	tactical_map_positions.clear()  # Reset the tracking dictionary before placing new maps
+
 	for n in range(5):  # Loop to place up to 10 tactical maps on the grid
 		var dmap: RTacticalmap = Runtimedata.tacticalmaps.get_random_map()
 		if not dmap:
-			return # We were unable to find any random map so we should return
+			return  # No random map found, exit function
 		var map_width = dmap.mapwidth
 		var map_height = dmap.mapheight
 		var chunks = dmap.chunks
@@ -554,6 +583,10 @@ func place_tactical_maps() -> void:
 					var cell_key = Vector2(local_x, local_y)
 					var chunk_index = j * map_width + i
 					var dchunk: RTacticalmap.TChunk = chunks[chunk_index]
+
+					# 🚨 Track tactical map position
+					tactical_map_positions[cell_key] = true
+
 					update_cell(local_to_global(cell_key), dchunk.id, dchunk.rotation)
 					placed_positions.append(cell_key)  # Track the positions that have been occupied
 
@@ -681,11 +714,9 @@ func connect_cities_by_hub_path(city_positions: Array) -> void:
 	var city_pairs: Array = get_city_pairs(city_positions)
 	var all_road_positions: Array = []
 
-	# Step 1: Handle hub connections for distant city pairs
+	# Handle hub connections for distant city pairs
 	connect_distant_city_pairs_with_hubs(city_pairs, city_positions, all_road_positions)
-
-	# Step 2: Finalize all road connections
-	update_all_road_connections(all_road_positions)
+	update_all_road_connections(all_road_positions) # Finalize all road connections
 
 
 # New function to connect city pairs directly if their distance is less than 40

--- a/Scripts/OvermapGrid.gd
+++ b/Scripts/OvermapGrid.gd
@@ -490,36 +490,39 @@ func place_area_on_grid(area_grid: Dictionary, placed_positions: Array, mapsize:
 	return Vector2(-1, -1)
 
 
-# Function to place overmap areas on this grid
+# Place overmap areas on the grid
 func place_overmap_areas() -> void:
-	var placed_positions = []  # Track positions that have already been placed
+	var placed_positions = []  # Track positions already occupied
 	area_positions.clear()
 
-	# Loop to place up to 10 overmap areas on the grid
-	for n in range(10):
-		var mygenerator = OvermapAreaGenerator.new()
-		var random_area: ROvermaparea = Runtimedata.overmapareas.get_random_area()
-		if not random_area:
-			return # we were unable to find any overmaparea so we should exit
-		var dovermaparea = Runtimedata.overmapareas.by_id(random_area.id)
-		mygenerator.rovermaparea = dovermaparea
+	# Place up to 10 overmap areas
+	for myint in range(10):
+		_place_single_overmap_area(placed_positions)
 
-		# Generate the area
-		var area_grid: Dictionary = mygenerator.generate_area(10000)
-		if area_grid.size() > 0:
-			# Use the dimensions from mygenerator after generating the area
-			var map_dimensions = mygenerator.dimensions
+# Helper function to place a single overmap area
+func _place_single_overmap_area(placed_positions: Array) -> void:
+	var generator = OvermapAreaGenerator.new()
+	var random_area: ROvermaparea = Runtimedata.overmapareas.get_random_area()
+	if not random_area:
+		return  # No valid area found
+	
+	# Initialize the area generator
+	generator.rovermaparea = random_area
+	var area_grid = generator.generate_area(10000)
+	if area_grid.size() == 0:
+		print_debug("Failed to generate overmap area.")
+		return
 
-			# Place the area and get the valid position
-			var valid_position = place_area_on_grid(area_grid, placed_positions, map_dimensions)
-			if valid_position != Vector2(-1, -1):
-				# Ensure the area_positions dictionary has an array for this dovermaparea.id
-				if not area_positions.has(dovermaparea.id):
-					area_positions[dovermaparea.id] = []
-				# Append the valid position to the list for this area's id
-				area_positions[dovermaparea.id].append(valid_position)
-		else:
-			print("Failed to find a valid position for the overmap area.")
+	# Find a valid position and place the area
+	var dimensions = generator.dimensions
+	var valid_position = place_area_on_grid(area_grid, placed_positions, dimensions)
+	if valid_position == Vector2(-1, -1):
+		return  # No valid position found
+
+	# Update the area_positions dictionary
+	if not area_positions.has(random_area.id):
+		area_positions[random_area.id] = []
+	area_positions[random_area.id].append(valid_position)
 
 
 # Function to place tactical maps on this grid

--- a/Scripts/OvermapGrid.gd
+++ b/Scripts/OvermapGrid.gd
@@ -48,7 +48,7 @@ class map_cell:
 			map_id = value
 			rmap = Runtimedata.maps.by_id(map_id)
 	var tacticalmapname: String = "town_00.json"
-	var revealed: int = RevealedState.REVEALED  # Default state is HIDDEN
+	var revealed: int = RevealedState.HIDDEN  # Default state is HIDDEN
 	var rotation: int = 0  # Will be any of [0, 90, 180, 270]
 
 	func get_data() -> Dictionary:

--- a/Scripts/OvermapGrid.gd
+++ b/Scripts/OvermapGrid.gd
@@ -160,8 +160,11 @@ class map_cell:
 
 
 # Translates local grid coordinates to global coordinates
+# Local coordinates: (0,0) -> (grid_width-1, grid_height-1)
+# Returns: Global coordinates (absolute positions in the world grid)
 func local_to_global(local_coord: Vector2) -> Vector2:
-	return local_coord + pos * grid_width
+	return local_coord + (pos * grid_width)
+
 
 func get_data() -> Dictionary:
 	var mydata: Dictionary = {"pos": pos, "cells": {}}
@@ -231,28 +234,28 @@ func connect_cities_by_riverlike_path(city_positions: Array) -> void:
 func generate_winding_path(global_start: Vector2, global_end: Vector2) -> Array:
 	var path = []
 	var current = global_start
+	
 	while current.distance_to(global_end) > 1:
 		if not path.has(current):
 			path.append(current)
 		var next_position = (global_end - current).normalized().round() + current
-		# Ensure small deviations and avoid straight paths
-		current = adjust_for_diagonal(next_position, current, path)
-	append_unique(path, global_end)
+		current = _adjust_path_for_organic_movement(next_position, current, path)
+	
+	# Ensure the end point is included
+	_append_unique(path, global_end)
 	return path
 
-
-# Helper function: Avoid straight paths and prefer neighbors
-func adjust_for_diagonal(next_position: Vector2, current: Vector2, path: Array) -> Vector2:
+# Adjust path to avoid straight lines and prefer organic movement
+func _adjust_path_for_organic_movement(next_position: Vector2, current: Vector2, path: Array) -> Vector2:
 	if is_diagonal(current, next_position):
 		if randi() % 2 == 0:
-			append_unique(path, current + Vector2(0, next_position.y - current.y))
+			_append_unique(path, current + Vector2(0, next_position.y - current.y))
 		else:
-			append_unique(path, current + Vector2(next_position.x - current.x, 0))
+			_append_unique(path, current + Vector2(next_position.x - current.x, 0))
 	return next_position
 
-
-# Helper function: Append only if the position is not already in the array
-func append_unique(path: Array, position: Vector2):
+# Append a position to the path only if it's unique
+func _append_unique(path: Array, position: Vector2) -> void:
 	if not path.has(position):
 		path.append(position)
 


### PR DESCRIPTION
Fixes #604 

The issue was limited to roads between overmapgrids, but it was still an issue. This pr implements code that keeps track of the positions of tacticalmaps and excludes those positions when placing roads. It's still not perfect, since now roads are interrupted by tacticalmaps, but it's better then what we had.