### PR TITLE
Prevent walking trough glass

### DIFF
--- a/Defaults/Projectiles/DefaultBullet.tscn
+++ b/Defaults/Projectiles/DefaultBullet.tscn
@@ -8,7 +8,7 @@ radius = 0.2
 
 [node name="BulletProjectile" type="RigidBody3D" node_paths=PackedStringArray("bullet_sprite")]
 collision_layer = 32
-collision_mask = 30
+collision_mask = 158
 mass = 0.01
 gravity_scale = 0.001
 contact_monitor = true

--- a/Scenes/player.tscn
+++ b/Scenes/player.tscn
@@ -51,7 +51,7 @@ radius = 1.5
 
 [node name="Player" type="CharacterBody3D" node_paths=PackedStringArray("sprite", "collision_detector", "camera_3d") groups=["Players"]]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 15)
-collision_mask = 22
+collision_mask = 150
 floor_constant_speed = true
 floor_max_angle = 0.872665
 script = ExtResource("1_8wv3l")

--- a/Scripts/FurnitureBlueprintSrv.gd
+++ b/Scripts/FurnitureBlueprintSrv.gd
@@ -640,6 +640,7 @@ func hide_visuals():
 		RenderingServer.instance_set_visible(quad_instance, false)
 	if container and container.sprite_instance:
 		RenderingServer.instance_set_visible(container.sprite_instance, false)
+	is_hidden = true
 
 # ✅ Function to show the furniture visuals
 func show_visuals():
@@ -649,6 +650,7 @@ func show_visuals():
 		RenderingServer.instance_set_visible(quad_instance, true)
 	if container and container.sprite_instance:
 		RenderingServer.instance_set_visible(container.sprite_instance, true)
+	is_hidden = false
 
 
 # ✅ Handles player Y level update and updates furniture visibility

--- a/Scripts/FurniturePhysicsSrv.gd
+++ b/Scripts/FurniturePhysicsSrv.gd
@@ -556,13 +556,15 @@ func get_y_position(is_snapped: bool = false) -> float:
 
 # ✅ Function to hide all visual elements
 func hide_visuals() -> void:
-	if mesh_instance:
+	if not mesh_instance == null:
 		RenderingServer.instance_set_visible(mesh_instance, false)
+	is_hidden = true
 
 # ✅ Function to show all visual elements
 func show_visuals() -> void:
-	if mesh_instance:
+	if not mesh_instance == null:
 		RenderingServer.instance_set_visible(mesh_instance, true)
+	is_hidden = false
 
 
 # ✅ Handles player Y level update and updates furniture visibility

--- a/Scripts/FurnitureStaticSrv.gd
+++ b/Scripts/FurnitureStaticSrv.gd
@@ -927,11 +927,8 @@ func set_collision_layers_and_masks():
 	# Set collision layer to layers 3 (static obstacles layer) and 7 (containers layer)
 	var collision_layer = (1 << 2) | (1 << 6)  # Layer 3 is 1 << 2, Layer 7 is 1 << 6
 	if rfurniture.support_shape.transparent:
-		# HACK Put the furniture on the moveable obstacles layer if the furniture is transparent
-		# The reason for this is that mobs should exclude transparent furniture from 
-		# consideration when locating a new target (i.e. they can see trough the furniture)
-		# TODO: Create another layer for transparent furnture
-		collision_layer = (1 << 3) | (1 << 6)  # Layer 4 is 1 << 3, Layer 7 is 1 << 6
+		# Put transparent furniture on it's own layer
+		collision_layer = (1 << 6) | (1 << 7)  # Layer 7 is 1 << 6, Layer 8 is 1 << 7
 
 	# Set collision mask to include layers 1, 2, 3, 4, 5, and 6
 	var collision_mask = (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3) | (1 << 4) | (1 << 5)

--- a/Scripts/Mob/Mob.gd
+++ b/Scripts/Mob/Mob.gd
@@ -67,7 +67,7 @@ func setup_basic_properties():
 # Set collision layers and masks
 func setup_collision_layers_and_masks():
 	collision_layer = 1 << 1  # Layer 2 is 1 << 1 (bit shift by 1)
-	collision_mask = (1 << 0) | (1 << 1) | (1 << 2) | (1 << 4)
+	collision_mask = (1 << 0) | (1 << 1) | (1 << 2) | (1 << 4) | (1 << 7)
 	# Explanation:
 	# - 1 << 0: Layer 1 (player layer)
 	# - 1 << 1: Layer 2 (enemy layer)
@@ -75,6 +75,7 @@ func setup_collision_layers_and_masks():
 	# - 1 << 4: Layer 5 (enemy projectiles layer)
 	# INFO: Do NOT add layer 6 to collision mask or the mob will be pushed by the projectile
 	# - 1 << 5: Layer 6 (friendly projectiles layer)
+	# - 1 << 7: Layer 8 (transparent static obstacles layer)
 
 
 # Create and configure NavigationAgent3D

--- a/project.godot
+++ b/project.godot
@@ -183,6 +183,7 @@ quest_menu={
 3d_physics/layer_5="enemyprojectiles"
 3d_physics/layer_6="friendlyprojectiles"
 3d_physics/layer_7="containers"
+3d_physics/layer_8="transparentstaticobstacles"
 2d_physics/layer_20="Items"
 
 [shader_globals]


### PR DESCRIPTION
Fixes #711 

Puts the transparent furniture in their own layer (8). Player and mobs can't pass trough but mobs and player can see trough it. Bullets also hit the glass.