### PR TITLE
Wait with movement until chunk finishes spawning

### DIFF
--- a/Scripts/FurniturePhysicsSpawner.gd
+++ b/Scripts/FurniturePhysicsSpawner.gd
@@ -7,6 +7,7 @@ var collider_to_furniture: Dictionary = {}
 # Reference to the World3D and Chunk
 var world3d: World3D
 var chunk: Chunk
+signal furniture_has_spawned(myspawner: FurniturePhysicsSpawner) # When the spawning of furniture is completed
 
 # Array that contains the JSON data for furniture to be spawned
 var furniture_json_list: Array = []:
@@ -16,8 +17,10 @@ var furniture_json_list: Array = []:
 		# INFO Important to connect the signals outside the task_manager.create_task
 		# since the furniture will start engaging with the game world when they are connected
 		# If they are connected inside task_manager.create_task, there will be a conflict in threads
+		print_debug("connecting furniture signals")
 		for furniture in collider_to_furniture.values():
 			furniture.connect_signals()
+		furniture_has_spawned.emit(self)
 
 
 # Initialize with reference to the chunk

--- a/Scripts/FurniturePhysicsSrv.gd
+++ b/Scripts/FurniturePhysicsSrv.gd
@@ -133,6 +133,7 @@ func _init(furniturepos: Vector3, newFurnitureJSON: Dictionary, world3d: World3D
 
 func connect_signals():
 	furniture_transform.chunk_changed.connect(_on_chunk_changed)
+	spawner.chunk.chunk_generated.connect(_on_chunk_generated)
 
 
 # Signal to emit when chunk position updates
@@ -165,9 +166,6 @@ func setup_physics_properties() -> void:
 
 	# Set collision layers and masks
 	set_collision_layers_and_masks()
-
-	# Set the force integration callback to update the visual position
-	PhysicsServer3D.body_set_force_integration_callback(collider, _moved)
 
 
 # Handle movement logic when the furniture changes position and rotation
@@ -577,3 +575,10 @@ func refresh_visibility(new_y_level: float):
 	else:
 		if is_hidden:
 			show_visuals()
+
+
+# When the chunk that this furniture spawns on is completely done generating
+# Waiting for this will buy some time before starting more expensive calculations
+func _on_chunk_generated():
+	# Set the force integration callback to update the visual position
+	PhysicsServer3D.body_set_force_integration_callback(collider, _moved)

--- a/Scripts/FurnitureStaticSpawner.gd
+++ b/Scripts/FurnitureStaticSpawner.gd
@@ -7,12 +7,14 @@ var collider_to_furniture: Dictionary = {}
 # Reference to the World3D and Chunk
 var world3d: World3D
 var chunk: Chunk
+signal furniture_has_spawned(myspawner: FurnitureStaticSpawner) # When the spawning of furniture is completed
 
 # Array that contains the JSON data for furniture to be spawned
 var furniture_json_list: Array = []:
 	set(value):
 		furniture_json_list = value
 		await Helper.task_manager.create_task(_spawn_all_furniture).completed
+		furniture_has_spawned.emit(self)
 
 
 # Initialize with reference to the chunk


### PR DESCRIPTION
This will freeze the moveable furnture until the chunk is completely finished spawning. This will take off some of the performance hit of spawning a map with a lot of moveable furniture.