### PR TITLE
Improve performance for furniturephysicssrv

### DIFF
--- a/Scripts/FurniturePhysicsSrv.gd
+++ b/Scripts/FurniturePhysicsSrv.gd
@@ -119,17 +119,17 @@ class FurnitureTransform:
 
 
 # Initialize the furniture object
-func _init(furniturepos: Vector3, newFurnitureJSON: Dictionary, world3d: World3D):
-	furnitureJSON = newFurnitureJSON
+func _init(myposition: Vector3, furniture_data: Dictionary, world: World3D):
+	furnitureJSON = furniture_data
 	rfurniture = Runtimedata.furnitures.by_id(furnitureJSON.id)
 	var myrotation: int = furnitureJSON.get("rotation", 0)
-	myworld3d = world3d
+	myworld3d = world
 
 	# Size of the collider will be a uniform sphere
-	var furniture_size: Vector3 = Vector3(0.3,0.3,0.3)
+	var furniture_size: Vector3 = Vector3(0.3, 0.3, 0.3)
 
 	# Initialize the furniture transform
-	furniture_transform = FurnitureTransform.new(furniturepos, myrotation, furniture_size)
+	furniture_transform = FurnitureTransform.new(myposition, myrotation, furniture_size)
 
 	if is_new_furniture():
 		furniture_transform.correct_new_position()


### PR DESCRIPTION
Fixes #718 

Had trouble figuring out how to make the furniture not move at the start of the game, so that the _moved function will not be called 700 times in a frame. Turns out it is safe to put the collider to sleep when it spawns, and it will go out of sleep as soon as the player pushes the furniture. This works because all movable furniture have a sphere collider of 0.3 in diameter. Once furniture gets a size difference (a table is bigger then a chair), the correct_new_position function in furniturephysicssrv.gd needs to be updated to account for the difference in size.

 force the furniture physics body to sleep immediately after spawning (in _on_chunk_generated). This will prevent unnecessary _moved calls until the furniture is actually moved (e.g., by the player).

I tested it and moveable furniture can still be pushed, even on the second story of a house. There are still other issues, but this one seems to have improved at least.