### PR TITLE
Quest step can update quest description

### DIFF
--- a/Scenes/ContentManager/Custom_Editors/QuestEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/QuestEditor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://b7k2j4d6wx4yy"]
+[gd_scene load_steps=8 format=3 uid="uid://b7k2j4d6wx4yy"]
 
 [ext_resource type="Script" path="res://Scenes/ContentManager/Custom_Editors/Scripts/QuestEditor.gd" id="1_4a2kk"]
 [ext_resource type="PackedScene" uid="uid://dsax7il2yggw8" path="res://Scenes/ContentManager/Custom_Widgets/DropEnabledTextEdit.tscn" id="2_w4cgs"]
@@ -18,7 +18,15 @@ content_margin_right = 8.0
 content_margin_bottom = 8.0
 bg_color = Color(0.671296, 0.576576, 0.548227, 1)
 
-[node name="QuestEditor" type="Control" node_paths=PackedStringArray("questImageDisplay", "IDTextLabel", "PathTextLabel", "NameTextEdit", "DescriptionTextEdit", "questSelector", "step_type_option_button", "steps_container", "rewards_item_list")]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_fhs5k"]
+bg_color = Color(0.239866, 0.290419, 0.348841, 1)
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+border_color = Color(0.120738, 0.170336, 0.226543, 1)
+
+[node name="QuestEditor" type="Control" node_paths=PackedStringArray("questImageDisplay", "IDTextLabel", "PathTextLabel", "NameTextEdit", "DescriptionTextEdit", "questSelector", "step_type_option_button", "steps_container", "rewards_item_list", "step_properties_popup_panel", "hint_text_edit", "description_text_edit", "ok_button", "cancel_button")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -36,6 +44,11 @@ step_type_option_button = NodePath("VBoxContainer/FormGrid/StepControlsHBoxConta
 steps_container = NodePath("VBoxContainer/FormGrid/ScrollContainer/StepsPanelContainer/StepsVBoxContainer")
 rewards_item_list = NodePath("VBoxContainer/FormGrid/ScrollContainer2/RewardsPanelContainer/RewardsItemList")
 dropabletextedit = ExtResource("2_w4cgs")
+step_properties_popup_panel = NodePath("StepPropertiesPopupPanel")
+hint_text_edit = NodePath("StepPropertiesPopupPanel/StepPropertiesVBoxContainer/HintTextEdit")
+description_text_edit = NodePath("StepPropertiesPopupPanel/StepPropertiesVBoxContainer/DescriptionTextEdit")
+ok_button = NodePath("StepPropertiesPopupPanel/StepPropertiesVBoxContainer/ControlsHBoxContainer/OkButton")
+cancel_button = NodePath("StepPropertiesPopupPanel/StepPropertiesVBoxContainer/ControlsHBoxContainer/CancelButton")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 1
@@ -207,6 +220,54 @@ columns = 3
 
 [node name="Sprite_selector" parent="." instance=ExtResource("3_2twbp")]
 visible = false
+
+[node name="StepPropertiesPopupPanel" type="PopupPanel" parent="."]
+initial_position = 1
+size = Vector2i(800, 261)
+theme_override_styles/panel = SubResource("StyleBoxFlat_fhs5k")
+
+[node name="StepPropertiesVBoxContainer" type="VBoxContainer" parent="StepPropertiesPopupPanel"]
+anchors_preset = -1
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 4.0
+offset_top = 4.0
+offset_right = -4.0
+offset_bottom = -4.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="HintLabel" type="Label" parent="StepPropertiesPopupPanel/StepPropertiesVBoxContainer"]
+layout_mode = 2
+text = "Hint (optional): Shows the entered text in the quest window in-game next to the step."
+
+[node name="HintTextEdit" type="TextEdit" parent="StepPropertiesPopupPanel/StepPropertiesVBoxContainer"]
+custom_minimum_size = Vector2(0, 32)
+layout_mode = 2
+placeholder_text = "Open the craft menu (c) to start crafting"
+
+[node name="DescriptionLabel" type="Label" parent="StepPropertiesPopupPanel/StepPropertiesVBoxContainer"]
+layout_mode = 2
+text = "Description (optional): Replaces the quest's description with the entered text once this step is reached."
+
+[node name="DescriptionTextEdit" type="TextEdit" parent="StepPropertiesPopupPanel/StepPropertiesVBoxContainer"]
+custom_minimum_size = Vector2(0, 128)
+layout_mode = 2
+placeholder_text = "Once you reached the location, you realized the truth..."
+
+[node name="ControlsHBoxContainer" type="HBoxContainer" parent="StepPropertiesPopupPanel/StepPropertiesVBoxContainer"]
+layout_mode = 2
+alignment = 1
+
+[node name="OkButton" type="Button" parent="StepPropertiesPopupPanel/StepPropertiesVBoxContainer/ControlsHBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Ok"
+
+[node name="CancelButton" type="Button" parent="StepPropertiesPopupPanel/StepPropertiesVBoxContainer/ControlsHBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Cancel"
 
 [connection signal="button_up" from="VBoxContainer/HBoxContainer/CloseButton" to="." method="_on_close_button_button_up"]
 [connection signal="button_up" from="VBoxContainer/HBoxContainer/SaveButton" to="." method="_on_save_button_button_up"]

--- a/Scenes/ContentManager/Custom_Editors/QuestEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/QuestEditor.tscn
@@ -223,7 +223,7 @@ visible = false
 
 [node name="StepPropertiesPopupPanel" type="PopupPanel" parent="."]
 initial_position = 1
-size = Vector2i(800, 261)
+size = Vector2i(800, 277)
 theme_override_styles/panel = SubResource("StyleBoxFlat_fhs5k")
 
 [node name="StepPropertiesVBoxContainer" type="VBoxContainer" parent="StepPropertiesPopupPanel"]
@@ -242,7 +242,7 @@ layout_mode = 2
 text = "Hint (optional): Shows the entered text in the quest window in-game next to the step."
 
 [node name="HintTextEdit" type="TextEdit" parent="StepPropertiesPopupPanel/StepPropertiesVBoxContainer"]
-custom_minimum_size = Vector2(0, 32)
+custom_minimum_size = Vector2(0, 48)
 layout_mode = 2
 placeholder_text = "Open the craft menu (c) to start crafting"
 

--- a/Scenes/ContentManager/Custom_Editors/Scripts/QuestEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/QuestEditor.gd
@@ -128,10 +128,14 @@ func _on_save_button_button_up() -> void:
 			var map_guide_option_button: OptionButton = hbox.get_child(3)
 			step["map_guide"] = map_guide_option_button.get_item_text(map_guide_option_button.selected)
 
-		# **Retrieve tip from metadata**
+		# **Retrieve tip and description from metadata**
 		var step_tip = hbox.get_meta("tip", "")
 		if step_tip != "":
-			step["tip"] = step_tip  # Only add tip if it is not empty
+			step["tip"] = step_tip  # Only add tip if it's not empty
+
+		var step_description = hbox.get_meta("description", "")
+		if step_description != "":
+			step["description"] = step_description  # Only add description if it's not empty
 
 		dquest.steps.append(step)
 
@@ -155,6 +159,7 @@ func _on_save_button_button_up() -> void:
 	dquest.changed(olddata)
 	data_changed.emit()
 	olddata = DQuest.new(dquest.get_data().duplicate(true), null)
+
 
 
 
@@ -382,9 +387,11 @@ func add_step_from_data(step: Dictionary):
 			hbox = add_kill_step(step)
 	add_step_controls(hbox, step)
 
-	# **Store step tip in metadata**
+	# **Store tip and description in metadata**
 	if step.has("tip"):
 		hbox.set_meta("tip", step["tip"])  # Save tip to metadata
+	if step.has("description"):
+		hbox.set_meta("description", step["description"])  # Save description to metadata
 
 	steps_container.add_child(hbox)
 
@@ -594,14 +601,17 @@ func create_map_guide_option_button() -> OptionButton:
 # Function to open the step properties popup
 func _on_settings_button_pressed(hbox: HBoxContainer):
 	selected_step = hbox  # Store the reference to the step being edited
-	hint_text_edit.text = selected_step.get_meta("tip", "")  # Load existing tip from metadata
+	hint_text_edit.text = selected_step.get_meta("tip", "")  # Load tip from metadata
+	description_text_edit.text = selected_step.get_meta("description", "")  # Load description from metadata
 	step_properties_popup_panel.popup_centered()
 
 # Function to handle OK button press
 func _on_ok_button_pressed():
 	if selected_step:
 		selected_step.set_meta("tip", hint_text_edit.text)  # Store tip in metadata
+		selected_step.set_meta("description", description_text_edit.text)  # Store description in metadata
 	step_properties_popup_panel.hide()
+
 
 # Function to handle Cancel button press
 func _on_cancel_button_pressed():

--- a/Scenes/ContentManager/Custom_Editors/Scripts/QuestEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/QuestEditor.gd
@@ -351,7 +351,7 @@ func add_step_controls(hbox: HBoxContainer, step: Dictionary):
 	var settings_button = Button.new()
 	settings_button.text = "⚙️"  # Use a cog emoji as the button text
 	settings_button.tooltip_text = "Edit step properties"
-	settings_button.pressed.connect(_on_settings_button_pressed)
+	settings_button.pressed.connect(_on_settings_button_pressed.bind(hbox))
 	hbox.add_child(settings_button)
 
 	var move_up_button = Button.new()

--- a/Scripts/Gamedata/DQuest.gd
+++ b/Scripts/Gamedata/DQuest.gd
@@ -19,6 +19,7 @@ extends RefCounted
 #				"amount": 1,
 #				"item": "long_stick",
 #				"tip": "You can find one in the forest",
+#				"description": "This stick will help figure out the truth!", # updates the quest description
 #				"type": "collect"
 #			}
 #			{

--- a/Scripts/Helper/quest_helper.gd
+++ b/Scripts/Helper/quest_helper.gd
@@ -127,11 +127,19 @@ func _on_step_complete(step: Dictionary):
 # step: the new step in the quest
 func _on_next_step(step: Dictionary):
 	check_and_emit_target_map(step)
-	# The player might already have the item for the next step so check it
+
+	# Extract step metadata (stepjson)
+	var stepmeta: Dictionary = step.get("meta_data", {}).get("stepjson", {})
+
+	# If the step has a "description", update the quest description
+	if stepmeta.has("description"):
+		var quest = QuestManager.get_quest(tracked_quest)
+		if quest:
+			quest.set_quest_details(stepmeta["description"])
+
+	# The player might already have the item for the next step, so check it
 	match step.get("step_type", ""):	
-		QuestManager.INCREMENTAL_STEP:
-			update_quest_by_inventory(null)
-		QuestManager.ITEMS_STEP:
+		QuestManager.INCREMENTAL_STEP, QuestManager.ITEMS_STEP:
 			update_quest_by_inventory(null)
 
 
@@ -178,6 +186,14 @@ func create_quest_from_data(quest_data: RQuest):
 
 
 # Add a quest step to the quest. In this case, the step is just a dictionary with some data
+# Example step dictionary:
+#			{
+#				"amount": 1,
+#				"item": "long_stick",
+#				"tip": "You can find one in the forest",
+#				"description": "This stick will help figure out the truth!", # updates the quest description
+#				"type": "collect"
+#			}
 func add_quest_step(quest: ScriptQuest, step: Dictionary) -> bool:
 	match step.type:
 		"collect":

--- a/Scripts/QuestWindow.gd
+++ b/Scripts/QuestWindow.gd
@@ -169,7 +169,7 @@ func _update_quest_details():
 	
 	# Update quest title and description
 	quest_details_section.get_node("QuestTitle").text = rquest.name
-	quest_details_section.get_node("QuestDescription").text = rquest.description
+	quest_details_section.get_node("QuestDescription").text = quest.quest_details
 	
 	# Update rewards details
 	update_rewards_details(quest)

--- a/Scripts/Runtimedata/RQuest.gd
+++ b/Scripts/Runtimedata/RQuest.gd
@@ -20,6 +20,7 @@ extends RefCounted
 #             "amount": 1,
 #             "item": "long_stick",
 #             "tip": "You can find one in the forest",
+#             "description": "This stick will help figure out the truth!", # updates the quest description
 #             "type": "collect"
 #         }
 #     ]


### PR DESCRIPTION
As per the suggestion in discord, steps inside a quest can now update the quest's description. 

The description updates when the step is reached. Any step can update the description. Currently, no quest makes use of this functionality but anyone can tinker with it. 

Also moves the "tip" text field to a popup that shows more options for the step.

The first step in the quest does not update the quest description, even if one is set for that step. This is not a problem because the general quest description will show and there is no point overriding that on the first step.