### PR TITLE
Implement basic flashlight

### DIFF
--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -441,6 +441,11 @@ json_data = "[
 		\"weight\": 1
 	},
 	{
+		\"Tool\": {
+			\"tool_qualities\": {
+				\"flashlight\": 1
+			}
+		},
 		\"description\": \"A basic battery powered flashlight. It will shine a beam of light when it is turned on\",
 		\"id\": \"flashlight_basic\",
 		\"image\": \"./Mods/Dimensionfall/Items/flashlight_32.png\",

--- a/Mods/Dimensionfall/Itemgroups/Itemgroups.json
+++ b/Mods/Dimensionfall/Itemgroups/Itemgroups.json
@@ -926,6 +926,12 @@
 				"max": 4,
 				"min": 4,
 				"probability": 100
+			},
+			{
+				"id": "flashlight_basic",
+				"max": 1,
+				"min": 1,
+				"probability": 100
 			}
 		],
 		"mode": "Collection",

--- a/Mods/Dimensionfall/Items/Items.json
+++ b/Mods/Dimensionfall/Items/Items.json
@@ -455,6 +455,11 @@
 		"weight": 1
 	},
 	{
+		"Tool": {
+			"tool_qualities": {
+				"flashlight": 1
+			}
+		},
 		"description": "A basic battery powered flashlight. It will shine a beam of light when it is turned on",
 		"id": "flashlight_basic",
 		"image": "./Mods/Dimensionfall/Items/flashlight_32.png",

--- a/Mods/Dimensionfall/Items/references.json
+++ b/Mods/Dimensionfall/Items/references.json
@@ -301,7 +301,8 @@
 			"cabinet_general",
 			"electronics_store_small",
 			"electronics_store_mixed",
-			"police_station_locker"
+			"police_station_locker",
+			"test_items"
 		],
 		"quests": [
 			"quest_holy_crusade_01"

--- a/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemEditor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=3 uid="uid://dmpomdwta1pgq"]
+[gd_scene load_steps=14 format=3 uid="uid://dmpomdwta1pgq"]
 
 [ext_resource type="Script" path="res://Scripts/ItemEditor.gd" id="1_ef3j7"]
 [ext_resource type="Texture2D" uid="uid://c8ragmxitca47" path="res://Scenes/ContentManager/Mapeditor/Images/emptyTile.png" id="2_ghd7c"]
@@ -12,6 +12,7 @@
 [ext_resource type="PackedScene" uid="uid://duoxs7mpo6x3t" path="res://Scenes/ContentManager/Custom_Editors/ItemEditor/ItemMeleeEditor.tscn" id="9_ucd7w"]
 [ext_resource type="PackedScene" uid="uid://cba63mf23i3ky" path="res://Scenes/ContentManager/Custom_Editors/ReferencesEditor.tscn" id="10_m8qfw"]
 [ext_resource type="PackedScene" uid="uid://dio1cpt7em6r2" path="res://Scenes/ContentManager/Custom_Editors/ItemEditor/ItemMedicalEditor.tscn" id="11_il5yl"]
+[ext_resource type="PackedScene" uid="uid://onkmwt1te3be" path="res://Scenes/ContentManager/Custom_Editors/ItemEditor/ItemToolEditor.tscn" id="12_378eu"]
 
 [node name="ItemEditor" type="Control" node_paths=PackedStringArray("tab_container", "itemImageDisplay", "IDTextLabel", "PathTextLabel", "NameTextEdit", "DescriptionTextEdit", "itemSelector", "VolumeNumberBox", "WeightNumberBox", "StackSizeNumberBox", "MaxStackSizeNumberBox", "types_container", "TwoHandedCheckBox", "references_editor")]
 layout_mode = 3
@@ -234,6 +235,9 @@ layout_mode = 2
 tooltip_text = "If this is checked, the item functions as food and the food properties tab will be visible. Otherwise, this item will not function as food and the food properties tab will not be visible"
 text = "Food"
 
