### PR TITLE
Add container unit test

### DIFF
--- a/Scripts/container.gd
+++ b/Scripts/container.gd
@@ -25,6 +25,13 @@ func _ready():
 
 # Called when a function creates this class using ContainerItem.new(container_json)
 # Basic setup for this container. Should be called before adding it to the scene tree
+# Example item:
+# {
+# 	"itemgroups": ["destroyed_furniture_medium"],
+# 	"global_position_x": 2,
+# 	"global_position_y": 1,
+# 	"global_position_z": 17
+# }
 func _init(item: Dictionary):
 	_initialize_container(item)
 	create_loot()

--- a/Scripts/runtimedata.gd
+++ b/Scripts/runtimedata.gd
@@ -64,3 +64,6 @@ func reconstruct() -> void:
 		DMod.ContentType.ITEMS: items,
 		DMod.ContentType.MOBFACTIONS: mobfactions
 	}
+
+func reset() -> void:
+	gamedata_map.clear()

--- a/Tests/Unit/test_container.gd
+++ b/Tests/Unit/test_container.gd
@@ -1,0 +1,45 @@
+extends GutTest
+
+var test_container: ContainerItem
+	
+# Runs before each test.
+func before_all():
+	Runtimedata.reconstruct() # Load all mod data in the proper way
+	await get_tree().process_frame 
+
+func before_each():
+	test_container = ContainerItem.new({
+		"global_position_x": 1,
+		"global_position_y": 1,
+		"global_position_z": 1,
+		"itemgroups": ["starting_items"]
+	})
+	add_child(test_container)
+	await get_tree().process_frame
+
+func after_each():
+	if test_container:
+		test_container.queue_free()
+
+func after_all():
+	Runtimedata.reset()
+	
+#Function tests for the presence of a container
+func test_container_is_there()->void:
+	var containers: Array = get_tree().get_nodes_in_group("Containers") 
+	assert_eq(containers.size(),1,"too many or not enough containers")
+
+# Tests that the provided position is correctly set to the variables
+func test_container_position()->void:
+	assert_eq(test_container.containerpos,Vector3(1,1,1),"containerpos differs from initial value")
+	assert_eq(test_container.position,Vector3(1,1,1),"position differs from initial value")
+
+# Tests that the inventory is properly created
+func test_container_has_inventory()->void:
+	assert_not_null(test_container.inventory, "No inventory present")
+
+# Tests that the item that is inserted is actually added to the container inventory.
+func test_add_item():
+	test_container.add_item("long_stick")
+	await get_tree().process_frame
+	assert_eq(test_container.inventory.has_item_by_id("long_stick"), true, "Failed to add item to container")


### PR DESCRIPTION
Builds upon Diamond-Dan's work in #675 

Adds a test for ContainerItem class. It's still very basic since I haven't tested before.

I am wondering about the dependency of Runtimedata. Should the ContainerItem class still work if there is no Runtimedata? I am not sure I think that doing any test without it will complicate the class more then needed. For example, you'd need additional functions to construct a new RItemgroup on the fly. I decided to reconstruct the Runtimedata before running the tests.

It's probably a good idea to re-introduce the test mod and when we test, we disable the Dimensionfall mod and enable the test mod. This way, our tests will be more reliable and also faster as long as the test mod has less content then Dimensionfall.