### PR TITLE
Enable an Attack with no attributes to work

### DIFF
--- a/Scenes/Overmap/Scripts/Overmap.gd
+++ b/Scenes/Overmap/Scripts/Overmap.gd
@@ -253,6 +253,7 @@ func _ready():
 	Helper.position_coord = Vector2(0, 0)
 	update_chunks()
 	connect_signals()
+	Helper.quest_helper.update_tracked_quest_target()
 
 
 # Connect necessary signals
@@ -560,11 +561,21 @@ func on_target_map_changed(map_ids: Array, target_properties: Dictionary = {}):
 		return
 
 	var dynamic: bool = target_properties.get("dynamic", false)
+
+	# 🔹 Ensure target exists and validate its map_id
 	if target:
 		var at_target: bool = Helper.overmap_manager.is_player_at_position(Vector2(target.coordinate.x, target.coordinate.y))
+
+		# ✅ If dynamic and the player is at the target, reset it
 		if dynamic and at_target:
 			reset_target()
+			return
 
+		# ✅ If target.map_id is NOT in map_ids, reset the target and then continue
+		if not target.map_id in map_ids:
+			reset_target()
+
+	# 🔹 Find the closest valid target
 	var closest_cell = Helper.overmap_manager.find_closest_map_cell_with_ids(map_ids, target_properties)
 	if closest_cell and target == null:
 		target = Target.new(closest_cell.map_id, Vector2(closest_cell.coordinate_x, closest_cell.coordinate_y))

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -226,7 +226,7 @@ func add_block_mobs():
 	# If you want to test a mob, you can use this to spawn it at 0,2,0
 	# Comment it out again when you're done testing
 	#if mypos == Vector3(0,0,0):
-		#var tempmob: CharacterBody3D = Mob.new(Vector3(0,1,0), {"id":"bone_thrower"})
+		#var tempmob: CharacterBody3D = Mob.new(Vector3(0,1,0), {"id":"basic_zombie_1"})
 		#level_manager.add_child.call_deferred(tempmob)
 
 # When a map is loaded for the first time we spawn the furniture on the block

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -226,7 +226,7 @@ func add_block_mobs():
 	# If you want to test a mob, you can use this to spawn it at 0,2,0
 	# Comment it out again when you're done testing
 	#if mypos == Vector3(0,0,0):
-		#var tempmob: CharacterBody3D = Mob.new(Vector3(0,1,0), {"id":"basic_zombie_1"})
+		#var tempmob: CharacterBody3D = Mob.new(Vector3(15,1,15), {"id":"bone_thrower"})
 		#level_manager.add_child.call_deferred(tempmob)
 
 # When a map is loaded for the first time we spawn the furniture on the block

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -226,7 +226,7 @@ func add_block_mobs():
 	# If you want to test a mob, you can use this to spawn it at 0,2,0
 	# Comment it out again when you're done testing
 	#if mypos == Vector3(0,0,0):
-		#var tempmob: CharacterBody3D = Mob.new(Vector3(15,1,15), {"id":"bone_thrower"})
+		#var tempmob: CharacterBody3D = Mob.new(Vector3(15,1,15), {"id":"disruptor_drone"})
 		#level_manager.add_child.call_deferred(tempmob)
 
 # When a map is loaded for the first time we spawn the furniture on the block

--- a/Scripts/EquippedItem.gd
+++ b/Scripts/EquippedItem.gd
@@ -89,9 +89,11 @@ func get_cursor_world_position() -> Vector3:
 func can_fire_weapon() -> bool:
 	if not equipped_item:
 		return false
-	if equipped_item.get_property("Melee") != null:  # Assuming melee weapons have a 'Melee' property
+	if equipped_item.get_property("Melee") != null:
 		return General.is_mouse_outside_HUD and not General.is_action_in_progress and equipped_item and not in_cooldown
