### PR TITLE
Update quest marker

### DIFF
--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -253,6 +253,7 @@ func _ready():
 	Helper.position_coord = Vector2(0, 0)
 	update_chunks()
 	connect_signals()
+	Helper.quest_helper.update_tracked_quest_target()
 
 
 # Connect necessary signals
@@ -560,11 +561,21 @@ func on_target_map_changed(map_ids: Array, target_properties: Dictionary = {}):
 		return
 
 	var dynamic: bool = target_properties.get("dynamic", false)
+
+	# 🔹 Ensure target exists and validate its map_id
 	if target:
 		var at_target: bool = Helper.overmap_manager.is_player_at_position(Vector2(target.coordinate.x, target.coordinate.y))
+
+		# ✅ If dynamic and the player is at the target, reset it
 		if dynamic and at_target:
 			reset_target()
+			return
 
+		# ✅ If target.map_id is NOT in map_ids, reset the target and then continue
+		if not target.map_id in map_ids:
+			reset_target()
+
+	# 🔹 Find the closest valid target
 	var closest_cell = Helper.overmap_manager.find_closest_map_cell_with_ids(map_ids, target_properties)
 	if closest_cell and target == null:
 		target = Target.new(closest_cell.map_id, Vector2(closest_cell.coordinate_x, closest_cell.coordinate_y))

--- a/Scripts/Helper/quest_helper.gd
+++ b/Scripts/Helper/quest_helper.gd
@@ -94,7 +94,8 @@ func _on_game_started():
 # Function for handling game loaded signal
 func _on_game_loaded():
 	connect_inventory_signals()
-	pass
+	var current_step = QuestManager.get_current_step(tracked_quest) # Get the quest's current step
+	check_and_emit_target_map(current_step) # Puts the quest marker on the overmap
 
 # Function for handling game ended signal
 func _on_game_ended():
@@ -520,3 +521,12 @@ func process_active_quests():
 				QuestManager.progress_quest(quest.quest_name)
 			else:
 				print_debug("Failed to spawn item on map for quest step in quest: " + quest.quest_name)
+
+# Retrieves the current step of the tracked quest and updates the target map.
+func update_tracked_quest_target() -> void:
+	if tracked_quest.is_empty():
+		return  # No quest is being tracked, so nothing to update.
+
+	var current_step = QuestManager.get_current_step(tracked_quest)  # Get the quest's current step
+	if current_step:
+		check_and_emit_target_map(current_step)  # Puts the quest marker on the overmap


### PR DESCRIPTION
Fixes #700 

The quest helper was lacking a check to see if the current target has the map id we need, so I added it.
Also put in a fix to show the marker when the game is loaded.