### PR TITLE
Implement camera near function use.

### DIFF
--- a/LevelManager.gd
+++ b/LevelManager.gd
@@ -20,19 +20,8 @@ func _process(_delta):
 func update_visibility(player_y: float):
 	# Update level visibility
 	for level in get_tree().get_nodes_in_group("maplevels"):
-		var is_above_player = level.y-0.2 > player_y
+		var is_above_player = level.y-0.38 > player_y
 		level.visible = not is_above_player
-
-	# Update mob visibility
-	for mob in get_tree().get_nodes_in_group("mobs"):
-		var is_above_player = mob.global_position.y > player_y
-		mob.visible = not is_above_player
-
-	# Update container visibility
-	for container in get_tree().get_nodes_in_group("Containers"):
-		# Add 0.1 margin otherwise they are invisible on high furniture.
-		var is_above_player = container.global_position.y-0.1 > player_y
-		container.visible = not is_above_player
 
 
 # When the initial chuks around the player are generated, 

--- a/Scenes/player.tscn
+++ b/Scenes/player.tscn
@@ -59,11 +59,13 @@ sprite = NodePath("Sprite3D2")
 collision_detector = NodePath("Sprite3D2/CollisionDetector")
 camera_3d = NodePath("Camera3D")
 
-[node name="Camera3D" type="Camera3D" parent="." groups=["Camera"]]
+[node name="Camera3D" type="Camera3D" parent="." node_paths=PackedStringArray("player") groups=["Camera"]]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 19, 0)
 current = true
 size = 50.0
+near = 18.58
 script = ExtResource("2_g83x8")
+player = NodePath("..")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.275, 0)
@@ -82,8 +84,10 @@ omni_range = 18.071
 omni_attenuation = 0.0371628
 
 [node name="SpotLight3D" parent="." instance=ExtResource("3_1cs2j")]
+shadow_enabled = false
 
 [node name="SpotLight3D2" parent="." instance=ExtResource("4_s4cit")]