-	return General.is_mouse_outside_HUD and not General.is_action_in_progress and General.is_allowed_to_shoot and equipped_item and not in_cooldown and (get_current_ammo() > 0 or not requires_ammo())
+	if equipped_item.get_property("Ranged") != null:
+		return General.is_mouse_outside_HUD and not General.is_action_in_progress and General.is_allowed_to_shoot and equipped_item and not in_cooldown and (get_current_ammo() > 0 or not requires_ammo())
+	return false
 
 
 # Function to check if the weapon requires ammo (for ranged weapons)

--- a/Scripts/FurnitureStaticSrv.gd
+++ b/Scripts/FurnitureStaticSrv.gd
@@ -928,6 +928,12 @@ func create_cylinder_shape():
 func set_collision_layers_and_masks():
 	# Set collision layer to layers 3 (static obstacles layer) and 7 (containers layer)
 	var collision_layer = (1 << 2) | (1 << 6)  # Layer 3 is 1 << 2, Layer 7 is 1 << 6
+	if rfurniture.support_shape.transparent:
+		# HACK Put the furniture on the moveable obstacles layer if the furniture is transparent
+		# The reason for this is that mobs should exclude transparent furniture from 
+		# consideration when locating a new target (i.e. they can see trough the furniture)
+		# TODO: Create another layer for transparent furnture
+		collision_layer = (1 << 3) | (1 << 6)  # Layer 4 is 1 << 3, Layer 7 is 1 << 6
 
 	# Set collision mask to include layers 1, 2, 3, 4, 5, and 6
 	var collision_mask = (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3) | (1 << 4) | (1 << 5)

--- a/Scripts/Helper/quest_helper.gd
+++ b/Scripts/Helper/quest_helper.gd
@@ -94,7 +94,8 @@ func _on_game_started():
 # Function for handling game loaded signal
 func _on_game_loaded():
 	connect_inventory_signals()
-	pass
+	var current_step = QuestManager.get_current_step(tracked_quest) # Get the quest's current step
+	check_and_emit_target_map(current_step) # Puts the quest marker on the overmap
 
 # Function for handling game ended signal
 func _on_game_ended():
@@ -520,3 +521,12 @@ func process_active_quests():
 				QuestManager.progress_quest(quest.quest_name)
 			else:
 				print_debug("Failed to spawn item on map for quest step in quest: " + quest.quest_name)
+
+# Retrieves the current step of the tracked quest and updates the target map.
+func update_tracked_quest_target() -> void:
+	if tracked_quest.is_empty():
+		return  # No quest is being tracked, so nothing to update.
+
+	var current_step = QuestManager.get_current_step(tracked_quest)  # Get the quest's current step
+	if current_step:
+		check_and_emit_target_map(current_step)  # Puts the quest marker on the overmap

