### PR TITLE
Set shadow reverse cull to fix lighting issue

### DIFF
--- a/Scenes/player.tscn
+++ b/Scenes/player.tscn
@@ -156,6 +156,7 @@ shape = SubResource("ConvexPolygonShape3D_drnhn")
 [node name="FrontLight" parent="Sprite3D2" instance=ExtResource("11_b146k")]
 unique_name_in_owner = true
 transform = Transform3D(1.91069e-15, 4.37114e-08, 1, 1, -4.37114e-08, 0, 4.37114e-08, 1, -4.37114e-08, 0.274, 0, -0.309)
+shadow_reverse_cull_face = true
 script = ExtResource("12_5v7lk")
 
 [node name="day_night" parent="Sprite3D2/FrontLight" instance=ExtResource("13_4vnbq")]


### PR DESCRIPTION
This turns shadow reverse culling on the frontlight.

I tried adjusting some settings on the frontlight to fix the awful shadows that were produced by simply looking at a wall. My understanding of light in godot is poor, so I don't know if this is the optimal solution. I don't see any downsides, so this will work for now.

There are still some lines visible when looking at an angle, but it's certainly an improvement over what we had.