+[node name="Tool" type="CheckBox" parent="VBoxContainer/TabContainer/Basic/TypesContainer"]
+layout_mode = 2
+
 [node name="Ranged" parent="VBoxContainer/TabContainer" instance=ExtResource("3_qqmud")]
 visible = false
 layout_mode = 2
@@ -279,6 +283,11 @@ visible = false
 layout_mode = 2
 metadata/_tab_index = 9
 
+[node name="Tool" parent="VBoxContainer/TabContainer" instance=ExtResource("12_378eu")]
+visible = false
+layout_mode = 2
+metadata/_tab_index = 10
+
 [node name="Sprite_selector" parent="." instance=ExtResource("3_qb68r")]
 visible = false
 
@@ -295,4 +304,5 @@ visible = false
 [connection signal="button_up" from="VBoxContainer/TabContainer/Basic/TypesContainer/DisassembleCheck" to="." method="_on_type_check_button_up"]
 [connection signal="button_up" from="VBoxContainer/TabContainer/Basic/TypesContainer/WearableCheck" to="." method="_on_type_check_button_up"]
 [connection signal="button_up" from="VBoxContainer/TabContainer/Basic/TypesContainer/Food" to="." method="_on_type_check_button_up"]
+[connection signal="button_up" from="VBoxContainer/TabContainer/Basic/TypesContainer/Tool" to="." method="_on_type_check_button_up"]
 [connection signal="sprite_selected_ok" from="Sprite_selector" to="." method="_on_sprite_selector_sprite_selected_ok"]

--- a/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemEditor.tscn
@@ -237,6 +237,7 @@ text = "Food"
 
 [node name="Tool" type="CheckBox" parent="VBoxContainer/TabContainer/Basic/TypesContainer"]
 layout_mode = 2
+text = "Tool"
 
 [node name="Ranged" parent="VBoxContainer/TabContainer" instance=ExtResource("3_qqmud")]
 visible = false
@@ -278,12 +279,12 @@ visible = false
 layout_mode = 2
 metadata/_tab_index = 8
 
-[node name="References" parent="VBoxContainer/TabContainer" instance=ExtResource("10_m8qfw")]
+[node name="Tool" parent="VBoxContainer/TabContainer" instance=ExtResource("12_378eu")]
 visible = false
 layout_mode = 2
 metadata/_tab_index = 9
 
-[node name="Tool" parent="VBoxContainer/TabContainer" instance=ExtResource("12_378eu")]
+[node name="References" parent="VBoxContainer/TabContainer" instance=ExtResource("10_m8qfw")]
 visible = false
 layout_mode = 2
 metadata/_tab_index = 10

