### PR TITLE
Get block

### DIFF
--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -1527,6 +1527,15 @@ func spawn_item_at_free_position(item_id: String, quantity: int, y: int) -> bool
 # Gets the block data from a specific level and block position
 # level_index: int (0 to 20) -> corresponds to levels -10 to 10
 # block_position: Vector2 (x: 0 to 31, y: 0 to 31) -> position in the 32x32 grid
+# Example return data:
+#{
+#    "id": "field_grass_basic_00",
+#    "shape": "cube",
+#    "rotation": 0
+#}
+# Example usage:
+#	var block_00: Dictionary = chunk.get_block_at(0, Vector2i(0, 0))
+#	print(block_00.get("id", "")) - prints field_grass_basic_00
 func get_block_at(level_index: int, block_position: Vector2i) -> Dictionary:
 	var level_index_internal = level_index + 10 # Convert to _mapleveldata index
 	if level_index_internal < 0 or level_index_internal >= _mapleveldata.size():

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -1537,28 +1537,11 @@ func spawn_item_at_free_position(item_id: String, quantity: int, y: int) -> bool
 #	var block_00: Dictionary = chunk.get_block_at(0, Vector2i(0, 0))
 #	print(block_00.get("id", "")) - prints field_grass_basic_00
 func get_block_at(level_index: int, block_position: Vector2i) -> Dictionary:
-	var level_index_internal = level_index + 10 # Convert to _mapleveldata index
-	if level_index_internal < 0 or level_index_internal >= _mapleveldata.size():
-		printerr("Level index out of range: ", level_index)
-		return {}
-
-	if block_position.x < 0 or block_position.x >= LEVEL_WIDTH or \
-	   block_position.y < 0 or block_position.y >= LEVEL_HEIGHT:
-		printerr("Block position out of range: ", block_position)
-		return {}
-
-	var level = _mapleveldata[level_index_internal]
-	if level.is_empty():
-		print_debug("Level %d is empty." % level_index)
-		return {}
-
-	var block_index = block_position.y * LEVEL_WIDTH + block_position.x
-	var block_data = level[block_index]
-
-	if block_data and block_data.has("id"):
-		return block_data
+	var key = "%s,%s,%s" % [block_position.x, level_index, block_position.y]
+	if block_positions.has(key):
+		return block_positions[key]
 	else:
-		print_debug("Block at %s on level %d is empty or has no 'id'." % [block_position, level_index])
+		print_debug("Block at %s on level %d not found in block_positions." % [block_position, level_index])
 		return {}
 
 
@@ -1571,5 +1554,4 @@ func _on_furniture_spawned(spawner: Node3D):
 	
 	# ✅ Emit signal only when all spawners have finished
 	if static_furniture_ready and physics_furniture_ready:
-		print_debug("All furniture spawned — emitting chunk_generated")
 		chunk_generated.emit()

--- a/Scripts/FurniturePhysicsSpawner.gd
+++ b/Scripts/FurniturePhysicsSpawner.gd
@@ -17,7 +17,6 @@ var furniture_json_list: Array = []:
 		# INFO Important to connect the signals outside the task_manager.create_task
 		# since the furniture will start engaging with the game world when they are connected
 		# If they are connected inside task_manager.create_task, there will be a conflict in threads
-		print_debug("connecting furniture signals")
 		for furniture in collider_to_furniture.values():
 			furniture.connect_signals()
 		furniture_has_spawned.emit(self)

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -260,6 +260,7 @@ func _input(event):
 		
 	#checking if we can interact with the object
 	if event.is_action_pressed("interact"):
+		print_block_id_under_player()
 		_check_for_interaction()
 
 # Check if player can interact with an object
@@ -699,10 +700,11 @@ func print_block_id_under_player() -> void:
 	if chunk == null:
 		print_debug("No chunk found at player position: ", global_position)
 		return
+	
+	# Calculate the local block position within the chunk (0-31)
+	var local_x = int(global_position.x) - chunk.mypos.x
+	var local_z = int(global_position.z) - chunk.mypos.z
 
-	# Calculate the local block position within the chunk
-	var local_x = int(global_position.x) % 32
-	var local_z = int(global_position.z) % 32
 	# Calculate the level index: always use the floor of y - a small epsilon to ensure we get the block below
 	var epsilon = 1.0
 	var level_index = int(floor(global_position.y - epsilon))
