### PR TITLE
Road roation fix

### DIFF
--- a/Scripts/Helper/map_manager.gd
+++ b/Scripts/Helper/map_manager.gd
@@ -41,7 +41,6 @@ func spawn_item_at_current_player_map(item_id: String, quantity: int) -> bool:
 	
 	# Attempt to spawn the item on an empty tile
 	return chunk.spawn_item_at_free_position(item_id,quantity,current_player_y)
-	return false
 
 # Takes an mob_id (of an RMob) and spawns it onto
 # the map that is indicated by the coordinates.
@@ -55,18 +54,18 @@ func spawn_mob_at_nearby_map(mob_id: String, coordinates: Vector2) -> bool:
 	
 	# Attempt to spawn the item on an empty tile
 	return chunk.spawn_mob_at_free_position(mob_id, current_player_y)
-	return false
 	
 
 # Function to process area data and assign to tile
-func process_area_data(area_data: Dictionary, original_tile_id: String, picked_tile: Dictionary = {}) -> Dictionary:
+# Example original_tile: {"id":"road_asphalt_basic","areas":[{"id":"cars","rotation":270}]}
+func process_area_data(area_data: Dictionary, original_tile: Dictionary, picked_tile: Dictionary = {}) -> Dictionary:
 	var result = {}
 
 	# Process and assign tile ID, allowing for an external picked_tile to be passed in
-	_process_tile_id(area_data, original_tile_id, result, picked_tile)
+	_process_tile_id(area_data, original_tile, result, picked_tile)
 
 	# Process entities data and add them to result
-	_process_entities_data(area_data, result)
+	_process_entities_data(area_data, result, original_tile)
 
 	return result
 
@@ -78,13 +77,16 @@ func _get_random_rotation(area_data: Dictionary) -> int:
 
 
 # Function to process and assign tile ID
-func _process_tile_id(area_data: Dictionary, original_tile_id: String, result: Dictionary, picked_tile: Dictionary = {}) -> void:
+func _process_tile_id(area_data: Dictionary, original_tile: Dictionary, result: Dictionary, picked_tile: Dictionary = {}) -> void:
 	var tiles_data = area_data.get("tiles", [])
+	var tile_area: Dictionary = original_tile.get("areas",[]).filter(func(area): 
+		return area.get("id","") == area_data.get("id","")
+	)[0] # Might result in {"id":"cars","rotation":270}
 
-	# Determine rotation using the new logic
-	var rotation = _get_random_rotation(area_data)
-	if rotation == -1:
-		rotation = area_data.get("rotation", 0)  # Use area-defined rotation if no random rotation is applied
+	# We get a random rotation if that's set as a property in the area data.
+	# Otherwise, randomrotation will be -1, so not random, defaulting to 0
+	var randomrotation = _get_random_rotation(area_data)
+	var rotation = randomrotation if randomrotation > -1 else tile_area.get("rotation", 0)
 
 	# Check if pick_one is set to true and a tile has already been picked for this cluster
 	if picked_tile and not picked_tile.is_empty() and not picked_tile["id"] == "null":