--- a/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemToolEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemToolEditor.tscn
@@ -1,0 +1,40 @@
+[gd_scene load_steps=2 format=3 uid="uid://onkmwt1te3be"]
+
+[ext_resource type="Script" path="res://Scripts/ItemToolEditor.gd" id="1_kjfxi"]
+
+[node name="ItemToolEditor" type="Control" node_paths=PackedStringArray("flashlight_number")]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_kjfxi")
+flashlight_number = NodePath("Tool/FlashlightNumber")
+
+[node name="Tool" type="GridContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_vertical = 3
+columns = 2
+
+[node name="HintLabel" type="Label" parent="Tool"]
+layout_mode = 2
+text = "Hint"
+
+[node name="HintLabelText" type="Label" parent="Tool"]
+layout_mode = 2
+text = "Assign a number to each tool quality, which represents how good this item will work in that capacity"
+
+[node name="FlashlightLabel" type="Label" parent="Tool"]
+layout_mode = 2
+text = "Flashlight"
+
+[node name="FlashlightNumber" type="SpinBox" parent="Tool"]
+layout_mode = 2
+tooltip_text = "The amount of ammunition this magazine has when it is spawned. You can use this to create magazines that have been somewhat spent."
+value = 20.0

--- a/Scenes/player.tscn
+++ b/Scenes/player.tscn
@@ -88,14 +88,13 @@ pixel_size = 0.003
 render_priority = 15
 texture = ExtResource("5_uy1e8")
 
-[node name="EquippedLeft" type="Sprite3D" parent="Sprite3D2" node_paths=PackedStringArray("attack_cooldown_timer", "melee_attack_area", "melee_collision_shape", "player", "playerSprite", "shoot_audio_player", "reload_audio_player")]
+[node name="EquippedLeft" type="Sprite3D" parent="Sprite3D2" node_paths=PackedStringArray("attack_cooldown_timer", "melee_attack_area", "melee_collision_shape", "player", "playerSprite", "shoot_audio_player", "reload_audio_player", "flash_light")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.194626, 0.116675, 0)
 pixel_size = 0.002
 render_priority = 15
 texture = ExtResource("10_j5u52")
 script = ExtResource("7_u8an4")
 bullet_speed = 25.0
-bullet_damage = 25.0
 bullet_scene = ExtResource("8_un7wc")
 attack_cooldown_timer = NodePath("../../Shooting/Left_attack_cooldown")
 melee_attack_area = NodePath("../MeleeRange")
@@ -108,15 +107,15 @@ hud = NodePath("../../../../../HUD")
 shoot_audio_player = NodePath("../../Shooting/ShootAudio")
 shoot_audio_randomizer = SubResource("AudioStreamRandomizer_n8kat")
 reload_audio_player = NodePath("../../Shooting/ReloadAudio")
+flash_light = NodePath("../FlashLight")
 
-[node name="EquippedRight" type="Sprite3D" parent="Sprite3D2" node_paths=PackedStringArray("attack_cooldown_timer", "melee_attack_area", "melee_collision_shape", "player", "playerSprite", "shoot_audio_player", "reload_audio_player")]
+[node name="EquippedRight" type="Sprite3D" parent="Sprite3D2" node_paths=PackedStringArray("attack_cooldown_timer", "melee_attack_area", "melee_collision_shape", "player", "playerSprite", "shoot_audio_player", "reload_audio_player", "flash_light")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.190849, -0.123334, 0)
 pixel_size = 0.002
 render_priority = 15
 texture = ExtResource("6_gljie")
 script = ExtResource("7_u8an4")
 bullet_speed = 25.0
-bullet_damage = 25.0
 bullet_scene = ExtResource("8_un7wc")
 attack_cooldown_timer = NodePath("../../Shooting/Right_attack_cooldown")
 slot_idx = 1
@@ -130,6 +129,7 @@ hud = NodePath("../../../../../HUD")
 shoot_audio_player = NodePath("../../Shooting/ShootAudio")
 shoot_audio_randomizer = SubResource("AudioStreamRandomizer_jdgh6")
 reload_audio_player = NodePath("../../Shooting/ReloadAudio")
+flash_light = NodePath("../FlashLight")
 
 [node name="MeleeRange" type="Area3D" parent="Sprite3D2"]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, -0.277026)
@@ -153,6 +153,14 @@ unique_name_in_owner = true
 script = ExtResource("12_5v7lk")
 
 [node name="day_night" parent="Sprite3D2/FrontLight" instance=ExtResource("13_4vnbq")]
+
+[node name="FlashLight" type="SpotLight3D" parent="Sprite3D2"]
+transform = Transform3D(1.91069e-15, 4.37114e-08, 1, 1, -4.37114e-08, 0, 4.37114e-08, 1, -4.37114e-08, 0.543, 0, -0.309)
+visible = false
+spot_range = 89.881
+spot_attenuation = -0.63
+spot_angle = 25.0
+spot_angle_attenuation = 0.019915
 
 [node name="Shooting" type="Node3D" parent="." node_paths=PackedStringArray("left_hand_item", "right_hand_item")]
 script = ExtResource("14_h4gah")

--- a/Scenes/player.tscn
+++ b/Scenes/player.tscn
@@ -88,7 +88,7 @@ pixel_size = 0.003
 render_priority = 15
 texture = ExtResource("5_uy1e8")
 
