### PR TITLE
Apply area rotation

### DIFF
--- a/Mods/Dimensionfall/Maps/scrap_yard.json
+++ b/Mods/Dimensionfall/Maps/scrap_yard.json
@@ -136,6 +136,40 @@
 					"id": "null"
 				}
 			]
+		},
+		{
+			"entities": [
+				{
+					"count": 1,
+					"id": "car_00",
+					"type": "furniture"
+				},
+				{
+					"count": 1,
+					"id": "car_01",
+					"type": "furniture"
+				},
+				{
+					"count": 1,
+					"id": "truck_wreck_01",
+					"type": "furniture"
+				},
+				{
+					"count": 1,
+					"id": "tanker_wreck_01",
+					"type": "furniture"
+				}
+			],
+			"id": "cars",
+			"pick_one": false,
+			"rotate_random": false,
+			"spawn_chance": 100,
+			"tiles": [
+				{
+					"count": 1,
+					"id": "null"
+				}
+			]
 		}
 	],
 	"categories": [
@@ -3088,6 +3122,10 @@
 					{
 						"id": "concrete_floor",
 						"rotation": 0
+					},
+					{
+						"id": "cars",
+						"rotation": 90
 					}
 				],
 				"id": "concrete_00",
@@ -3100,11 +3138,6 @@
 						"rotation": 0
 					}
 				],
-				"furniture": {
-					"id": "car_00",
-					"itemgroups": [],
-					"rotation": 90
-				},
 				"id": "concrete_00",
 				"rotation": 270
 			},
@@ -4295,13 +4328,12 @@
 					{
 						"id": "concrete_floor",
 						"rotation": 0
+					},
+					{
+						"id": "cars",
+						"rotation": 90
 					}
 				],
-				"furniture": {
-					"id": "truck_wreck_01",
-					"itemgroups": [],
-					"rotation": 90
-				},
 				"id": "concrete_00",
 				"rotation": 90
 			},
@@ -5517,6 +5549,10 @@
 					{
 						"id": "concrete_floor",
 						"rotation": 0
+					},
+					{
+						"id": "cars",
+						"rotation": 90
 					}
 				],
 				"id": "concrete__cracked_debris_01",
@@ -5529,11 +5565,6 @@
 						"rotation": 0
 					}
 				],
-				"furniture": {
-					"id": "tanker_wreck_01",
-					"itemgroups": [],
-					"rotation": 90
-				},
 				"id": "concrete_00"
 			},
 			{
@@ -6702,6 +6733,10 @@
 					{
 						"id": "concrete_floor",
 						"rotation": 0
+					},
+					{
+						"id": "cars",
+						"rotation": 90
 					}
 				],
 				"id": "concrete__cracked_02",
@@ -6714,11 +6749,6 @@
 						"rotation": 0
 					}
 				],
-				"furniture": {
-					"id": "car_01",
-					"itemgroups": [],
-					"rotation": 90
-				},
 				"id": "concrete_00"
 			},
 			{
@@ -7225,11 +7255,6 @@
 						"rotation": 0
 					}
 				],
-				"furniture": {
-					"id": "tanker_wreck_01",
-					"itemgroups": [],
-					"rotation": 270
-				},
 				"id": "concrete__cracked_01",
 				"rotation": 180
 			},
@@ -7238,6 +7263,10 @@
 					{
 						"id": "concrete_floor",
 						"rotation": 0
+					},
+					{
+						"id": "cars",
+						"rotation": 270
 					}
 				],
 				"id": "concrete__cracked_02",
@@ -7841,6 +7870,10 @@
 					{
 						"id": "concrete_floor",
 						"rotation": 0
+					},
+					{
+						"id": "cars",
+						"rotation": 90
 					}
 				],
 				"id": "concrete_00",
@@ -7853,11 +7886,6 @@
 						"rotation": 0
 					}
 				],
-				"furniture": {
-					"id": "car_00",
-					"itemgroups": [],
-					"rotation": 90
-				},
 				"id": "concrete_00",
 				"rotation": 90
 			},
@@ -9050,6 +9078,10 @@
 					{
 						"id": "concrete_floor",
 						"rotation": 0
+					},
+					{
+						"id": "cars",
+						"rotation": 90
 					}
 				],
 				"id": "concrete_00",
@@ -9062,11 +9094,6 @@
 						"rotation": 0
 					}
 				],
-				"furniture": {
-					"id": "tanker_wreck_01",
-					"itemgroups": [],
-					"rotation": 90
-				},
 				"id": "concrete__cracked_02",
 				"rotation": 180
 			},
@@ -10049,6 +10076,10 @@
 					{
 						"id": "concrete_floor",
 						"rotation": 0
+					},
+					{
+						"id": "cars",
+						"rotation": 180
 					}
 				],
 				"id": "concrete_00"
@@ -10201,6 +10232,10 @@
 					{
 						"id": "concrete_floor",
 						"rotation": 0
+					},
+					{
+						"id": "cars",
+						"rotation": 180
 					}
 				],
 				"id": "concrete_00"
@@ -10418,11 +10453,6 @@
 						"rotation": 0
 					}
 				],
-				"furniture": {
-					"id": "car_00",
-					"itemgroups": [],
-					"rotation": 180
-				},
 				"id": "concrete__cracked_01",
 				"rotation": 270
 			},
@@ -10573,11 +10603,6 @@
 						"rotation": 0
 					}
 				],
-				"furniture": {
-					"id": "car_01",
-					"itemgroups": [],
-					"rotation": 180
-				},
 				"id": "concrete_00"
 			},
 			{
@@ -10616,11 +10641,6 @@
 						"rotation": 0
 					}
 				],
-				"furniture": {
-					"id": "truck_wreck_01",
-					"itemgroups": [],
-					"rotation": 90
-				},
 				"id": "concrete_00",
 				"rotation": 180
 			},

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditortile.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditortile.gd
@@ -110,15 +110,18 @@ func set_tooltip(tileData: Dictionary) -> void:
 		tooltiptext += "Tile Item areas: " + str(tileData.itemgroups) + "\n"
 	else:
 		tooltiptext += "Tile Item areas: None\n"
-	
+
 	# Display areas information
 	if tileData.has("areas"):
 		tooltiptext += "Tile areas: "
 		for area in tileData.areas:
-			tooltiptext += area.id + ", "
+			var rotation_text = " (" + str(area.get("rotation", 0)) + ")"  # Get rotation or default to 0
+			tooltiptext += area.id + rotation_text + ", "
+		tooltiptext = tooltiptext.rstrip(", ")  # Remove the last comma and space
 		tooltiptext += "\n"
 	else:
 		tooltiptext += "Tile areas: None\n"
+
 	
 	# Set the tooltip
 	self.tooltip_text = tooltiptext

--- a/Scripts/OvermapGrid.gd
+++ b/Scripts/OvermapGrid.gd
@@ -619,7 +619,7 @@ func generate_cells() -> void:
 			# If you need to test a specific map, uncomment these two lines and put in your map name.
 			# It will spawn the map at position (0,0), where the player starts
 			#if global_x == 0 and global_y == 0:
-				#cell.map_id = "survivor_gas_station"
+				#cell.map_id = "scrap_yard"
 
 			# Add the cell to the grid's cells dictionary
 			cells[cell_key] = cell


### PR DESCRIPTION
Fixes #663 

The purpose of area rotation is that when you paint an area with a certain rotation (e.g. 90), the area is applied to that tile with the painted rotation. This pr includes an example of that, where cars are spawned at selected locations with a certain rotation.