--- a/Scripts/Mob/Detection.gd
+++ b/Scripts/Mob/Detection.gd
@@ -105,7 +105,7 @@ func get_visible_targets(potential_targets: Array[CharacterBody3D]) -> Array[Cha
 		var query = PhysicsRayQueryParameters3D.create(
 			global_position,  # Ray start point (mob's position)
 			target.global_position,  # Ray end point (target's position)
-			3,  # Layer mask for layer 1 and layer 2
+			(1 << 0) | (1 << 1) | (1 << 2), # Layer mask for layers 1 (player), 2 (mobs), and 3 (walls)
 			[self]  # Exclude the mob itself from the query
 		)
 

--- a/Scripts/Mob/Mob.gd
+++ b/Scripts/Mob/Mob.gd
@@ -387,13 +387,13 @@ func get_attack_of_type(type: String = "melee") -> Dictionary:
 # Returns the range of the first ranged attack, if it has any
 func get_ranged_range() -> float:
 	var rattack: RAttack = Runtimedata.attacks.by_id(get_attack_of_type("ranged").id)
-	if rattack and rattack.get("range"):
-		return rattack.range
+	if rattack and rattack.get("myrange"):
+		return rattack.myrange
 	return 0.0
 
 # Returns the range of the first melee attack in the attack list, if it has any
 func get_melee_range() -> float:
 	var rattack: RAttack = Runtimedata.attacks.by_id(get_attack_of_type("melee").id)
-	if rattack and rattack.get("range"):
-		return rattack.range
+	if rattack and rattack.get("myrange"):
+		return rattack.myrange
 	return 0.0

--- a/Scripts/Mob/Mob.gd
+++ b/Scripts/Mob/Mob.gd
@@ -67,12 +67,13 @@ func setup_basic_properties():
 # Set collision layers and masks
 func setup_collision_layers_and_masks():
 	collision_layer = 1 << 1  # Layer 2 is 1 << 1 (bit shift by 1)
-	collision_mask = (1 << 0) | (1 << 1) | (1 << 2) | (1 << 4) | (1 << 5)
+	collision_mask = (1 << 0) | (1 << 1) | (1 << 2) | (1 << 4)
 	# Explanation:
 	# - 1 << 0: Layer 1 (player layer)
 	# - 1 << 1: Layer 2 (enemy layer)
 	# - 1 << 2: Layer 3 (static obstacles layer)
 	# - 1 << 4: Layer 5 (enemy projectiles layer)
+	# INFO: Do NOT add layer 6 to collision mask or the mob will be pushed by the projectile
 	# - 1 << 5: Layer 6 (friendly projectiles layer)
 
 

--- a/Scripts/Runtimedata/RAttack.gd
+++ b/Scripts/Runtimedata/RAttack.gd
@@ -9,7 +9,7 @@ extends RefCounted
 #		"id": "melee_basic",
 #		"name": "Basic melee attack",
 #		"type": "melee", // can be "melee" or "ranged"
-#		"range": 10,
+#		"myrange": 10,
 #		"cooldown": 1,
 #		"knockback": 2,
 #		"projectile_speed": 20, // Only applies to the "ranged" type
@@ -45,7 +45,7 @@ var description: String
 var spriteid: String
 var sprite: Texture
 var type: String # Can be "melee" or "ranged"
-var range: float # The attack will start when the enemy is within this range
+var myrange: float # The attack will start when the enemy is within this range
 var cooldown: float # The time between attacks
 var knockback: float # The amount of tiles that the enemy is pushed back
 var projectile_speed: float  # Only relevant for ranged attacks
@@ -67,7 +67,7 @@ func overwrite_from_dattack(dattack: DAttack) -> void:
 	spriteid = dattack.spriteid
 	sprite = dattack.sprite
 	type = dattack.type
-	range = dattack.range
+	myrange = dattack.range
 	cooldown = dattack.cooldown
 	knockback = dattack.knockback
 	projectile_speed = dattack.projectile_speed
@@ -112,9 +112,12 @@ func get_scaled_all_of_attribute_damage(multiplier: float) -> Array:
 
 # Takes a multipler and returns the amount of damage and knockback
 func get_scaled_attack_effects(multiplier: float) -> Dictionary:
-	var scaled_attributes: Array = [get_scaled_attribute_damage(multiplier)]
-	scaled_attributes.append_array(get_scaled_all_of_attribute_damage(multiplier))
+	var any_of: Dictionary = get_scaled_attribute_damage(multiplier)
+	var scaled_attributes: Array = []
+	if not any_of.is_empty():
+		scaled_attributes.append(any_of)
 
+	scaled_attributes.append_array(get_scaled_all_of_attribute_damage(multiplier))
 	return {
 		"attributes": scaled_attributes,
 		"knockback": knockback


### PR DESCRIPTION
Requires #709 

There was an issue where an error shows up if the player is attacked by a `disruptor_drone`. The attack of that mob has no targets in the `any_of` column, and the script couldn't handle that.

Adds a check in case the attribute list is empty in the `any_of` column.