-[node name="EquippedLeft" type="Sprite3D" parent="Sprite3D2" node_paths=PackedStringArray("attack_cooldown_timer", "melee_attack_area", "melee_collision_shape", "player", "playerSprite", "shoot_audio_player", "reload_audio_player", "flash_light")]
+[node name="EquippedLeft" type="Sprite3D" parent="Sprite3D2" node_paths=PackedStringArray("attack_cooldown_timer", "melee_hitbox", "melee_collision_shape", "player", "shoot_audio_player", "reload_audio_player", "flashlight_spotlight")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.194626, 0.116675, 0)
 pixel_size = 0.002
 render_priority = 15
@@ -97,19 +97,18 @@ script = ExtResource("7_u8an4")
 bullet_speed = 25.0
 bullet_scene = ExtResource("8_un7wc")
 attack_cooldown_timer = NodePath("../../Shooting/Left_attack_cooldown")
-melee_attack_area = NodePath("../MeleeRange")
+melee_hitbox = NodePath("../MeleeRange")
 melee_collision_shape = NodePath("../MeleeRange/MeleeCollisionShape3D")
 default_hand_position = Vector3(-0.195, 0.117, 0)
 melee_attack_z_rotation_offset = 15.0
 player = NodePath("../..")
-playerSprite = NodePath("..")
 hud = NodePath("../../../../../HUD")
 shoot_audio_player = NodePath("../../Shooting/ShootAudio")
 shoot_audio_randomizer = SubResource("AudioStreamRandomizer_n8kat")
 reload_audio_player = NodePath("../../Shooting/ReloadAudio")
-flash_light = NodePath("../FlashLight")
+flashlight_spotlight = NodePath("../FlashLight")
 
-[node name="EquippedRight" type="Sprite3D" parent="Sprite3D2" node_paths=PackedStringArray("attack_cooldown_timer", "melee_attack_area", "melee_collision_shape", "player", "playerSprite", "shoot_audio_player", "reload_audio_player", "flash_light")]
+[node name="EquippedRight" type="Sprite3D" parent="Sprite3D2" node_paths=PackedStringArray("attack_cooldown_timer", "melee_hitbox", "melee_collision_shape", "player", "shoot_audio_player", "reload_audio_player", "flashlight_spotlight")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.190849, -0.123334, 0)
 pixel_size = 0.002
 render_priority = 15
@@ -119,17 +118,16 @@ bullet_speed = 25.0
 bullet_scene = ExtResource("8_un7wc")
 attack_cooldown_timer = NodePath("../../Shooting/Right_attack_cooldown")
 slot_idx = 1
-melee_attack_area = NodePath("../MeleeRange")
+melee_hitbox = NodePath("../MeleeRange")
 melee_collision_shape = NodePath("../MeleeRange/MeleeCollisionShape3D")
 default_hand_position = Vector3(-0.191, -0.123, 0)
 melee_attack_z_rotation_offset = -15.0
 player = NodePath("../..")
-playerSprite = NodePath("..")
 hud = NodePath("../../../../../HUD")
 shoot_audio_player = NodePath("../../Shooting/ShootAudio")
 shoot_audio_randomizer = SubResource("AudioStreamRandomizer_jdgh6")
 reload_audio_player = NodePath("../../Shooting/ReloadAudio")
-flash_light = NodePath("../FlashLight")
+flashlight_spotlight = NodePath("../FlashLight")
 
 [node name="MeleeRange" type="Area3D" parent="Sprite3D2"]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, -0.277026)

--- a/Scripts/EquippedItem.gd
+++ b/Scripts/EquippedItem.gd
@@ -496,10 +496,7 @@ func setup_tool_item_properties(_equippedItem: InventoryItem):
 
 
 func refresh_flashlight_visibility():
-	if get_highest_tool_quality("flashlight") > -1:
-		flashlight_spotlight.visible = true
-	else:
-		flashlight_spotlight.visible = false
+	flashlight_spotlight.visible = get_highest_tool_quality("flashlight") > -1
 
 
 # Configure the melee collision shape based on the weapon's reach
@@ -546,21 +543,15 @@ func get_other_equipped_items() -> Array[EquippedItem]:
 			other_equipped_items.append(item)
 	return other_equipped_items
 