@@ -711,5 +713,7 @@ func print_block_id_under_player() -> void:
 	var block_data = chunk.get_block_at(level_index, Vector2i(local_x, local_z))
 	if block_data.has("id"):
 		print("Player is standing on block id: ", block_data["id"])
+		print_debug("Player is standing on (", local_x, ", ", level_index, ", ", local_z, ") block id: ", block_data["id"], ". Player is at: ", str(global_position), ". Chunk is at: ", str(chunk.mypos))
 	else:
 		print_debug("No block found at (", local_x, ", ", level_index, ", ", local_z, ") in chunk.")
+		print_debug("No block found at (", local_x, ", ", level_index, ", ", local_z, ") in chunk. Player is at: ", str(global_position), ". Chunk is at: ", str(chunk.mypos))

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -690,3 +690,26 @@ func _update_player_y_level():
 	# Only emit the signal if the Y level has changed
 	if current_y_level != last_y_level:
 		last_y_level = current_y_level # Update last known Y level
+
+
+# Prints the id of the block the player is currently standing on
+func print_block_id_under_player() -> void:
+	# Get the chunk at the player's current position
+	var chunk = Helper.map_manager.get_chunk_from_position(global_position)
+	if chunk == null:
+		print_debug("No chunk found at player position: ", global_position)
+		return
+
+	# Calculate the local block position within the chunk
+	var local_x = int(global_position.x) % 32
+	var local_z = int(global_position.z) % 32
+	# Calculate the level index: always use the floor of y - a small epsilon to ensure we get the block below
+	var epsilon = 1.0
+	var level_index = int(floor(global_position.y - epsilon))
+
+	# Get the block at this position
+	var block_data = chunk.get_block_at(level_index, Vector2i(local_x, local_z))
+	if block_data.has("id"):
+		print("Player is standing on block id: ", block_data["id"])
+	else:
+		print_debug("No block found at (", local_x, ", ", level_index, ", ", local_z, ") in chunk.")

--- a/Tests/Unit/test_chunk.gd
+++ b/Tests/Unit/test_chunk.gd
@@ -72,15 +72,15 @@ func test_chunk_load_unload():
 	assert_eq(block_00.get("id", ""), "dot_tile", "Block at (0, 0) is not 'dot_tile'.")
 	assert_eq(block_00.get("rotation", 0.0), 0.0, "Block at (0, 0) does not have rotation 0.")
 
-	# Check (0, 31) -> "dot_tile", rotation 270 --> bottom-left block
+	# Check (0, 31) -> "dot_tile", rotation 270 --> top-right block
 	var block_031 = test_chunk.get_block_at(level_index, Vector2i(0, 31))
 	assert_eq(block_031.get("id", ""), "dot_tile", "Block at (0, 31) is not 'dot_tile'.")
-	assert_eq(block_031.get("rotation", 0.0), 270.0, "Block at (0, 31) does not have rotation 270.")
+	assert_eq(block_031.get("rotation", 0.0), 90.0, "Block at (0, 31) does not have rotation 270.")
 
-	# Check (31, 0) -> "dot_tile", rotation 90 --> top-right block
+	# Check (31, 0) -> "dot_tile", rotation 90 --> bottom-left block
 	var block_310 = test_chunk.get_block_at(level_index, Vector2i(31, 0))
 	assert_eq(block_310.get("id", ""), "dot_tile", "Block at (31, 0) is not 'dot_tile'.")
-	assert_eq(block_310.get("rotation", 0.0), 90.0, "Block at (31, 0) does not have rotation 90.")
+	assert_eq(block_310.get("rotation", 0.0), 270.0, "Block at (31, 0) does not have rotation 90.")
 
 	# Check (31, 31) -> "dot_tile", rotation 180 --> bottom-right block
 	var block_3131 = test_chunk.get_block_at(level_index, Vector2i(31, 31))


### PR DESCRIPTION
Added the get block under player function. Right now it does nothing but print the id of the block that the player stands on. THe problem is that all the blocks are visually and physically offset by 0.5 in the - direction, so there is a mismatch between the player's location and the block he's on.

I want to correct the mismatch in another pr. We can use the function in the player script later to know what footsteps to play at what volume