+shadow_enabled = false
 
 [node name="Sprite3D2" type="Sprite3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -0.277026, 0)
@@ -151,6 +155,7 @@ shape = SubResource("ConvexPolygonShape3D_drnhn")
 
 [node name="FrontLight" parent="Sprite3D2" instance=ExtResource("11_b146k")]
 unique_name_in_owner = true
+transform = Transform3D(1.91069e-15, 4.37114e-08, 1, 1, -4.37114e-08, 0, 4.37114e-08, 1, -4.37114e-08, 0.274, 0, -0.309)
 script = ExtResource("12_5v7lk")
 
 [node name="day_night" parent="Sprite3D2/FrontLight" instance=ExtResource("13_4vnbq")]

--- a/Scripts/Camera.gd
+++ b/Scripts/Camera.gd
@@ -1,6 +1,13 @@
 extends Camera3D
 
 var can_zoom: bool = true
+@export var player: Player = null
+
+# Current default near value
+const DEFAULT_NEAR = 18.601
+const BUFF = -0.001
+# The threshold for snapping back to default near value
+const Y_THRESHOLD = 0.5
 
 func _ready():
 	# We connect to the inventory visibility change to interrupt zooming
@@ -18,3 +25,44 @@ func _input(event):
 # When the inventory is opened, stop zooming
 func _on_inventory_visibility_change(inventoryWindow):
 	can_zoom = not inventoryWindow.visible
+
+
+func _process(_delta):
+	# Correct for the camera offset (since the camera is a child of the player)
+	var corrected_position: float = player.global_position.y - 0.101
+	
+	# ✅ Custom snapping function based on Y_THRESHOLD
+	var decimal_part = corrected_position - floor(corrected_position)
+	var snapped_y_level = floor(corrected_position)
+
+	if decimal_part >= Y_THRESHOLD:
+		snapped_y_level = ceil(corrected_position)
+	
+	
+	#var snapped_y_level = round(corrected_position)
+	var y_offset = corrected_position - snapped_y_level
+	
+	# Gradually adjust near value based on y_offset until the threshold is reached
+	if abs(y_offset) >= Y_THRESHOLD:
+		# If the player crosses the threshold, snap back to default near value
+		near = DEFAULT_NEAR
+	else:
+		# Adjust near value smoothly based on y_offset from snapped level
+		near = BUFF + DEFAULT_NEAR + y_offset#(y_offset / Y_THRESHOLD)
+	
+	# INFO: Below is commented out for future debugging purposes
+	# Result calculation to compensate for y_offset and near adjustment
+	#var result = (global_position.y - player.global_position.y - near) + y_offset + 0.6
+
+	# Debug info to verify values
+	#print(
+		#"Player Y: %.3f, Camera Y: %.3f, Near: %.3f, Y Offset: %.3f, Snapped Y Level: %.3f, Corrected Position: %.3f, Result: %.3f" % [
+			#player.global_position.y, 
+			#global_position.y, 
+			#near, 
+			#y_offset,
+			#snapped_y_level,
+			#corrected_position,
+			#result
+		#]
+	#)

--- a/Scripts/FurnitureBlueprintSrv.gd
+++ b/Scripts/FurnitureBlueprintSrv.gd
@@ -214,7 +214,6 @@ func _init(furniturepos: Vector3, newFurnitureJSON: Dictionary, world3d: World3D
 
 	# Apply the mode-specific logic. Only constructed furniture will be BLUEPRINT
 	set_mode()
-	Helper.signal_broker.player_current_y_level.connect.call_deferred(_on_player_y_level_updated)
 
 
 # If this furniture is a container, it will add a container node to the furniture.
@@ -653,8 +652,7 @@ func show_visuals():
 	is_hidden = false
 
 
-# ✅ Handles player Y level update and updates furniture visibility
-func _on_player_y_level_updated(_old_y_level: float, new_y_level: float):
+func refresh_visibility(new_y_level: float):
 	var furniture_y = get_y_position(true)  # Get snapped Y level
 
 	# Hide furniture above player, show furniture below

--- a/Scripts/FurniturePhysicsSpawner.gd
+++ b/Scripts/FurniturePhysicsSpawner.gd
@@ -50,7 +50,6 @@ func spawn_furniture(furniture_data: Dictionary) -> void:
 	
 	new_furniture.about_to_be_destroyed.connect(_on_furniture_about_to_be_destroyed)
 	new_furniture.spawner = self
-	new_furniture.refresh_visibility(0) # Initial update for visibility
 	
 	# Add the collider to the dictionary
 	collider_to_furniture[new_furniture.collider] = new_furniture

--- a/Scripts/FurniturePhysicsSrv.gd
+++ b/Scripts/FurniturePhysicsSrv.gd
@@ -133,7 +133,6 @@ func _init(furniturepos: Vector3, newFurnitureJSON: Dictionary, world3d: World3D
 
 func connect_signals():
 	furniture_transform.chunk_changed.connect(_on_chunk_changed)
-	Helper.signal_broker.player_current_y_level.connect.call_deferred(_on_player_y_level_updated)
 
 
 # Signal to emit when chunk position updates
@@ -566,11 +565,6 @@ func show_visuals() -> void:
 	if not mesh_instance == null:
 		RenderingServer.instance_set_visible(mesh_instance, true)
 	is_hidden = false
-
-
-# ✅ Handles player Y level update and updates furniture visibility
-func _on_player_y_level_updated(_old_y_level: float, new_y_level: float):
-	refresh_visibility(new_y_level)
 
 
 func refresh_visibility(new_y_level: float):

--- a/Scripts/FurnitureStaticSpawner.gd
+++ b/Scripts/FurnitureStaticSpawner.gd
@@ -43,7 +43,6 @@ func spawn_furniture(furniture_data: Dictionary) -> void:
 		new_furniture = FurnitureStaticSrv.new(myposition, furniture_data, world3d)
 	new_furniture.about_to_be_destroyed.connect(_on_furniture_about_to_be_destroyed)
 	new_furniture.spawner = self
-	new_furniture.refresh_visibility(0) # Initial update for visibility
 	# Add the collider to the dictionary
 	collider_to_furniture[new_furniture.collider] = new_furniture
 

--- a/Scripts/FurnitureStaticSrv.gd
+++ b/Scripts/FurnitureStaticSrv.gd
@@ -791,7 +791,6 @@ func _init(furniturepos: Vector3, new_furniture_json: Dictionary, world3d: World
 	if rfurniture.consumption:
 		consumption = Consumption.new(self)
 	Helper.time_helper.minute_passed.connect.call_deferred(on_minute_passed)
-	Helper.signal_broker.player_current_y_level.connect.call_deferred(_on_player_y_level_updated)
 
 
 # If this furniture is a container, it will add a container node to the furniture.
@@ -1230,9 +1229,6 @@ func _die(do_add_corpse: bool = true):
 	if is_container():
 		Helper.signal_broker.container_exited_proximity.emit(self)
 	Helper.time_helper.minute_passed.disconnect(on_minute_passed)
-	# Disconnect from signal to stop tracking Y level changes
-	if Helper.signal_broker.player_current_y_level.is_connected(_on_player_y_level_updated):
-		Helper.signal_broker.player_current_y_level.disconnect(_on_player_y_level_updated)
 	free_resources()  # Free resources
 	queue_free()  # Remove the node from the scene tree
 
@@ -1244,7 +1240,7 @@ func show_indicator(text: String, color: Color):
 	label.modulate = color
 	label.font_size = 64
 	Helper.map_manager.level_generator.get_tree().get_root().add_child(label)
-	label.position = furniture_transform.get_position() + Vector3(0, 2, 0)  # Slightly above the furniture
+	label.position = furniture_transform.get_position() + Vector3(0, 0.5, 0)  # Slightly above the furniture
 	label.billboard = BaseMaterial3D.BILLBOARD_ENABLED
 
 	# Animate the indicator to disappear quickly
@@ -1476,11 +1472,6 @@ func show_visuals():
 	if not container == null and not container.sprite_instance == null:
 		RenderingServer.instance_set_visible(container.sprite_instance, true)
 	is_hidden = false
-
-
-# ✅ Handles player Y level update and updates furniture visibility
-func _on_player_y_level_updated(_old_y_level: float, new_y_level: float):
-	refresh_visibility(new_y_level)
 
 
 func refresh_visibility(new_y_level: float):

--- a/Scripts/Helper/SignalBroker/signal_broker.gd
+++ b/Scripts/Helper/SignalBroker/signal_broker.gd
@@ -120,8 +120,6 @@ signal player_skill_changed(player: Player)
 signal player_attribute_changed(player: Player, attribute: PlayerAttribute)
 @warning_ignore("unused_signal")
 signal player_ammo_changed(current_ammo: int, max_ammo: int, slot_index: int)
-@warning_ignore("unused_signal")
-signal player_current_y_level(old_y_level: float, new_y_level: float)
 
 # Save load start end events
 @warning_ignore("unused_signal")

--- a/Scripts/Mob/Mob.gd
+++ b/Scripts/Mob/Mob.gd
@@ -232,7 +232,7 @@ func show_miss_indicator():
 	miss_label.font_size = 64
 	get_tree().get_root().add_child(miss_label)
 	miss_label.position = position
-	miss_label.position.y += 2
+	miss_label.position.y += 0
 	miss_label.billboard = BaseMaterial3D.BILLBOARD_ENABLED
 	miss_label.render_priority = 10
 

--- a/Scripts/OvermapGrid.gd
+++ b/Scripts/OvermapGrid.gd
@@ -619,7 +619,7 @@ func generate_cells() -> void:
 			# If you need to test a specific map, uncomment these two lines and put in your map name.
 			# It will spawn the map at position (0,0), where the player starts
 			#if global_x == 0 and global_y == 0:
-				#cell.map_id = "urbanroad"
+				#cell.map_id = "Generichouse"
 
 			# Add the cell to the grid's cells dictionary
 			cells[cell_key] = cell

--- a/Scripts/Runtimedata/RFurnitures.gd
+++ b/Scripts/Runtimedata/RFurnitures.gd
@@ -96,12 +96,6 @@ func create_shape_material(furniture_id: String) -> StandardMaterial3D:
 		material.albedo_color.a = 0.5
 	else:
 		material.albedo_color = color
-		material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
-		material.albedo_color.a = 1.0
-
-	# Optionally adjust shading and other visual properties
-	#material.flags_unshaded = true
-
 	return material
 
 

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -678,5 +678,4 @@ func _update_player_y_level():
 	var current_y_level = global_position.y
 	# Only emit the signal if the Y level has changed
 	if current_y_level != last_y_level:
-		Helper.signal_broker.player_current_y_level.emit(last_y_level, current_y_level)
 		last_y_level = current_y_level # Update last known Y level


### PR DESCRIPTION
In order to increase performance, I had to find a way to eliminate hiding and showing furniture each time the player moves to a different y level. After investigating a few options, I settled with using the camera's near function.

Setting the near property of the camera will make it so that everything up to the level the player is at will not be rendered. Even though the furniture is technically visible, the camera will not render them if they are above the player. I still have to hide the chunk levels when the player moves up and down because a glitch will appear when the player's y level is around .999. Maybe we can improve on that in the future.

The downside is that everything above the player is hidden, so for example I had to lower the y coordinate of the "miss" and "hit" labels that show when an enemy or furniture is attacked. If we want to show something above the player in the future, we will have to fiddle with the camera settings again.

This implementation works and is stable too. Now we have more performance.