+
 # Returns the level of the specified tool quality for the equipped item.
 # If the tool does not have the quality, returns -1.
 func get_tool_quality(tool_quality: String) -> int:
 	if not equipped_item:
-		print_debug("get_tool_quality: No item equipped.")
 		return -1
-	
-	var tool_properties = equipped_item.get_property("Tool")
-	if not tool_properties:
-		print_debug("get_tool_quality: Equipped item has no Tool properties.")
-		return -1
-	
-	var tool_qualities = tool_properties.get("tool_qualities", {})
-	var quality_level = tool_qualities.get(tool_quality, -1)
-	return quality_level
+	var tool_properties = equipped_item.get_property("Tool") or {}
+	return tool_properties.get("tool_qualities", {}).get(tool_quality, -1)
+
 
 # Returns the highest tool quality level among all equipped items.
 # If no equipped item has the given tool quality, returns -1.

--- a/Scripts/EquippedItem.gd
+++ b/Scripts/EquippedItem.gd
@@ -258,10 +258,10 @@ func clear_held_item():
 		equipped_item.properties_changed.disconnect(_on_helditem_properties_changed)
 		equipped_item.set_property("is_reloading", false)
 	disable_melee_collision_shape()
-	refresh_flashlight_visibility()
 	visible = false
 	equipped_item = null
 	in_cooldown = false
+	refresh_flashlight_visibility()
 	Helper.signal_broker.player_ammo_changed.emit(-1, -1, slot_idx)  # Emit signal to indicate no weapon is equipped
 
 func _on_left_attack_cooldown_timeout():
@@ -549,7 +549,7 @@ func get_other_equipped_items() -> Array[EquippedItem]:
 func get_tool_quality(tool_quality: String) -> int:
 	if not equipped_item:
 		return -1
-	var tool_properties = equipped_item.get_property("Tool") or {}
+	var tool_properties = equipped_item.get_property("Tool", {})
 	return tool_properties.get("tool_qualities", {}).get(tool_quality, -1)
 
 

--- a/Scripts/Gamedata/DItem.gd
+++ b/Scripts/Gamedata/DItem.gd
@@ -33,6 +33,8 @@ var food: Food
 var medical: Medical
 var ammo: Ammo
 var wearable: Wearable
+var tool: Tool
+
 
 # Inner class to handle the Craft property
 class CraftRecipe:
@@ -381,6 +383,19 @@ class Wearable:
 				break  # Exit the loop after removing the attribute
 
 
+# Inner class to handle the Tool property
+class Tool:
+	var tool_qualities: Dictionary  # Example: { "flashlight": 1 }
+
+	# Constructor to initialize tool properties from a dictionary
+	func _init(data: Dictionary):
+		tool_qualities = data.get("tool_qualities", {})
+
+	# Get data function to return a dictionary with all properties
+	func get_data() -> Dictionary:
+		return { "tool_qualities": tool_qualities }
+
+
 # Constructor to initialize item properties from a dictionary
 # myparent: The list containing all items for this mod
 func _init(data: Dictionary, parent_container: DItems):
@@ -414,6 +429,7 @@ func _initialize_specialized_properties(data: Dictionary) -> void:
 	medical = _initialize_subclass(data, "Medical", Medical)
 	ammo = _initialize_subclass(data, "Ammo", Ammo)
 	wearable = _initialize_subclass(data, "Wearable", Wearable)
+	tool = _initialize_subclass(data, "Tool", Tool)
 
 
 # Helper to initialize a subclass if data is present
@@ -457,6 +473,9 @@ func get_data() -> Dictionary:
 
 	if ammo:
 		data["Ammo"] = ammo.get_data()
+
+	if tool:
+		data["Tool"] = tool.get_data()
 
 	if wearable:
 		var wearabledata = wearable.get_data()

--- a/Scripts/ItemToolEditor.gd
+++ b/Scripts/ItemToolEditor.gd
@@ -17,13 +17,8 @@ var ditem: DItem = null:
 
 
 func save_properties() -> void:
-	# Ensure tool_qualities exists
-	if not ditem.tool:
-		print_debug("ditem.tool is null, cannot save tool qualities.")
-		return
-
 	# Save the flashlight number into tool_qualities as {"flashlight": value}
-	ditem.tool.tool_qualities["flashlight"] = int(flashlight_number.value)
+	ditem.tool = DItem.Tool.new({"tool_qualities": {"flashlight": int(flashlight_number.value)}})
 
 
 func load_properties() -> void:

--- a/Scripts/ItemToolEditor.gd
+++ b/Scripts/ItemToolEditor.gd
@@ -1,0 +1,35 @@
+extends Control
+
+# This scene is intended to be used inside the item editor
+# It is supposed to edit exactly one tool
+
+
+# Form elements
+@export var flashlight_number: SpinBox = null
+
+
+var ditem: DItem = null:
+	set(value):
+		if not value:
+			return
+		ditem = value
+		load_properties()
+
+
+func save_properties() -> void:
+	# Ensure tool_qualities exists
+	if not ditem.tool:
+		print_debug("ditem.tool is null, cannot save tool qualities.")
+		return
+
+	# Save the flashlight number into tool_qualities as {"flashlight": value}
+	ditem.tool.tool_qualities["flashlight"] = int(flashlight_number.value)
+
+
+func load_properties() -> void:
+	if not ditem.tool:
+		print_debug("ditem.tool is null, skipping property loading.")
+		return
+	
+	# Load the flashlight number from tool_qualities, defaulting to 1 if not set
+	flashlight_number.value = ditem.tool.tool_qualities.get("flashlight", 1)

--- a/Scripts/Runtimedata/RItem.gd
+++ b/Scripts/Runtimedata/RItem.gd
@@ -192,6 +192,19 @@ class Wearable:
 	func get_data() -> Dictionary:
 		return { "slot": slot, "player_attributes": player_attributes }
 
+
+# Inner class to handle the Tool property
+class Tool:
+	var tool_qualities: Dictionary  # Example: { "flashlight": 1 }
+
+	# Constructor to initialize tool properties from a dictionary
+	func _init(data: Dictionary):
+		tool_qualities = data.get("tool_qualities", {})
+
+	# Get data function to return a dictionary with all properties
+	func get_data() -> Dictionary:
+		return { "tool_qualities": tool_qualities }
+
 # Properties of the RItem class
 var id: String
 var name: String
@@ -211,6 +224,7 @@ var food: Food
 var medical: Medical
 var ammo: Ammo
 var wearable: Wearable
+var tool: Tool
 var referenced_items: Array[String]
 var parent: RItems
 
@@ -249,6 +263,7 @@ func overwrite_from_ditem(ditem: DItem) -> void:
 	medical = Medical.new(ditem.medical.get_data()) if ditem.medical else null
 	ammo = Ammo.new(ditem.ammo.get_data()) if ditem.ammo else null
 	wearable = Wearable.new(ditem.wearable.get_data()) if ditem.wearable else null
+	tool = Tool.new(ditem.tool.get_data()) if ditem.tool else null
 
 # Get data function
 func get_data() -> Dictionary:
@@ -279,6 +294,8 @@ func get_data() -> Dictionary:
 		data["Ammo"] = ammo.get_data()
 	if wearable:
 		data["Wearable"] = wearable.get_data()
+	if tool:
+		data["Tool"] = tool.get_data()
 	return data
 
 

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -21,6 +21,7 @@ var current_nutrition
 var pain
 var current_pain = 0
 
+# Slots that the player can equip items into, i.e. left hand and right hand
 var held_item_slots : Array[EquippedItem]
 var stats = {}
 var skills = {}


### PR DESCRIPTION
Fixes #499 

The flashlight item now has a `flashlight` tool quality of 1. Tool qualities didn't exist before this, so I added them as a "Tool" property of items. Tool qualities are hard-coded for now, but once we have more we can probably make it moddable.

The flashlight turns on when the flashlight item is equipped and turns off when no flashlight is equipped. The flashlight item itself can't be turned on or off and doesn't take batteries (yet).