### PR TITLE
fix Grid loading

### DIFF
--- a/Scripts/FurnitureStaticSrv.gd
+++ b/Scripts/FurnitureStaticSrv.gd
@@ -686,7 +686,6 @@ class Consumption:
 		
 		# Check if the parent furniture has a container
 		if not parent_furniture.container:
-			print("No container found in the furniture.")
 			return
 		
 		# Get the container inventory

--- a/Scripts/Helper.gd
+++ b/Scripts/Helper.gd
@@ -84,9 +84,8 @@ func save_and_exit_game():
 	exit_game()
 
 
-#Level_name is a filename in /mods/core/maps
-#global_pos is the absolute position on the overmap
-#see overmap.gd for how global_pos is used there
+# Changes the scene to "level_generation", which is the main game
+# chunk_navigation_maps holds the navigation maps for the mobs until issue #438 is fixed
 func initiate_game() -> void:
 	chunk_navigation_maps.clear()
 	get_tree().change_scene_to_file.bind("res://level_generation.tscn").call_deferred()

--- a/Scripts/Helper/overmap_manager.gd
+++ b/Scripts/Helper/overmap_manager.gd
@@ -142,7 +142,6 @@ func _on_game_loaded():
 
 # Function for handling game ended signal
 func _on_game_ended():
-	save_all_grids()
 	player = null
 
 

--- a/Scripts/Helper/save_helper.gd
+++ b/Scripts/Helper/save_helper.gd
@@ -101,6 +101,7 @@ func get_saved_map_folder(level_pos: Vector2) -> String:
 func save_game():
 	save_map_data()
 	Helper.overmap_manager.save_all_segments()
+	Helper.overmap_manager.save_all_grids()
 	save_player_inventory()
 	save_player_equipment()
 	save_quest_state()

--- a/Scripts/crafting_recipes_manager.gd
+++ b/Scripts/crafting_recipes_manager.gd
@@ -9,6 +9,7 @@ var craftable_items: Array[RItem]
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	Helper.signal_broker.game_started.connect(get_crafting_recipes_from_json)
+	Helper.signal_broker.game_loaded.connect(get_crafting_recipes_from_json)
 
 func get_crafting_recipes_from_json() -> void:
 	craftable_items = Runtimedata.items.get_hand_craftable_items()


### PR DESCRIPTION
Fixes #656 

The overmap grids were only saved when the game ends properly, when returning to the main menu

I changed it so the grids are saved every time the game is saved, including at the start of the game.