@@ -92,6 +94,7 @@ func _process_tile_id(area_data: Dictionary, original_tile_id: String, result: D
 		result["rotation"] = rotation
 		return  # Exit the function since the tile has been set
 
+	var original_tile_id = original_tile.get("id","")
 	# If no tile has been picked or pick_one is false, pick a new tile
 	if not tiles_data.is_empty():
 		var new_picked_tile = pick_item_based_on_count(tiles_data)
@@ -105,7 +108,7 @@ func _process_tile_id(area_data: Dictionary, original_tile_id: String, result: D
 
 
 # Function to process entities data and add them to result
-func _process_entities_data(area_data: Dictionary, result: Dictionary) -> void:
+func _process_entities_data(area_data: Dictionary, result: Dictionary, original_tile: Dictionary) -> void:
 	# Calculate the total count of tiles
 	var tiles_data = area_data.get("tiles", [])
 	var total_tiles_count: int = calculate_total_count(tiles_data)
@@ -120,13 +123,18 @@ func _process_entities_data(area_data: Dictionary, result: Dictionary) -> void:
 	# This results in the tree being picked every 1 in 100 tiles.
 	entities_data.append({"id": "None", "type": "None", "count": total_tiles_count})
 
+
+	var tile_area: Dictionary = original_tile.get("areas",[]).filter(func(area): 
+		return area.get("id","") == area_data.get("id","")
+	)[0]# Might result in {"id":"cars","rotation":270}
+	
 	# Pick an entity from the duplicated entities_data
 	if not entities_data.is_empty():
 		var selected_entity = pick_item_based_on_count(entities_data)
 		if selected_entity["type"] != "None":
 			var rotation = _get_random_rotation(area_data)
 			if rotation == -1:
-				rotation = area_data.get("rotation", 0)
+				rotation = tile_area.get("rotation", 0)
 
 			match selected_entity["type"]:
 				"furniture":
@@ -363,22 +371,9 @@ func apply_area_clusters_to_tiles(level: Array, area_id: String, mapData: Dictio
 			picked_tile = pick_item_based_on_count(area_data["tiles"])
 
 		# Loop through each tile in the cluster
-		for tile in cluster:
-			var original_tile_id = tile.get("id", "")
-			var processed_data = process_area_data(area_data, original_tile_id, picked_tile)
-
-			# Step 1: Get a random rotation first
-			var tile_rotation = _get_random_rotation(area_data)
-
-			# Step 2: If random rotation is -1, get rotation from the tile's area data
-			if tile_rotation == -1 and tile.has("areas"):
-				for area in tile["areas"]:
-					if area.get("id") == area_id:
-						tile_rotation = area.get("rotation", 0)  # Get rotation from the area inside tile
-						break
-
-			# Apply rotation to the processed data
-			processed_data["rotation"] = tile_rotation if tile_rotation > -1 else 0
+		# Example tile: {"id":"road_asphalt_basic","areas":[{"id":"cars","rotation":270}]}
+		for tile: Dictionary in cluster:
+			var processed_data = process_area_data(area_data, tile, picked_tile)
 
 			# Remove existing entities if new entities are present in processed data
 			var entities_to_check = ["mob", "furniture", "mobgroup", "itemgroups"]
@@ -391,11 +386,7 @@ func apply_area_clusters_to_tiles(level: Array, area_id: String, mapData: Dictio
 
 			# Apply the processed data to the tile
 			for key in processed_data.keys():
-				if key in ["mob", "furniture", "mobgroup"]:
-					# If key is an entity, also apply rotation
-					tile[key] = {"id": processed_data[key]["id"], "rotation": tile_rotation}
-				else:
-					tile[key] = processed_data[key]
+				tile[key] = processed_data[key]
 
 
 # Modify the existing function to integrate clusters when applying areas to tiles

--- a/Scripts/Helper/map_manager.gd
+++ b/Scripts/Helper/map_manager.gd
@@ -58,6 +58,7 @@ func spawn_mob_at_nearby_map(mob_id: String, coordinates: Vector2) -> bool:
 
 # Function to process area data and assign to tile
 # Example original_tile: {"id":"road_asphalt_basic","areas":[{"id":"cars","rotation":270}]}
+# Example picked_tile: {"id": "forest_underbrush_04", "count": 100}
 func process_area_data(area_data: Dictionary, original_tile: Dictionary, picked_tile: Dictionary = {}) -> Dictionary:
 	var result = {}
 
@@ -159,14 +160,20 @@ func _process_entities_data(area_data: Dictionary, result: Dictionary, original_
 
 
 # Function to pick an item based on its count property
-func pick_item_based_on_count(items: Array) -> Dictionary:
-	var total_count: int = calculate_total_count(items)
+# Example tiles array:
+#        "tiles": [
+#            {"id": "forest_underbrush_03", "count": 100},
+#            {"id": "forest_underbrush_04", "count": 100},
+#            {"id": "dirt_light_00", "count": 2},
+#            {"id": "grass_medium_dirt_00", "count": 2}
+#        ]
+func pick_item_based_on_count(tiles: Array) -> Dictionary:
+	var total_count: int = calculate_total_count(tiles)
 	var random_pick: int = randi() % total_count
-	for item in items:
-		if random_pick < item["count"]:
-			return item
-		random_pick -= item["count"]
-
+	for tile: Dictionary in tiles:
+		if random_pick < tile["count"]:
+			return tile
+		random_pick -= tile["count"]
 	return {}  # In case no item is selected, though this should not happen if the input is valid
 
 
@@ -383,6 +390,7 @@ func apply_area_clusters_to_tiles(level: Array, area_id: String, mapData: Dictio
 
 		# Loop through each tile in the cluster
 		# Example tile: {"id":"road_asphalt_basic","areas":[{"id":"cars","rotation":270}]}
+		# Example picked_tile: {"id": "forest_underbrush_04", "count": 100}
 		for tile: Dictionary in cluster:
 			var processed_data = process_area_data(area_data, tile, picked_tile)
 

--- a/Scripts/OvermapGrid.gd
+++ b/Scripts/OvermapGrid.gd
@@ -619,7 +619,7 @@ func generate_cells() -> void:
 			# If you need to test a specific map, uncomment these two lines and put in your map name.
 			# It will spawn the map at position (0,0), where the player starts
 			#if global_x == 0 and global_y == 0:
-				#cell.map_id = "scrap_yard"
+				#cell.map_id = "urbanroad"
 
 			# Add the cell to the grid's cells dictionary
 			cells[cell_key] = cell

--- a/Tests/Unit/test_map_manager.gd
+++ b/Tests/Unit/test_map_manager.gd
@@ -1,0 +1,131 @@
+extends GutTest
+
+# This script is meant to test Helper.map_manager
+# We test the functions from that helper script to improve reliability
+
+var map_manager: Node
+
+# Runs before each test.
+func before_all():
+	var custom_mods: Array[DMod] = [Gamedata.mods.by_id("Core"), Gamedata.mods.by_id("Test")]
+	Runtimedata.reconstruct(custom_mods)
+	map_manager = Helper.map_manager
+	await get_tree().process_frame 
+
+func before_each():
+	await get_tree().process_frame
+
+func after_each():
+	await get_tree().process_frame
+
+func after_all():
+	Runtimedata.reset()
+
+
+func test_get_tile_area_rotation_with_rotation():
+	var tile = {"areas": [{"id": "test_area", "rotation": 90}]}
+	var area_data = {"id": "test_area"}
+	assert_eq(map_manager.get_tile_area_rotation(tile, area_data), 90, "Expected rotation 90")
+
+func test_get_tile_area_rotation_no_match():
+	var tile = {"areas": [{"id": "other_area", "rotation": 45}]}
+	var area_data = {"id": "test_area"}
+	assert_eq(map_manager.get_tile_area_rotation(tile, area_data), 0, "Expected rotation 0 for non-matching area")
+
+func test_get_tile_area_rotation_no_rotation():
+	var tile = {"areas": [{"id": "test_area"}]}
+	var area_data = {"id": "test_area"}
+	assert_eq(map_manager.get_tile_area_rotation(tile, area_data), 0, "Expected rotation 0 for missing rotation")
+
+func test_pick_item_based_on_count():
+	var items = [{"id": "item1", "count": 1}, {"id": "item2", "count": 3}]
+	var picked = map_manager.pick_item_based_on_count(items)
+	assert_not_null(picked, "Expected an item to be picked")
+	assert_true(["item1", "item2"].has(picked["id"]), "Picked unknown item")
+
+func test_calculate_total_count():
+	var items = [{"id": "item1", "count": 1}, {"id": "item2", "count": 3}]
+	assert_eq(map_manager.calculate_total_count(items), 4, "Expected total count 4")
+
+
+# Test both cases that are possible for the _get_random_rotation function
+# Area data has been simplified to only id and rotate_random but usually contains more
+func test_get_random_rotation():
+	var area_random_data: Dictionary = {"id": "tree_layer","rotate_random": true}
+	assert_true([0, 90, 180, 270].has(map_manager._get_random_rotation(area_random_data)), "Picked unknown rotation")
+	var area_data: Dictionary = {"id": "tree_layer","rotate_random": false}
+	assert_eq(map_manager._get_random_rotation(area_data), -1, "Expected -1")
+
+
+# Test processing of a tile based on the provided area and map data
+func test_process_tile_id():
+	var area_data: Dictionary = { # The area that will be applied to this map tile
+		"id": "ground_layer",
+		"rotate_random": true,
+		"spawn_chance": 100,
+		"entities": [],
+		"tiles": [
+			{"id": "forest_underbrush_03", "count": 100},
+			{"id": "forest_underbrush_04", "count": 100},
+			{"id": "forest_underbrush_05", "count": 100},
+			{"id": "dirt_light_00", "count": 2},
+			{"id": "grass_medium_dirt_00", "count": 2}
+		]
+	}
+	var original_tile: Dictionary = { # The tile as it was painted onto the map
+		"id":"grass_medium_00",
+		"areas":[{"id":"ground_layer","rotation":270}]
+	}
+	var result = {}
+	# Since the area does not have "pick_one" set to true, we don't pick a tile ahead of time
+	var picked_tile: Dictionary = {}
+	map_manager._process_tile_id(area_data, original_tile, result, picked_tile)
+	var result_id: String = result.get("id","")
+	var result_rotation: int = result.get("rotation",0)
+
+	# The grass_medium_00 tile must've been replaced by one of the following
+	var valid_ids: Array[String] = ["forest_underbrush_03","forest_underbrush_04",
+		"forest_underbrush_05",	"dirt_light_00", "grass_medium_dirt_00"	]
+
+	# Check if result_id and rotation is valid
+	assert_true(valid_ids.has(result_id), "Unexpected tile id: " + result_id)
+	assert_true([0, 90, 180, 270].has(result_rotation), "Unexpected rotation: " + str(result_rotation))
+
+
+# Test processing of a entities based on the provided area and map data
+# The purpose is to apply furniture to a tile
+func test_process_entities_data():
+	var area_data: Dictionary = { # The area that will be applied to this map tile
+		"id": "tree_layer",
+		"rotate_random": true,
+		"spawn_chance": 100,
+		"entities": [
+			{"id": "Tree_00", "type": "furniture", "count": 11},
+			{"id": "PineTree_00", "type": "furniture", "count": 11},
+			{"id": "WillowTree_00", "type": "furniture", "count": 11}
+		],
+		"tiles": [{"id": "null", "count": 100}]
+	}
+	var original_tile: Dictionary = { # The tile as it was painted onto the map
+		"id":"grass_medium_00",
+		"areas":[{"id":"tree_layer","rotation":90}]
+	}
+	# In this example, the grass_medium_00 was replaced by dirt_light_00:
+	var result = {"id":"dirt_light_00","rotation":180} # Example result from _process_tile_id
+	map_manager._process_entities_data(area_data, result, original_tile)
+	var result_rotation: int = result.get("rotation",0)
+
+	# The tile id and rotation shouldn't have changed
+	assert_eq(result.get("id",""), "dirt_light_00", "Unexpected tile id")
+	assert_eq(result.get("rotation",0), 180, "Rotation has changed")
+	
+	if result.has("furniture"):
+		var valid_ids: Array[String] = ["Tree_00", "PineTree_00", "WillowTree_00"]
+		# furniture has been selected from the area, so it must be a tree
+		assert_true(valid_ids.has(result.furniture.id), "Unexpected furniture")
+	else:
+		# No furniture was put onto the tile, but the tile shouldn't have any of the following
+		assert_does_not_have(result,"mob","Unexpected mob key")
+		assert_does_not_have(result,"mobgroup","Unexpected mobgroup key")
+		assert_does_not_have(result,"itemgroup","Unexpected itemgroup key")
+		

--- a/Tests/Unit/test_map_manager.gd
+++ b/Tests/Unit/test_map_manager.gd
@@ -113,7 +113,6 @@ func test_process_entities_data():
 	# In this example, the grass_medium_00 was replaced by dirt_light_00:
 	var result = {"id":"dirt_light_00","rotation":180} # Example result from _process_tile_id
 	map_manager._process_entities_data(area_data, result, original_tile)
-	var result_rotation: int = result.get("rotation",0)
 
 	# The tile id and rotation shouldn't have changed
 	assert_eq(result.get("id",""), "dirt_light_00", "Unexpected tile id")


### PR DESCRIPTION
Fixes #677 

The tile's rotation was not factored in properly. This makes the required changes to fix it. Now the tiles don't rotate when not needed but the furniture still rotates as specified in the area.

Also adds a basic test for the map_manager